### PR TITLE
Refactor Cookiecutter storage as disk storage wrapper

### DIFF
--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -30,7 +30,7 @@ def _runhook(hooks: dict[str, File], hook: str, *, cwd: pathlib.Path) -> None:
                 _runcommand(path, cwd=cwd)
 
 
-class CookiecutterFileStorageWrapper(FileStorageWrapper[DiskFileStorage]):
+class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
     """Wrap a disk-based file store with Cookiecutter hooks."""
 
     @classmethod

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -37,7 +37,7 @@ class CookiecutterFileStorage(DiskFileStorage):
         *,
         fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
         hookfiles: Iterable[File] = (),
-    ):
+    ) -> None:
         """Initialize."""
         super().__init__(root, fileexists=fileexists)
         self.hooks = {hook.path.stem: hook for hook in hookfiles}

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -51,7 +51,6 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
 
     def add(self, file: File) -> None:
         """Add file to storage."""
-        # FIXME: Hooks break rollback assumptions.
         if self.project is None:
             self.project = self.storage.resolve(file.path.parents[-2])
             self.project.mkdir(

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -30,17 +30,6 @@ def _runhook(hooks: dict[str, File], hook: str, *, cwd: pathlib.Path) -> None:
                 _runcommand(path, cwd=cwd)
 
 
-def CookiecutterFileStorage(  # noqa: N802
-    root: pathlib.Path,
-    *,
-    fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
-    hookfiles: Iterable[File] = (),
-) -> FileStorage:
-    """Disk-based file store with Cookiecutter hooks."""
-    storage = DiskFileStorage(root, fileexists=fileexists)
-    return CookiecutterFileStorageWrapper.wrap(storage, hookfiles=hookfiles)
-
-
 class CookiecutterFileStorageWrapper(FileStorageWrapper[DiskFileStorage]):
     """Wrap a disk-based file store with Cookiecutter hooks."""
 

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -10,6 +10,8 @@ from typing import Optional
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.domain.files import File
+from cutty.filestorage.domain.storage import FileStorage
+from cutty.filestorage.domain.storage import FileStorageWrapper
 
 
 def _runcommand(path: pathlib.Path, *, cwd: pathlib.Path) -> None:
@@ -58,3 +60,43 @@ class CookiecutterFileStorage(DiskFileStorage):
         """Commit the stores."""
         if self.project is not None:
             _runhook(self.hooks, "post_gen_project", cwd=self.project)
+
+
+class CookiecutterFileStorageWrapper(FileStorageWrapper[DiskFileStorage]):
+    """Wrap a disk-based file store with Cookiecutter hooks."""
+
+    @classmethod
+    def wrap(
+        cls, storage: DiskFileStorage, *, hookfiles: Iterable[File] = ()
+    ) -> FileStorage:
+        """Wrap the disk storage using the given Cookiecutter hooks."""
+        # TODO: Use disk storage if there are no hooks.
+        return cls(storage, hookfiles=hookfiles)
+
+    def __init__(
+        self, storage: DiskFileStorage, *, hookfiles: Iterable[File] = ()
+    ) -> None:
+        """Initialize."""
+        super().__init__(storage)
+        self.hooks = {hook.path.stem: hook for hook in hookfiles}
+        self.project: Optional[pathlib.Path] = None
+
+    def add(self, file: File) -> None:
+        """Add file to storage."""
+        # FIXME: Hooks break rollback assumptions.
+        if self.project is None:
+            self.project = self.storage.resolve(file.path.parents[-2])
+            self.project.mkdir(
+                parents=True,
+                exist_ok=self.storage.fileexists is not FileExistsPolicy.RAISE,
+            )
+            _runhook(self.hooks, "pre_gen_project", cwd=self.project)
+
+        super().add(file)
+
+    def commit(self) -> None:
+        """Commit the stores."""
+        if self.project is not None:
+            _runhook(self.hooks, "post_gen_project", cwd=self.project)
+
+        super().commit()

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -38,8 +38,8 @@ class CookiecutterFileStorageWrapper(FileStorageWrapper[DiskFileStorage]):
         cls, storage: DiskFileStorage, *, hookfiles: Iterable[File] = ()
     ) -> FileStorage:
         """Wrap the disk storage using the given Cookiecutter hooks."""
