### PR TITLE
:boom: Change CLI usage to `cutty create`

### DIFF
--- a/src/cutty/__main__.py
+++ b/src/cutty/__main__.py
@@ -1,5 +1,5 @@
 """Command-line interface."""
-from cutty.entrypoints.cli.create import main
+from cutty.entrypoints.cli import main
 
 if __name__ == "__main__":
     main(prog_name="cutty")  # pragma: no cover

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -1,2 +1,3 @@
 """Command-line interface."""
-from .create import main as main  # noqa: F401
+from . import create  # noqa: F401
+from ._main import main as main  # noqa: F401

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -1,1 +1,2 @@
 """Command-line interface."""
+from .create import main as main  # noqa: F401

--- a/src/cutty/entrypoints/cli/_main.py
+++ b/src/cutty/entrypoints/cli/_main.py
@@ -1,0 +1,7 @@
+"""Main entry-point for the command-line interface."""
+import click
+
+
+@click.group()
+def main() -> None:
+    """An experimental Cookiecutter clone."""

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -28,7 +28,7 @@ def extra_context_callback(
     return dict(_generate())
 
 
-@_main.command("create")
+@_main.command()
 @click.argument("template")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
@@ -73,7 +73,7 @@ def extra_context_callback(
     help="Skip the files in the corresponding directories if they already exist.",
 )
 @click.version_option()
-def main(
+def create(
     template: str,
     extra_context: dict[str, str],
     no_input: bool,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import click
 
+from cutty.entrypoints.cli._main import main as _main
 from cutty.services.create import create
 
 
@@ -27,7 +28,7 @@ def extra_context_callback(
     return dict(_generate())
 
 
-@click.command()
+@_main.command("create")
 @click.argument("template")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli._main import main as _main
-from cutty.services.create import create
+from cutty.services.create import create as service_create
 
 
 def extra_context_callback(
@@ -84,7 +84,7 @@ def main(
     skip_if_file_exists: bool,
 ) -> None:
     """cutty."""
-    create(
+    service_create(
         template,
         extra_context=extra_context,
         no_input=no_input,

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -17,7 +17,7 @@ def runner() -> Iterator[CliRunner]:
         yield runner
 
 
-def test_main_help(runner: CliRunner) -> None:
+def test_create_help(runner: CliRunner) -> None:
     """It exits with a status code of zero."""
     result = runner.invoke(main, ["create", "--help"])
     assert result.exit_code == 0
@@ -42,7 +42,7 @@ def repository(template_directory: Path) -> Path:
     return template_directory
 
 
-def test_main_cookiecutter(runner: CliRunner, repository: Path) -> None:
+def test_create_cookiecutter(runner: CliRunner, repository: Path) -> None:
     """It generates a project."""
     runner.invoke(
         main, ["create", str(repository)], input="foobar\n\n\n", catch_exceptions=False

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -19,7 +19,7 @@ def runner() -> Iterator[CliRunner]:
 
 def test_main_help(runner: CliRunner) -> None:
     """It exits with a status code of zero."""
-    result = runner.invoke(main, ["--help"])
+    result = runner.invoke(main, ["create", "--help"])
     assert result.exit_code == 0
 
 
@@ -44,5 +44,7 @@ def repository(template_directory: Path) -> Path:
 
 def test_main_cookiecutter(runner: CliRunner, repository: Path) -> None:
     """It generates a project."""
-    runner.invoke(main, [str(repository)], input="foobar\n\n\n", catch_exceptions=False)
+    runner.invoke(
+        main, ["create", str(repository)], input="foobar\n\n\n", catch_exceptions=False
+    )
     assert Path("foobar", "README.md").read_text() == "# foobar\n"

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -6,7 +6,7 @@ import pygit2
 import pytest
 from click.testing import CliRunner
 
-from cutty.entrypoints.cli.create import main
+from cutty.entrypoints.cli import main
 
 
 @pytest.fixture

--- a/tests/unit/entrypoints/cli/test_create.py
+++ b/tests/unit/entrypoints/cli/test_create.py
@@ -49,7 +49,7 @@ def runner(monkeypatch: pytest.MonkeyPatch) -> RunnerDecoratorFactory:
 def test_extra_context_happy(runner: RunnerDecoratorFactory) -> None:
     """It parses additional arguments into key-value pairs."""
 
-    @runner(main, monkeypatch="cutty.entrypoints.cli.create.create")
+    @runner(main, monkeypatch="cutty.entrypoints.cli.create.service_create")
     def invoke(*args: Any, extra_context: dict[str, str], **kwargs: Any) -> None:
         """Main function."""
         assert extra_context == {"project": "example"}
@@ -60,7 +60,7 @@ def test_extra_context_happy(runner: RunnerDecoratorFactory) -> None:
 def test_extra_context_invalid(runner: RunnerDecoratorFactory) -> None:
     """It raises an exception if additional arguments cannot be parsed."""
 
-    @runner(main, monkeypatch="cutty.entrypoints.cli.create.create")
+    @runner(main, monkeypatch="cutty.entrypoints.cli.create.service_create")
     def invoke(*args: Any, **kwargs: Any) -> None:
         pass
 

--- a/tests/unit/entrypoints/cli/test_create.py
+++ b/tests/unit/entrypoints/cli/test_create.py
@@ -7,7 +7,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from cutty.entrypoints.cli.create import main
+from cutty.entrypoints.cli.create import create
 
 
 RunnerDecorator = Callable[[Callable[..., None]], Callable[..., None]]
@@ -49,7 +49,7 @@ def runner(monkeypatch: pytest.MonkeyPatch) -> RunnerDecoratorFactory:
 def test_extra_context_happy(runner: RunnerDecoratorFactory) -> None:
     """It parses additional arguments into key-value pairs."""
 
-    @runner(main, monkeypatch="cutty.entrypoints.cli.create.service_create")
+    @runner(create, monkeypatch="cutty.entrypoints.cli.create.service_create")
     def invoke(*args: Any, extra_context: dict[str, str], **kwargs: Any) -> None:
         """Main function."""
         assert extra_context == {"project": "example"}
@@ -60,7 +60,7 @@ def test_extra_context_happy(runner: RunnerDecoratorFactory) -> None:
 def test_extra_context_invalid(runner: RunnerDecoratorFactory) -> None:
     """It raises an exception if additional arguments cannot be parsed."""
 
-    @runner(main, monkeypatch="cutty.entrypoints.cli.create.service_create")
+    @runner(create, monkeypatch="cutty.entrypoints.cli.create.service_create")
     def invoke(*args: Any, **kwargs: Any) -> None:
         pass
 

--- a/tests/unit/entrypoints/cli/test_main.py
+++ b/tests/unit/entrypoints/cli/test_main.py
@@ -1,0 +1,10 @@
+"""Unit tests for cutty.entrypoints.cli.main."""
+from click.testing import CliRunner
+
+from cutty.entrypoints.cli import main
+
+
+def test_help() -> None:
+    """It exits with success."""
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0


### PR DESCRIPTION
- :recycle: [entrypoints] Export main entry-point from cli.main
- :sparkles: [entrypoints] Register cli.create as cli.main command
- :recycle: [entrypoints] Import services.create.create as service_create
- :recycle: [entrypoints] Rename function cli.create.{main => create}
