### PR TITLE
Improve test coverage for cutty.templates

### DIFF
--- a/tests/unit/templates/adapters/test_jinja.py
+++ b/tests/unit/templates/adapters/test_jinja.py
@@ -117,3 +117,16 @@ def test_render_with_context_prefix(cookiecutter_render: Renderer) -> None:
     variable = Binding("value", "teapot")
     text = cookiecutter_render("{{ cookiecutter.value }}", [variable])
     assert text == "teapot"
+
+
+def test_render_with_extra_context(tmp_path: pathlib.Path) -> None:
+    """It renders a Jinja template with extra context."""
+    root = Path(filesystem=DiskFilesystem(tmp_path))
+    rendertext = createjinjarenderer(
+        searchpath=[root], extra_context={"value": "teapot"}
+    )
+    render = createrenderer(
+        {**defaultrenderregistry, str: asrendercontinuation(rendertext)}
+    )
+    text = render("{{ value }}", [])
+    assert text == "teapot"

--- a/tests/unit/templates/domain/test_config.py
+++ b/tests/unit/templates/domain/test_config.py
@@ -1,0 +1,8 @@
+"""Unit tests for cutty.templates.domain.config."""
+from cutty.templates.domain.config import Config
+from cutty.templates.domain.variables import Variable
+
+
+def test_config(variable: Variable) -> None:
+    """It can store settings and variables."""
+    Config(settings={"a-setting": "value"}, variables=(variable,))


### PR DESCRIPTION
- :white_check_mark: [templates] Add unit test for config module
- :white_check_mark: [templates] Add test for Jinja renderer with extra context