-        # TODO: Use disk storage if there are no hooks.
-        return cls(storage, hookfiles=hookfiles)
+        hookfiles = tuple(hookfiles)
+        return cls(storage, hookfiles=hookfiles) if hookfiles else storage
 
     def __init__(
         self, storage: DiskFileStorage, *, hookfiles: Iterable[File] = ()

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -35,18 +35,10 @@ class CookiecutterFileStorage(DiskFileStorage):
         self,
         root: pathlib.Path,
         *,
+        fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
         hookfiles: Iterable[File] = (),
-        overwrite_if_exists: bool = False,
-        skip_if_file_exists: bool = False,
     ):
         """Initialize."""
-        fileexists = (
-            FileExistsPolicy.RAISE
-            if not overwrite_if_exists
-            else FileExistsPolicy.SKIP
-            if skip_if_file_exists
-            else FileExistsPolicy.OVERWRITE
-        )
         super().__init__(root, fileexists=fileexists)
         self.hooks = {hook.path.stem: hook for hook in hookfiles}
         self.project: Optional[pathlib.Path] = None

--- a/src/cutty/filestorage/domain/storage.py
+++ b/src/cutty/filestorage/domain/storage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import abc
 from types import TracebackType
+from typing import Generic
 from typing import Optional
 from typing import TypeVar
 
@@ -41,3 +42,23 @@ class FileStorage(abc.ABC):
             self.commit()
         else:
             self.rollback()
+
+
+class FileStorageWrapper(FileStorage, Generic[T]):
+    """Wrapper for file storage implementations."""
+
+    def __init__(self, storage: T) -> None:
+        """Initialize."""
+        self.storage = storage
+
+    def add(self, file: File) -> None:
+        """Add the file to the storage."""
+        self.storage.add(file)
+
+    def commit(self) -> None:
+        """Commit all stores."""
+        self.storage.commit()
+
+    def rollback(self) -> None:
+        """Rollback all stores."""
+        self.storage.rollback()

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -8,6 +8,7 @@ from typing import Optional
 import appdirs
 
 from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorage
+from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filesystems.domain.path import Path
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
 from cutty.templates.adapters.cookiecutter.config import loadconfig
@@ -42,6 +43,19 @@ def iterhooks(path: Path) -> Iterator[Path]:
         for path in hookdir.iterdir():
             if path.is_file() and not path.name.endswith("~") and path.stem in hooks:
                 yield path
