### PR TITLE
:recycle: Refactor disk storage implementation

### DIFF
--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -24,7 +24,7 @@ def _runhook(hooks: dict[str, File], hook: str, *, cwd: pathlib.Path) -> None:
         with tempfile.TemporaryDirectory() as root:
             with DiskFileStorage(pathlib.Path(root)) as storage:
                 storage.add(hookfile)
-                path = pathlib.Path(root, *hookfile.path.parts)
+                path = storage.resolve(hookfile)
                 _runcommand(path, cwd=cwd)
 
 

--- a/src/cutty/filestorage/adapters/disk.py
+++ b/src/cutty/filestorage/adapters/disk.py
@@ -34,7 +34,7 @@ class DiskFileStorage(FileStorage):
 
     def add(self, file: File) -> None:
         """Add the file to the storage."""
-        path = self.root.joinpath(*file.path.parts)
+        path = self.resolve(file)
 
         if not path.exists():
             self._storefile(file, path)
@@ -42,6 +42,10 @@ class DiskFileStorage(FileStorage):
             self._storefile(file, path, overwrite=True)
         elif self.fileexists is FileExistsPolicy.RAISE:
             raise FileExistsError(f"{path} already exists")
+
+    def resolve(self, file: File) -> pathlib.Path:
+        """Return the filesystem location."""
+        return self.root.joinpath(*file.path.parts)
 
     def _storefile(
         self,

--- a/src/cutty/filestorage/adapters/disk.py
+++ b/src/cutty/filestorage/adapters/disk.py
@@ -25,16 +25,11 @@ class FileExistsPolicy(enum.Enum):
             path: The path to be checked against the policy.
 
         Returns:
-            ``None`` if the path does not exist, ``False`` if the path should be
-            skipped, or ``True`` if the path should be overwritten.
+            ``True`` to overwrite the path, ``False`` to skip the path.
 
         Raises:
-            FileExistsError: The path already exists, and the policy does not
-                permit overwriting it.
+            FileExistsError: The policy does not permit overwriting the path.
         """
-        if not path.exists():
-            return None
-
         if self is FileExistsPolicy.OVERWRITE:
             return True
 
@@ -62,7 +57,10 @@ class DiskFileStorage(FileStorage):
     def add(self, file: File) -> None:
         """Add the file to the storage."""
         path = self.resolve(file)
-        result = self.fileexists.check(path)
+        if not path.exists():
+            result = None
+        else:
+            result = self.fileexists.check(path)
 
         if result is not False:
             self._storefile(file, path, overwrite=result is True)

--- a/src/cutty/filestorage/adapters/disk.py
+++ b/src/cutty/filestorage/adapters/disk.py
@@ -18,60 +18,6 @@ class FileExistsPolicy(enum.Enum):
     SKIP = enum.auto()
 
 
-def _storefile(
-    file: File,
-    path: pathlib.Path,
-    *,
-    undo: list[Callable[[], None]],
-    overwrite: bool = False,
-) -> None:
-    """Store the file at the given path on disk."""
-    # OVERWRITING.
-    #
-    # These operations are allowed:
-    #
-    # - Overwrite a regular file with another regular file.
-    # - Overwrite a symbolic link with a regular file.
-    # - Overwrite a symbolic link with another symbolic link.
-    #
-    # These operations raise exceptions:
-    #
-    # - Do not overwrite a directory with a regular file.
-    # - Do not overwrite a directory with a symbolic link.
-    # - Do not overwrite a regular file with a symbolic link.
-    # - Do not overwrite a regular file with a directory.
-    # - Do not overwrite a symbolic link with a directory if the link target is
-    #   not a directory. (Symbolic links in the path are followed if they point
-    #   to directories.)
-
-    if overwrite and path.is_symlink():
-        path.unlink()
-
-    for parent in reversed(path.parents):
-        if not parent.is_dir():
-            parent.mkdir()
-            undo.append(parent.rmdir)
-
-    if isinstance(file, RegularFile):
-        path.write_bytes(file.blob)
-
-        if not overwrite:
-            undo.append(path.unlink)
-
-        if isinstance(file, Executable):
-            path.chmod(path.stat().st_mode | 0o111)
-
-    elif isinstance(file, SymbolicLink):
-        target = pathlib.Path(*file.target.parts)
-        path.symlink_to(target)
-
-        if not overwrite:
-            undo.append(path.unlink)
-
-    else:
-        raise TypeError(f"cannot store file of type {type(file)}")
-
-
 class DiskFileStorage(FileStorage):
     """Disk-based file storage."""
 
@@ -91,11 +37,65 @@ class DiskFileStorage(FileStorage):
         path = self.root.joinpath(*file.path.parts)
 
         if not path.exists():
-            _storefile(file, path, undo=self.undo)
+            self._storefile(file, path, undo=self.undo)
         elif self.fileexists is FileExistsPolicy.OVERWRITE:
-            _storefile(file, path, undo=self.undo, overwrite=True)
+            self._storefile(file, path, undo=self.undo, overwrite=True)
         elif self.fileexists is FileExistsPolicy.RAISE:
             raise FileExistsError(f"{path} already exists")
+
+    def _storefile(
+        self,
+        file: File,
+        path: pathlib.Path,
+        *,
+        undo: list[Callable[[], None]],
+        overwrite: bool = False,
+    ) -> None:
+        """Store the file at the given path on disk."""
+        # OVERWRITING.
+        #
+        # These operations are allowed:
+        #
+        # - Overwrite a regular file with another regular file.
+        # - Overwrite a symbolic link with a regular file.
+        # - Overwrite a symbolic link with another symbolic link.
+        #
+        # These operations raise exceptions:
+        #
+        # - Do not overwrite a directory with a regular file.
+        # - Do not overwrite a directory with a symbolic link.
+        # - Do not overwrite a regular file with a symbolic link.
+        # - Do not overwrite a regular file with a directory.
+        # - Do not overwrite a symbolic link with a directory if the link target is
+        #   not a directory. (Symbolic links in the path are followed if they point
+        #   to directories.)
+
+        if overwrite and path.is_symlink():
+            path.unlink()
+
+        for parent in reversed(path.parents):
+            if not parent.is_dir():
+                parent.mkdir()
+                undo.append(parent.rmdir)
+
+        if isinstance(file, RegularFile):
+            path.write_bytes(file.blob)
+
+            if not overwrite:
+                undo.append(path.unlink)
+
+            if isinstance(file, Executable):
+                path.chmod(path.stat().st_mode | 0o111)
+
+        elif isinstance(file, SymbolicLink):
+            target = pathlib.Path(*file.target.parts)
+            path.symlink_to(target)
+
+            if not overwrite:
+                undo.append(path.unlink)
+
+        else:
+            raise TypeError(f"cannot store file of type {type(file)}")
 
     def rollback(self) -> None:
         """Rollback all stores."""

--- a/src/cutty/filestorage/adapters/disk.py
+++ b/src/cutty/filestorage/adapters/disk.py
@@ -58,12 +58,9 @@ class DiskFileStorage(FileStorage):
         """Add the file to the storage."""
         path = self.resolve(file)
         if not path.exists():
-            result = None
-        else:
-            result = self.fileexists.check(path)
-
-        if result is not False:
-            self._storefile(file, path, overwrite=result is True)
+            self._storefile(file, path, overwrite=False)
+        elif self.fileexists.check(path):
+            self._storefile(file, path, overwrite=True)
 
     def resolve(self, file: File) -> pathlib.Path:
         """Return the filesystem location."""

--- a/src/cutty/filestorage/domain/storage.py
+++ b/src/cutty/filestorage/domain/storage.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 import abc
 from types import TracebackType
 from typing import Optional
+from typing import TypeVar
 
 from cutty.filestorage.domain.files import File
+
+
+T = TypeVar("T", bound="FileStorage")
 
 
 class FileStorage(abc.ABC):
@@ -22,7 +26,7 @@ class FileStorage(abc.ABC):
     def rollback(self) -> None:
         """Rollback all stores."""
 
-    def __enter__(self) -> FileStorage:
+    def __enter__(self: T) -> T:
         """Enter the runtime context."""
         return self
 


### PR DESCRIPTION
- :recycle: [filestorage] Inline function storefile
- :recycle: [filestorage] Move function _storefile
- :recycle: [filestorage] Remove parameter `undo`
- :recycle: [filestorage] Return concrete type from `__enter__`
- :recycle: [filestorage] Extract function `resolve`
- :recycle: [filestorage] Use `resolve` in hook implementation
- :recycle: [filestorage] Extract function `checkpolicy`
- :recycle: [filestorage] Move function `checkpolicy` to FileExistsPolicy
- :recycle: [filestorage] Change return value semantics in policy check
- :recycle: [filestorage] Move exists query to caller
- :recycle: [filestorage] Simplify conditional logic
