### PR TITLE
Skip files and directories if their basename renders as empty

### DIFF
--- a/src/cutty/core/generate.py
+++ b/src/cutty/core/generate.py
@@ -54,7 +54,12 @@ class Generator:
 
     def _render(self, source: Path, output_dir: Path) -> None:
         with exceptions.PathRenderError(source):
-            target = output_dir / self.renderer.render(source.name)
+            name = self.renderer.render(source.name)
+
+        if not name:
+            return
+
+        target = output_dir / name
 
         # If the target exists at this point, we are in overwrite mode. Remove
         # existing files and symlinks, but do not recursively remove directory


### PR DESCRIPTION
This fixes an incompatibility with Cookiecutter when the basename of a file or directory is rendered as empty. This should be handled by skipping the file or directory. Currently cutty takes the target path to be the parent directory, which is very wrong.

This is a fix for the current release, and should be merged into the 0.2.x branch.