+
+
+def fileexistspolicy(
+    overwrite_if_exists: bool, skip_if_file_exists: bool
+) -> FileExistsPolicy:
+    """Return the policy for overwriting existing files."""
+    return (
+        FileExistsPolicy.RAISE
+        if not overwrite_if_exists
+        else FileExistsPolicy.SKIP
+        if skip_if_file_exists
+        else FileExistsPolicy.OVERWRITE
+    )
 
 
 def create(
@@ -85,8 +99,7 @@ def create(
     with CookiecutterFileStorage(
         output_dir,
         hookfiles=hookfiles,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
+        fileexists=fileexistspolicy(overwrite_if_exists, skip_if_file_exists),
     ) as storage:
         for file in files:
             storage.add(file)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -7,8 +7,10 @@ from typing import Optional
 
 import appdirs
 
-from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorage
+from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorageWrapper
+from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
+from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.path import Path
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
 from cutty.templates.adapters.cookiecutter.config import loadconfig
@@ -96,10 +98,12 @@ def create(
     if output_dir is None:
         output_dir = pathlib.Path.cwd()  # pragma: no cover
 
-    with CookiecutterFileStorage(
+    storage: FileStorage
+    storage = DiskFileStorage(
         output_dir,
-        hookfiles=hookfiles,
         fileexists=fileexistspolicy(overwrite_if_exists, skip_if_file_exists),
-    ) as storage:
+    )
+    storage = CookiecutterFileStorageWrapper.wrap(storage, hookfiles=hookfiles)
+    with storage:
         for file in files:
             storage.add(file)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import appdirs
 
-from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorageWrapper
+from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorage
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.domain.storage import FileStorage
@@ -103,7 +103,7 @@ def create(
         output_dir,
         fileexists=fileexistspolicy(overwrite_if_exists, skip_if_file_exists),
     )
-    storage = CookiecutterFileStorageWrapper.wrap(storage, hookfiles=hookfiles)
+    storage = CookiecutterFileStorage.wrap(storage, hookfiles=hookfiles)
     with storage:
         for file in files:
             storage.add(file)

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -69,10 +69,12 @@ def test_hooks(
 
 def test_no_files(tmp_path: pathlib.Path, createstorage: CreateFileStorage) -> None:
     """It does nothing."""
-    storage = createstorage(["post_gen_project"])
+    hooks = ["pre_gen_project", "post_gen_project"]
+    storage = createstorage(hooks)
 
     with storage:
         pass
 
-    path = tmp_path / "example" / "post_gen_project"
-    assert not path.is_file()
+    for hook in hooks:
+        path = tmp_path / "example" / hook
+        assert not path.is_file()

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import pytest
 
-from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorageWrapper
+from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorage
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.domain.files import Executable
 from cutty.filestorage.domain.files import File
@@ -38,7 +38,7 @@ def createstorage(tmp_path: pathlib.Path) -> CreateFileStorage:
             for hook in hooks
         ]
         storage = DiskFileStorage(tmp_path)
-        return CookiecutterFileStorageWrapper.wrap(storage, hookfiles=hookfiles)
+        return CookiecutterFileStorage.wrap(storage, hookfiles=hookfiles)
 
     return _createstorage
 

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -42,19 +42,29 @@ def createstorage(tmp_path: pathlib.Path) -> CreateFileStorage:
     return _createstorage
 
 
+@pytest.mark.parametrize(
+    "hooks",
+    [
+        ["pre_gen_project"],
+        ["post_gen_project"],
+        ["pre_gen_project", "post_gen_project"],
+    ],
+)
 def test_hooks(
     tmp_path: pathlib.Path,
     createstorage: CreateFileStorage,
     file: File,
+    hooks: Iterable[str],
 ) -> None:
     """It executes the hook."""
-    storage = createstorage(["post_gen_project"])
+    storage = createstorage(hooks)
 
     with storage:
         storage.add(file)
 
-    path = tmp_path / "example" / "post_gen_project"
-    assert path.is_file()
+    for hook in hooks:
+        path = tmp_path / "example" / hook
+        assert path.is_file()
 
 
 def test_no_files(tmp_path: pathlib.Path, createstorage: CreateFileStorage) -> None:

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -15,11 +15,12 @@ from cutty.filesystems.domain.purepath import PurePath
 
 
 @pytest.fixture
-def file() -> RegularFile:
-    """Fixture for a regular file."""
-    path = PurePath("example", "README.md")
-    blob = b"# example\n"
-    return RegularFile(path, blob)
+def files() -> Iterable[File]:
+    """Fixture with files to be stored."""
+    return [
+        RegularFile(PurePath("example", "file1"), b"data1"),
+        RegularFile(PurePath("example", "file2"), b"data2"),
+    ]
 
 
 CreateFileStorage = Callable[[Iterable[str]], FileStorage]
@@ -53,14 +54,15 @@ def createstorage(tmp_path: pathlib.Path) -> CreateFileStorage:
 def test_hooks(
     tmp_path: pathlib.Path,
     createstorage: CreateFileStorage,
-    file: File,
+    files: Iterable[File],
     hooks: Iterable[str],
 ) -> None:
     """It executes the hook."""
     storage = createstorage(hooks)
 
     with storage:
-        storage.add(file)
+        for file in files:
+            storage.add(file)
 
     for hook in hooks:
         path = tmp_path / "example" / hook

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -1,15 +1,28 @@
 """Unit tests for cutty.filestorage.adapters.cookiecutter."""
 import pathlib
+from collections.abc import Iterable
 
 import pytest
 
-from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorage
+from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorageWrapper
+from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.domain.files import Executable
 from cutty.filestorage.domain.files import File
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
+
+
+def CookiecutterFileStorage(  # noqa: N802
+    root: pathlib.Path,
+    *,
+    fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
+    hookfiles: Iterable[File] = (),
+) -> FileStorage:
+    """Disk-based file store with Cookiecutter hooks."""
+    storage = DiskFileStorage(root, fileexists=fileexists)
+    return CookiecutterFileStorageWrapper.wrap(storage, hookfiles=hookfiles)
 
 
 @pytest.fixture

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -21,7 +21,7 @@ def file() -> RegularFile:
 
 
 @pytest.fixture
-def storagewithhook(tmp_path: pathlib.Path) -> FileStorage:
+def storage(tmp_path: pathlib.Path) -> FileStorage:
     """Fixture for a storage with hooks."""
     hook = Executable(
         PurePath("hooks", "post_gen_project.py"),
@@ -31,20 +31,18 @@ def storagewithhook(tmp_path: pathlib.Path) -> FileStorage:
     return CookiecutterFileStorageWrapper.wrap(storage, hookfiles=[hook])
 
 
-def test_hooks(
-    tmp_path: pathlib.Path, storagewithhook: FileStorage, file: File
-) -> None:
+def test_hooks(tmp_path: pathlib.Path, storage: FileStorage, file: File) -> None:
     """It executes the hook."""
-    with storagewithhook:
-        storagewithhook.add(file)
+    with storage:
+        storage.add(file)
 
     path = tmp_path / "example" / "marker"
     assert path.is_file()
 
 
-def test_no_files(tmp_path: pathlib.Path, storagewithhook: FileStorage) -> None:
+def test_no_files(tmp_path: pathlib.Path, storage: FileStorage) -> None:
     """It does nothing."""
-    with storagewithhook:
+    with storage:
         pass
 
     path = tmp_path / "example" / "marker"

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -80,3 +80,20 @@ def test_no_files(tmp_path: pathlib.Path, createstorage: CreateFileStorage) -> N
     for hook in hooks:
         path = tmp_path / "example" / hook
         assert not path.is_file()
+
+
+@pytest.mark.xfail(reason="FIXME: Hooks break rollback assumptions")
+def test_rollback(
+    tmp_path: pathlib.Path, createstorage: CreateFileStorage, files: Iterable[File]
+) -> None:
+    """It removes any created files."""
+    storage = createstorage(["pre_gen_project"])
+
+    with pytest.raises(RuntimeError):
+        with storage:
+            for file in files:
+                storage.add(file)
+            raise RuntimeError()
+
+    path = tmp_path / "example" / "pre_gen_project"
+    assert not path.is_file()

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -4,6 +4,7 @@ import pathlib
 import pytest
 
 from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorage
+from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.domain.files import Executable
 from cutty.filestorage.domain.files import File
 from cutty.filestorage.domain.files import RegularFile
@@ -86,11 +87,7 @@ def test_already_exists(storage: FileStorage, file: File) -> None:
 
 def test_overwrite_if_exists(tmp_path: pathlib.Path, file: File) -> None:
     """It overwrites existing files."""
-    storage = CookiecutterFileStorage(
-        tmp_path,
-        overwrite_if_exists=True,
-        skip_if_file_exists=False,
-    )
+    storage = CookiecutterFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE)
 
     path = tmp_path.joinpath(*file.path.parts)
     path.parent.mkdir()
@@ -104,11 +101,7 @@ def test_overwrite_if_exists(tmp_path: pathlib.Path, file: File) -> None:
 
 def test_skip_if_file_exists(tmp_path: pathlib.Path, file: File) -> None:
     """It skips existing files."""
-    storage = CookiecutterFileStorage(
-        tmp_path,
-        overwrite_if_exists=True,
-        skip_if_file_exists=True,
-    )
+    storage = CookiecutterFileStorage(tmp_path, fileexists=FileExistsPolicy.SKIP)
 
     path = tmp_path.joinpath(*file.path.parts)
     path.parent.mkdir()

--- a/tests/unit/filestorage/adapters/test_disk.py
+++ b/tests/unit/filestorage/adapters/test_disk.py
@@ -48,7 +48,7 @@ def storage(tmp_path: pathlib.Path) -> DiskFileStorage:
     return DiskFileStorage(tmp_path)
 
 
-def test_regular_file(file: RegularFile, storage: DiskFileStorage) -> None:
+def test_regular_file(storage: DiskFileStorage, file: RegularFile) -> None:
     """It stores the file."""
     with storage:
         storage.add(file)
@@ -70,7 +70,7 @@ class FakeError(Exception):
     """Exception used for testing rollback."""
 
 
-def test_regular_file_undo(file: RegularFile, storage: DiskFileStorage) -> None:
+def test_regular_file_undo(storage: DiskFileStorage, file: RegularFile) -> None:
     """It removes a created file when rolling back after an error."""
     with contextlib.suppress(FakeError):
         with storage:
@@ -81,7 +81,7 @@ def test_regular_file_undo(file: RegularFile, storage: DiskFileStorage) -> None:
     assert not path.exists()
 
 
-def test_directory_undo(file: RegularFile, storage: DiskFileStorage) -> None:
+def test_directory_undo(storage: DiskFileStorage, file: RegularFile) -> None:
     """It removes a created directory when rolling back after an error."""
     with contextlib.suppress(FakeError):
         with storage:
@@ -160,7 +160,7 @@ def test_file_exists_overwrite_undo(tmp_path: pathlib.Path, file: RegularFile) -
     assert path.exists()
 
 
-def test_executable_blob(executable: Executable, storage: DiskFileStorage) -> None:
+def test_executable_blob(storage: DiskFileStorage, executable: Executable) -> None:
     """It stores the file."""
     with storage:
         storage.add(executable)
@@ -173,7 +173,7 @@ def test_executable_blob(executable: Executable, storage: DiskFileStorage) -> No
     platform.system() == "Windows",
     reason="Path.chmod ignores executable bits on Windows.",
 )
-def test_executable_mode(executable: File, storage: DiskFileStorage) -> None:
+def test_executable_mode(storage: DiskFileStorage, executable: File) -> None:
     """It stores the file."""
     with storage:
         storage.add(executable)
@@ -182,7 +182,7 @@ def test_executable_mode(executable: File, storage: DiskFileStorage) -> None:
     assert os.access(path, os.X_OK)
 
 
-def test_symlink(symlink: SymbolicLink, storage: DiskFileStorage) -> None:
+def test_symlink(storage: DiskFileStorage, symlink: SymbolicLink) -> None:
     """It stores the file."""
     with storage:
         storage.add(symlink)

--- a/tests/unit/filestorage/adapters/test_disk.py
+++ b/tests/unit/filestorage/adapters/test_disk.py
@@ -12,6 +12,7 @@ from cutty.filestorage.domain.files import Executable
 from cutty.filestorage.domain.files import File
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.files import SymbolicLink
+from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
 
 
@@ -207,3 +208,58 @@ def test_unknown_filetype(tmp_path: pathlib.Path) -> None:
     path = tmp_path.joinpath(*file.path.parts)
     assert not path.exists()
     assert not path.parent.exists()
+
+
+@pytest.fixture
+def storage(tmp_path: pathlib.Path) -> FileStorage:
+    """Fixture for a storage."""
+    return DiskFileStorage(tmp_path)
+
+
+def test_multiple_files(
+    tmp_path: pathlib.Path, storage: FileStorage, file: File, executable: File
+) -> None:
+    """It stores all the files."""
+    with storage:
+        storage.add(executable)
+        storage.add(file)
+
+    assert all(
+        tmp_path.joinpath(*each.path.parts).is_file() for each in (file, executable)
+    )
+
+
+def test_already_exists(storage: FileStorage, file: File) -> None:
+    """It raises an exception if the file already exists."""
+    with storage:
+        storage.add(file)
+        with pytest.raises(Exception):
+            storage.add(file)
+
+
+def test_overwrite_if_exists(tmp_path: pathlib.Path, file: File) -> None:
+    """It overwrites existing files."""
+    storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE)
+
+    path = tmp_path.joinpath(*file.path.parts)
+    path.parent.mkdir()
+    path.write_text("old")
+
+    with storage:
+        storage.add(file)
+
+    assert path.read_text() != "old"
+
+
+def test_skip_if_file_exists(tmp_path: pathlib.Path, file: File) -> None:
+    """It skips existing files."""
+    storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.SKIP)
+
+    path = tmp_path.joinpath(*file.path.parts)
+    path.parent.mkdir()
+    path.write_text("old")
+
+    with storage:
+        storage.add(file)
+
+    assert path.read_text() == "old"

