### PR TITLE
:recycle: [repositories] Add adapter for creating default repository provider

### DIFF
--- a/src/cutty/application/cookiecutter/main.py
+++ b/src/cutty/application/cookiecutter/main.py
@@ -12,9 +12,7 @@ from cutty.application.cookiecutter.filestorage import iterhooks
 from cutty.application.cookiecutter.paths import iterpaths
 from cutty.application.cookiecutter.prompts import prompt
 from cutty.application.cookiecutter.render import registerrenderers
-from cutty.repositories.adapters.registry import defaultproviderregistry
-from cutty.repositories.adapters.storage import getdefaultproviderstore
-from cutty.repositories.domain.providers import repositoryprovider
+from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
 from cutty.templates.domain.binders import binddefault
 from cutty.templates.domain.binders import override
 from cutty.templates.domain.binders import renderbindwith
@@ -37,10 +35,7 @@ def main(
 ) -> None:
     """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(appdirs.user_cache_dir("cutty"))
-    provider = repositoryprovider(
-        defaultproviderregistry,
-        getdefaultproviderstore(cachedir),
-    )
+    provider = getdefaultrepositoryprovider(cachedir)
     path = provider(template, revision=checkout)
 
     if directory is not None:

--- a/src/cutty/application/cookiecutter/main.py
+++ b/src/cutty/application/cookiecutter/main.py
@@ -14,7 +14,6 @@ from cutty.application.cookiecutter.prompts import prompt
 from cutty.application.cookiecutter.render import registerrenderers
 from cutty.repositories.adapters.registry import defaultproviderregistry
 from cutty.repositories.adapters.storage import getdefaultproviderstore
-from cutty.repositories.adapters.storage import RepositoryStorage
 from cutty.repositories.domain.providers import repositoryprovider
 from cutty.templates.domain.binders import binddefault
 from cutty.templates.domain.binders import override
@@ -38,10 +37,9 @@ def main(
 ) -> None:
     """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(appdirs.user_cache_dir("cutty"))
-    storage = RepositoryStorage(cachedir)
     provider = repositoryprovider(
         defaultproviderregistry,
-        getdefaultproviderstore(storage),
+        getdefaultproviderstore(cachedir),
     )
     path = provider(template, revision=checkout)
 

--- a/src/cutty/application/cookiecutter/main.py
+++ b/src/cutty/application/cookiecutter/main.py
@@ -13,7 +13,7 @@ from cutty.application.cookiecutter.paths import iterpaths
 from cutty.application.cookiecutter.prompts import prompt
 from cutty.application.cookiecutter.render import registerrenderers
 from cutty.repositories.adapters.registry import defaultproviderregistry
-from cutty.repositories.adapters.storage import getproviderstore
+from cutty.repositories.adapters.storage import getdefaultproviderstore
 from cutty.repositories.adapters.storage import RepositoryStorage
 from cutty.repositories.domain.providers import repositoryprovider
 from cutty.templates.domain.binders import binddefault
