### PR TITLE
Bump typeguard from 2.12.0 to 2.12.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1053,7 +1053,7 @@ python-versions = "*"
 
 [[package]]
 name = "typeguard"
-version = "2.12.0"
+version = "2.12.1"
 description = "Run-time type checker for Python"
 category = "dev"
 optional = false
@@ -1855,8 +1855,8 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typeguard = [
-    {file = "typeguard-2.12.0-py3-none-any.whl", hash = "sha256:7d1cf82b35e9ff3cd083133ebda54ad1d7a40296471397e6c6b229cf07fe5307"},
-    {file = "typeguard-2.12.0.tar.gz", hash = "sha256:fca77fd4ccba63465b421cdbbab5a1a8e3994e6d6f18b45da2bb475c09f147ef"},
+    {file = "typeguard-2.12.1-py3-none-any.whl", hash = "sha256:cc15ef2704c9909ef9c80e19c62fb8468c01f75aad12f651922acf4dbe822e02"},
+    {file = "typeguard-2.12.1.tar.gz", hash = "sha256:c2af8b9bdd7657f4bd27b45336e7930171aead796711bc4cfc99b4731bb9d051"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,13 @@ exclude_lines = [
     "pragma: no cover",
     "@overload",
 ]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:no type annotations present -- not typechecking .*",
+    "ignore:no code associated -- not typechecking .*",
+]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/cutty/__main__.py
+++ b/src/cutty/__main__.py
@@ -27,24 +27,6 @@ def extra_context_callback(
     return dict(_generate())
 
 
-try:
-    # https://github.com/agronholm/typeguard/issues/191
-    import typeguard  # type: ignore[import]
-except ImportError:
-    pass
-else:  # pragma: no cover
-    from typing import no_type_check
-
-    @no_type_check
-    def _patched_typechecked(*args, **kwargs):
-        if args and isinstance(args[0], click.Command):
-            return args[0]
-        return typeguard_typechecked(*args, **kwargs)
-
-    typeguard_typechecked = typeguard.typechecked
-    typeguard.typechecked = _patched_typechecked
-
-
 @click.command()
 @click.argument("template")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)


### PR DESCRIPTION
- Bump typeguard from 2.12.0 to 2.12.1
- Revert ":beetle: [cookiecutter] Work around Typeguard bug triggered by click 8.x"
- :wrench: [pytest] Filter Typeguard warnings about skipped type checks