--- a/tests/unit/filestorage/adapters/test_disk.py
+++ b/tests/unit/filestorage/adapters/test_disk.py
@@ -12,7 +12,6 @@ from cutty.filestorage.domain.files import Executable
 from cutty.filestorage.domain.files import File
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.files import SymbolicLink
-from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
 
 
@@ -44,19 +43,17 @@ def symlink() -> SymbolicLink:
 
 
 @pytest.fixture
-def storage(tmp_path: pathlib.Path) -> FileStorage:
+def storage(tmp_path: pathlib.Path) -> DiskFileStorage:
     """Fixture for a storage."""
     return DiskFileStorage(tmp_path)
 
 
-def test_regular_file(
-    tmp_path: pathlib.Path, file: RegularFile, storage: FileStorage
-) -> None:
+def test_regular_file(file: RegularFile, storage: DiskFileStorage) -> None:
     """It stores the file."""
     with storage:
         storage.add(file)
 
-    path = tmp_path.joinpath(*file.path.parts)
+    path = storage.resolve(file.path)
     assert path.read_bytes() == file.blob
 
 
@@ -64,38 +61,32 @@ class FakeError(Exception):
     """Exception used for testing rollback."""
 
 
-def test_regular_file_undo(
-    tmp_path: pathlib.Path, file: RegularFile, storage: FileStorage
-) -> None:
+def test_regular_file_undo(file: RegularFile, storage: DiskFileStorage) -> None:
     """It removes a created file when rolling back after an error."""
     with contextlib.suppress(FakeError):
         with storage:
             storage.add(file)
             raise FakeError()
 
