### PR TITLE
Provide test coverage for Windows paths on POSIX

### DIFF
--- a/src/cutty/repositories/domain/urls.py
+++ b/src/cutty/repositories/domain/urls.py
@@ -6,12 +6,11 @@ import platform
 from yarl import URL
 
 
-def aspath(url: URL) -> pathlib.Path:
-    """Convert URL to filesystem path."""
+def aspurewindowspath(url: URL) -> pathlib.PureWindowsPath:
+    """Convert URL to Windows filesystem path."""
     if any(
         (
             url.scheme and url.scheme != "file",
-            url.host and platform.system() != "Windows",
             url.user,
             url.password,
             url.port,
@@ -21,15 +20,41 @@ def aspath(url: URL) -> pathlib.Path:
     ):
         raise ValueError(f"not a path: {url}")
 
-    if platform.system() == "Windows":
-        if url.host:
-            return pathlib.Path(f"//{url.host}{url.path}")
+    if url.host:
+        return pathlib.PureWindowsPath(f"//{url.host}{url.path}")
 
-        path = pathlib.Path(url.path[1:])
-        if path.drive:
-            return path
+    path = pathlib.PureWindowsPath(url.path[1:])
+    if path.drive:
+        return path
 
-    return pathlib.Path(url.path)
+    return pathlib.PureWindowsPath(url.path)
+
+
+def aspureposixpath(url: URL) -> pathlib.PurePosixPath:
+    """Convert URL to POSIX filesystem path."""
+    if any(
+        (
+            url.scheme and url.scheme != "file",
+            url.host,
+            url.user,
+            url.password,
+            url.port,
+            url.query_string,
+            url.fragment,
+        )
+    ):
+        raise ValueError(f"not a path: {url}")
+
+    return pathlib.PurePosixPath(url.path)
+
+
+def aspath(url: URL) -> pathlib.Path:
+    """Convert URL to filesystem path."""
+    return pathlib.Path(
+        aspurewindowspath(url)
+        if platform.system() == "Windows"
+        else aspureposixpath(url)
+    )
 
 
 def realpath(path: pathlib.Path) -> pathlib.Path:

--- a/tests/unit/repositories/domain/test_urls.py
+++ b/tests/unit/repositories/domain/test_urls.py
@@ -3,11 +3,13 @@ import os
 import platform
 from collections.abc import Iterator
 from pathlib import Path
+from pathlib import PureWindowsPath
 
 import pytest
 from yarl import URL
 
 from cutty.repositories.domain.urls import aspath
+from cutty.repositories.domain.urls import aspurewindowspath
 from cutty.repositories.domain.urls import asurl
 from cutty.repositories.domain.urls import parseurl
 from cutty.repositories.domain.urls import realpath
@@ -61,18 +63,17 @@ def test_aspath_invalid(url: URL) -> None:
         aspath(url)
 
 
-@onlywindows
 @pytest.mark.parametrize(
     ("url", "expected"),
     [
-        (URL("file:///dir/file"), Path("\\dir\\file")),
-        (URL("file:///C:/dir/file"), Path("C:\\dir\\file")),
-        (URL("file://host/share/file"), Path("\\\\host\\share\\file")),
+        (URL("file:///dir/file"), PureWindowsPath("\\dir\\file")),
+        (URL("file:///C:/dir/file"), PureWindowsPath("C:\\dir\\file")),
+        (URL("file://host/share/file"), PureWindowsPath("\\\\host\\share\\file")),
     ],
 )
-def test_aspath_windows(url: URL, expected: Path) -> None:
+def test_aspurewindowspath(url: URL, expected: PureWindowsPath) -> None:
     """It translates drive letters and hosts."""
-    assert aspath(url) == expected
+    assert aspurewindowspath(url) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/repositories/domain/test_urls.py
+++ b/tests/unit/repositories/domain/test_urls.py
@@ -9,6 +9,7 @@ import pytest
 from yarl import URL
 
 from cutty.repositories.domain.urls import aspath
+from cutty.repositories.domain.urls import aspureposixpath
 from cutty.repositories.domain.urls import aspurewindowspath
 from cutty.repositories.domain.urls import asurl
 from cutty.repositories.domain.urls import parseurl
@@ -49,6 +50,7 @@ def test_asurl_aspath_roundtrip(path: Path) -> None:
 @pytest.mark.parametrize(
     "url",
     [
+        URL("//host/drive/dir"),
         URL("http://example.com"),
         URL("file:///path/to/dir#fragment"),
         URL("file:///path/to/dir?query"),
@@ -57,10 +59,27 @@ def test_asurl_aspath_roundtrip(path: Path) -> None:
     ],
     ids=str,
 )
-def test_aspath_invalid(url: URL) -> None:
+def test_aspureposixpath_invalid(url: URL) -> None:
     """It raises an exception."""
     with pytest.raises(ValueError):
-        aspath(url)
+        aspureposixpath(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        URL("http://example.com"),
+        URL("file:///path/to/dir#fragment"),
+        URL("file:///path/to/dir?query"),
+        URL("/path/to/dir#fragment"),
+        URL("/path/to/dir?query"),
+    ],
+    ids=str,
+)
+def test_aspurewindowspath_invalid(url: URL) -> None:
+    """It raises an exception."""
+    with pytest.raises(ValueError):
+        aspurewindowspath(url)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- :white_check_mark: [repositories] Run test for Windows paths on all platforms
- :white_check_mark: [repositories] Run tests for invalid paths on all platforms
- :recycle: [repositories] Decompose aspath into aspure{windows,posix}path