@@ -39,7 +39,10 @@ def main(
     """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(appdirs.user_cache_dir("cutty"))
     storage = RepositoryStorage(cachedir)
-    provider = repositoryprovider(defaultproviderregistry, getproviderstore(storage))
+    provider = repositoryprovider(
+        defaultproviderregistry,
+        getdefaultproviderstore(storage),
+    )
     path = provider(template, revision=checkout)
 
     if directory is not None:

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -14,8 +14,11 @@ from typing import Optional
 
 from yarl import URL
 
+from cutty.repositories.adapters.registry import defaultproviderregistry
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
+from cutty.repositories.domain.providers import RepositoryProvider
+from cutty.repositories.domain.providers import repositoryprovider
 from cutty.repositories.domain.stores import Store
 
 
@@ -145,3 +148,13 @@ def getdefaultproviderstore(
         return store
 
     return providerstore
+
+
+def getdefaultrepositoryprovider(
+    path: pathlib.Path, *, timer: Timer = defaulttimer
+) -> RepositoryProvider:
+    """Return a repository provider."""
+    return repositoryprovider(
+        defaultproviderregistry,
+        getdefaultproviderstore(path, timer=timer),
+    )

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -126,8 +126,11 @@ class RepositoryStorage:
                 shutil.rmtree(record.path)
 
 
-def getdefaultproviderstore(storage: RepositoryStorage) -> ProviderStore:
+def getdefaultproviderstore(
+    path: pathlib.Path, *, timer: Timer = defaulttimer
+) -> ProviderStore:
     """Return a provider store."""
+    storage = RepositoryStorage(path, timer=timer)
 
     def providerstore(provider: str) -> Store:
         """Return a store function for the provider."""

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -126,7 +126,7 @@ class RepositoryStorage:
                 shutil.rmtree(record.path)
 
 
-def getproviderstore(storage: RepositoryStorage) -> ProviderStore:
+def getdefaultproviderstore(storage: RepositoryStorage) -> ProviderStore:
     """Return a provider store."""
 
     def providerstore(provider: str) -> Store:

--- a/tests/unit/repositories/adapters/test_storage.py
+++ b/tests/unit/repositories/adapters/test_storage.py
@@ -6,7 +6,7 @@ import pytest
 from yarl import URL
 
 from cutty.repositories.adapters.storage import defaulttimer
-from cutty.repositories.adapters.storage import getproviderstore
+from cutty.repositories.adapters.storage import getdefaultproviderstore
 from cutty.repositories.adapters.storage import hashurl
 from cutty.repositories.adapters.storage import RepositoryStorage
 from cutty.repositories.adapters.storage import StorageRecord
@@ -181,18 +181,20 @@ def test_storage_clean_something(
     assert second in records
 
 
-def test_getproviderstore_exists(storage: RepositoryStorage, url: URL) -> None:
+def test_getdefaultproviderstore_exists(storage: RepositoryStorage, url: URL) -> None:
     """It returns a valid filesystem path."""
-    providerstore = getproviderstore(storage)
+    providerstore = getdefaultproviderstore(storage)
     store = providerstore("git")
     path = store(url)
 
     assert path.exists()
 
 
-def test_getproviderstore_idempotent(storage: RepositoryStorage, url: URL) -> None:
+def test_getdefaultproviderstore_idempotent(
+    storage: RepositoryStorage, url: URL
+) -> None:
     """It returns the same path each time."""
-    providerstore = getproviderstore(storage)
+    providerstore = getdefaultproviderstore(storage)
     store = providerstore("git")
 
     assert store(url) == store(url)

--- a/tests/unit/repositories/adapters/test_storage.py
+++ b/tests/unit/repositories/adapters/test_storage.py
@@ -10,6 +10,7 @@ from cutty.repositories.adapters.storage import getdefaultproviderstore
 from cutty.repositories.adapters.storage import hashurl
 from cutty.repositories.adapters.storage import RepositoryStorage
 from cutty.repositories.adapters.storage import StorageRecord
+from cutty.repositories.domain.providers import ProviderStore
 
 
 @pytest.fixture
@@ -181,9 +182,14 @@ def test_storage_clean_something(
     assert second in records
 
 
-def test_getdefaultproviderstore_exists(storage: RepositoryStorage, url: URL) -> None:
+@pytest.fixture
+def providerstore(tmp_path: Path, timer: FakeTimer) -> ProviderStore:
+    """Fixture for a repository storage."""
+    return getdefaultproviderstore(tmp_path, timer=timer)
+
+
+def test_getdefaultproviderstore_exists(providerstore: ProviderStore, url: URL) -> None:
     """It returns a valid filesystem path."""
-    providerstore = getdefaultproviderstore(storage)
     store = providerstore("git")
     path = store(url)
 
@@ -191,10 +197,9 @@ def test_getdefaultproviderstore_exists(storage: RepositoryStorage, url: URL) ->
 
 
 def test_getdefaultproviderstore_idempotent(
-    storage: RepositoryStorage, url: URL
+    providerstore: ProviderStore, url: URL
 ) -> None:
     """It returns the same path each time."""
-    providerstore = getdefaultproviderstore(storage)
     store = providerstore("git")
 
     assert store(url) == store(url)


### PR DESCRIPTION
- :recycle: [repositories] Rename function get{ => default}providerstore
- :recycle: [repositories] Move RepositoryStorage creation into getdefaultproviderstore
- :recycle: [repositories] Extract function getdefaultrepositoryprovider from cookiecutter