-    path = tmp_path.joinpath(*file.path.parts)
+    path = storage.resolve(file.path)
     assert not path.exists()
 
 
-def test_directory_undo(
-    tmp_path: pathlib.Path, file: RegularFile, storage: FileStorage
-) -> None:
+def test_directory_undo(file: RegularFile, storage: DiskFileStorage) -> None:
     """It removes a created directory when rolling back after an error."""
     with contextlib.suppress(FakeError):
         with storage:
             storage.add(file)
             raise FakeError()
 
-    path = tmp_path.joinpath(*file.path.parts)
+    path = storage.resolve(file.path)
     assert not path.exists()
     assert not path.parent.exists()
 
 
-def test_file_exists_raise(
-    tmp_path: pathlib.Path, file: RegularFile, storage: FileStorage
-) -> None:
+def test_file_exists_raise(file: RegularFile, storage: DiskFileStorage) -> None:
     """It raises an exception if the file exists."""
-    path = tmp_path.joinpath(*file.path.parts)
+    path = storage.resolve(file.path)
     path.parent.mkdir(parents=True)
     path.touch()
 
@@ -106,11 +97,13 @@ def test_file_exists_raise(
 
 def test_file_exists_skip(tmp_path: pathlib.Path, file: RegularFile) -> None:
     """It skips existing files when requested."""
-    path = tmp_path.joinpath(*file.path.parts)
+    storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.SKIP)
+
+    path = storage.resolve(file.path)
     path.parent.mkdir(parents=True)
     path.touch()
 
