### PR TITLE
:sparkles: Continue on error when rolling back disk stores

### DIFF
--- a/src/cutty/filestorage/adapters/disk.py
+++ b/src/cutty/filestorage/adapters/disk.py
@@ -1,4 +1,5 @@
 """Disk-based file storage."""
+import contextlib
 import enum
 import pathlib
 from collections.abc import Callable
@@ -119,4 +120,5 @@ class DiskFileStorage(FileStorage):
     def rollback(self) -> None:
         """Rollback all stores."""
         for action in reversed(self.undo):
-            action()  # if this fails then so be it
+            with contextlib.suppress(Exception):
+                action()

--- a/tests/unit/filestorage/adapters/test_disk.py
+++ b/tests/unit/filestorage/adapters/test_disk.py
@@ -93,6 +93,21 @@ def test_directory_undo(storage: DiskFileStorage, file: RegularFile) -> None:
     assert not path.parent.exists()
 
 
+def test_undo_continues_on_error(
+    storage: DiskFileStorage, file: RegularFile, executable: File
+) -> None:
+    """It rolls back even if some actions cannot be undone."""
+    with contextlib.suppress(FakeError):
+        with storage:
+            storage.add(file)
+            storage.add(executable)
+            storage.resolve(executable.path).unlink()
+            raise FakeError()
+
+    path = storage.resolve(file.path)
+    assert not path.exists()
+
+
 def test_file_exists_raise(storage: DiskFileStorage, file: File) -> None:
     """It raises an exception if the file already exists."""
     with storage:


### PR DESCRIPTION
- :white_check_mark: [filestorage] Add failing test for rollback continuing on error
- :sparkles: [filestorage] Continue on error when rolling back disk stores