-    with DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.SKIP) as storage:
+    with storage:
         storage.add(file)
 
     assert not path.read_bytes()
@@ -118,11 +111,13 @@ def test_file_exists_skip(tmp_path: pathlib.Path, file: RegularFile) -> None:
 
 def test_file_exists_overwrite(tmp_path: pathlib.Path, file: RegularFile) -> None:
     """It overwrites an existing file when requested."""
-    path = tmp_path.joinpath(*file.path.parts)
+    storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE)
+
+    path = storage.resolve(file.path)
     path.parent.mkdir(parents=True)
     path.touch()
 
-    with DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE) as storage:
+    with storage:
         storage.add(file)
 
     assert path.read_bytes() == file.blob
@@ -132,10 +127,12 @@ def test_file_exists_overwrite_directory(
     tmp_path: pathlib.Path, file: RegularFile
 ) -> None:
     """It raises an exception if the target is an existing directory."""
-    path = tmp_path.joinpath(*file.path.parts)
+    storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE)
+
+    path = storage.resolve(file.path)
     path.mkdir(parents=True)
 
-    with DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE) as storage:
+    with storage:
         error = PermissionError if platform.system() == "Windows" else IsADirectoryError
         with pytest.raises(error):
             storage.add(file)
@@ -143,28 +140,26 @@ def test_file_exists_overwrite_directory(
 
 def test_file_exists_overwrite_undo(tmp_path: pathlib.Path, file: RegularFile) -> None:
     """It does not remove overwritten files when rolling back."""
-    path = tmp_path.joinpath(*file.path.parts)
+    storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE)
+
+    path = storage.resolve(file.path)
     path.parent.mkdir(parents=True)
     path.touch()
 
     with contextlib.suppress(FakeError):
-        with DiskFileStorage(
-            tmp_path, fileexists=FileExistsPolicy.OVERWRITE
-        ) as storage:
+        with storage:
             storage.add(file)
             raise FakeError()
 
     assert path.exists()
 
 
-def test_executable_blob(
-    tmp_path: pathlib.Path, executable: Executable, storage: FileStorage
-) -> None:
+def test_executable_blob(executable: Executable, storage: DiskFileStorage) -> None:
     """It stores the file."""
     with storage:
         storage.add(executable)
 
-    path = tmp_path.joinpath(*executable.path.parts)
+    path = storage.resolve(executable.path)
     assert path.read_bytes() == executable.blob
 
 
@@ -172,25 +167,21 @@ def test_executable_blob(
     platform.system() == "Windows",
     reason="Path.chmod ignores executable bits on Windows.",
 )
-def test_executable_mode(
-    tmp_path: pathlib.Path, executable: File, storage: FileStorage
-) -> None:
+def test_executable_mode(executable: File, storage: DiskFileStorage) -> None:
     """It stores the file."""
     with storage:
         storage.add(executable)
 
-    path = tmp_path.joinpath(*executable.path.parts)
+    path = storage.resolve(executable.path)
     assert os.access(path, os.X_OK)
 
 
-def test_symlink(
-    tmp_path: pathlib.Path, symlink: SymbolicLink, storage: FileStorage
-) -> None:
+def test_symlink(symlink: SymbolicLink, storage: DiskFileStorage) -> None:
     """It stores the file."""
     with storage:
         storage.add(symlink)
 
-    path = tmp_path.joinpath(*symlink.path.parts)
+    path = storage.resolve(symlink.path)
     assert path.readlink().parts == symlink.target.parts
 
 
@@ -198,10 +189,12 @@ def test_symlink_overwrite_symlink(
     tmp_path: pathlib.Path, symlink: SymbolicLink
 ) -> None:
     """It raises an exception."""
-    path = tmp_path.joinpath(*symlink.path.parts)
+    storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE)
+
+    path = storage.resolve(symlink.path)
     path.symlink_to(tmp_path)
 
-    with DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE) as storage:
+    with storage:
         storage.add(symlink)
 
     assert path.readlink().parts == symlink.target.parts
@@ -209,15 +202,17 @@ def test_symlink_overwrite_symlink(
 
 def test_symlink_overwrite_file(tmp_path: pathlib.Path, symlink: SymbolicLink) -> None:
     """It raises an exception."""
-    path = tmp_path.joinpath(*symlink.path.parts)
+    storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE)
+
+    path = storage.resolve(symlink.path)
     path.touch()
 
-    with DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE) as storage:
+    with storage:
         with pytest.raises(FileExistsError):
             storage.add(symlink)
 
 
-def test_unknown_filetype(tmp_path: pathlib.Path, storage: FileStorage) -> None:
+def test_unknown_filetype(storage: DiskFileStorage) -> None:
     """It raises a TypeError."""
     file = File(PurePath("dir", "file"))
 
@@ -225,25 +220,21 @@ def test_unknown_filetype(tmp_path: pathlib.Path, storage: FileStorage) -> None:
         with storage:
             storage.add(file)
 
-    path = tmp_path.joinpath(*file.path.parts)
+    path = storage.resolve(file.path)
     assert not path.exists()
     assert not path.parent.exists()
 
 
-def test_multiple_files(
-    tmp_path: pathlib.Path, storage: FileStorage, file: File, executable: File
-) -> None:
+def test_multiple_files(storage: DiskFileStorage, file: File, executable: File) -> None:
     """It stores all the files."""
     with storage:
         storage.add(executable)
         storage.add(file)
 
-    assert all(
-        tmp_path.joinpath(*each.path.parts).is_file() for each in (file, executable)
-    )
+    assert all(storage.resolve(each.path).is_file() for each in (file, executable))
 
 
-def test_already_exists(storage: FileStorage, file: File) -> None:
+def test_already_exists(storage: DiskFileStorage, file: File) -> None:
     """It raises an exception if the file already exists."""
     with storage:
         storage.add(file)
@@ -255,7 +246,7 @@ def test_overwrite_if_exists(tmp_path: pathlib.Path, file: File) -> None:
     """It overwrites existing files."""
     storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.OVERWRITE)
 
-    path = tmp_path.joinpath(*file.path.parts)
+    path = storage.resolve(file.path)
     path.parent.mkdir()
     path.write_text("old")
 
@@ -269,7 +260,7 @@ def test_skip_if_file_exists(tmp_path: pathlib.Path, file: File) -> None:
     """It skips existing files."""
     storage = DiskFileStorage(tmp_path, fileexists=FileExistsPolicy.SKIP)
 
-    path = tmp_path.joinpath(*file.path.parts)
+    path = storage.resolve(file.path)
     path.parent.mkdir()
     path.write_text("old")
 


### PR DESCRIPTION
- :recycle: [filestorage] Create FileExistsPolicy in services.create
- :sparkles: [filestorage] Add file storage wrapper
- :art: [filestorage] Add missing return type annotation
- :sparkles: [filestorage] Add CookiecutterFileStorageWrapper
- :recycle: [services] Use CookiecutterFileStorageWrapper in services.create
- :recycle: [filestorage] Turn CookiecutterFileStorage into wrapper function
- :recycle: [filestorage] Move function CookiecutterFileStorage to test
- :recycle: [filestorage] Use disk storage if there are no hooks
- :recycle: [filestorage] Inline function CookiecutterFileStorage in test
- :recycle: [filestorage] Move disk storage tests
- :recycle: [filestorage] Rename fixture storagewithhooks to storage
- :recycle: [filestorage] Use storage fixture in disk storage tests
- :recycle: [filestorage] Use storage.resolve in disk storage tests
- :fire: [filestorage] Remove duplicate tests
- :recycle: [filestorage] Use consistent parameter order in disk storage tests
- :recycle: [filestorage] Use factory fixture in cookiecutter storage tests
- :white_check_mark: [filestorage] Generalize test for all hook combinations
- :white_check_mark: [filestorage] Include pre-generate hook in test with no files
- :white_check_mark: [filestorage] Test cookiecutter storage with multiple files
- :recycle: [filestorage] Rename CookiecutterFileStorage{Wrapper => }
- :white_check_mark: [filestorage] Add failing test for rollback with hooks
