### PR TITLE
:recycle: Pass project directory to Cookiecutter storage

### DIFF
--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -17,6 +17,7 @@ from cutty.filestorage.domain.storage import FileStorageWrapper
 def _runcommand(path: pathlib.Path, *, cwd: pathlib.Path) -> None:
     command = [pathlib.Path(sys.executable), path] if path.suffix == ".py" else [path]
     shell = platform.system() == "Windows"
+    cwd.mkdir(parents=True, exist_ok=True)
     subprocess.run(command, shell=shell, cwd=cwd, check=True)  # noqa: S602
 
 
@@ -45,7 +46,6 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
         """Add file to storage."""
         if self.project is None:
             self.project = self.storage.resolve(file.path.parents[-2])
-            self.project.mkdir(parents=True, exist_ok=True)
             _runhook(self.hooks, "pre_gen_project", cwd=self.project)
 
         super().add(file)

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -6,7 +6,6 @@ import subprocess  # noqa: S404
 import sys
 import tempfile
 from collections.abc import Iterable
-from typing import Optional
 
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
@@ -39,7 +38,7 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
         storage: DiskFileStorage,
         *,
         hookfiles: Iterable[File] = (),
-        project: Optional[pathlib.Path] = None
+        project: pathlib.Path
     ) -> None:
         """Initialize."""
         super().__init__(storage)
@@ -49,8 +48,6 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
 
     def add(self, file: File) -> None:
         """Add file to storage."""
-        if self.project is None:
-            self.project = self.storage.resolve(file.path.parents[-2])
         if not self.added:
             _runhook(self.hooks, "pre_gen_project", cwd=self.project)
             self.added = True
@@ -60,17 +57,13 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
     def commit(self) -> None:
         """Commit the stores."""
         if self.added:
-            assert self.project is not None  # noqa: S101
             _runhook(self.hooks, "post_gen_project", cwd=self.project)
 
         super().commit()
 
     def rollback(self) -> None:
         """Roll back the stores."""
-        if (
-            self.project is None
-            or self.storage.fileexists is FileExistsPolicy.OVERWRITE
-        ):
+        if self.storage.fileexists is FileExistsPolicy.OVERWRITE:
             super().rollback()
         else:
             shutil.rmtree(self.project, ignore_errors=True)

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -45,10 +45,7 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
         """Add file to storage."""
         if self.project is None:
             self.project = self.storage.resolve(file.path.parents[-2])
-            self.project.mkdir(
-                parents=True,
-                exist_ok=self.storage.fileexists is not FileExistsPolicy.RAISE,
-            )
+            self.project.mkdir(parents=True, exist_ok=True)
             _runhook(self.hooks, "pre_gen_project", cwd=self.project)
 
         super().add(file)

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -35,12 +35,16 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
     """Wrap a disk-based file store with Cookiecutter hooks."""
 
     def __init__(
-        self, storage: DiskFileStorage, *, hookfiles: Iterable[File] = ()
+        self,
+        storage: DiskFileStorage,
+        *,
+        hookfiles: Iterable[File] = (),
+        project: Optional[pathlib.Path] = None
     ) -> None:
         """Initialize."""
         super().__init__(storage)
         self.hooks = {hook.path.stem: hook for hook in hookfiles}
-        self.project: Optional[pathlib.Path] = None
+        self.project = project
         self.added = False
 
     def add(self, file: File) -> None:

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -26,6 +26,7 @@ from cutty.templates.domain.config import Config
 from cutty.templates.domain.render import createrenderer
 from cutty.templates.domain.render import defaultrenderregistry
 from cutty.templates.domain.renderfiles import renderfiles
+from cutty.util.peek import peek
 
 
 def iterpaths(path: Path, config: Config) -> Iterator[Path]:
@@ -108,7 +109,12 @@ def create(
 
     hookfiles = tuple(hookfiles)
     if hookfiles:  # pragma: no cover
-        storage = CookiecutterFileStorage(storage, hookfiles=hookfiles)
+        file, files = peek(files)
+        if file is not None:
+            project = storage.resolve(file.path.parents[-2])
+            storage = CookiecutterFileStorage(
+                storage, hookfiles=hookfiles, project=project
+            )
 
     with storage:
         for file in files:

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -105,10 +105,11 @@ def create(
         output_dir,
         fileexists=fileexistspolicy(overwrite_if_exists, skip_if_file_exists),
     )
+
     hookfiles = tuple(hookfiles)
-    storage = (
-        CookiecutterFileStorage(storage, hookfiles=hookfiles) if hookfiles else storage
-    )
+    if hookfiles:  # pragma: no cover
+        storage = CookiecutterFileStorage(storage, hookfiles=hookfiles)
+
     with storage:
         for file in files:
             storage.add(file)

--- a/src/cutty/util/peek.py
+++ b/src/cutty/util/peek.py
@@ -1,0 +1,21 @@
+"""The peek utility."""
+import itertools
+from collections.abc import Iterable
+from collections.abc import Iterator
+from typing import Optional
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def peek(
+    iterable: Iterable[T], *, default: Optional[T] = None
+) -> tuple[Optional[T], Iterator[T]]:
+    """Peek at the first item of an iterable."""
+    iterator = iter(iterable)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return default, iterator
+    else:
+        return first, itertools.chain([first], iterator)

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -54,7 +54,8 @@ def createstorage(tmp_path: pathlib.Path) -> CreateFileStorage:
             )
             for hook in hooks
         ]
-        return CookiecutterFileStorage(storage, hookfiles=hookfiles)
+        project = storage.resolve(PurePath("example"))
+        return CookiecutterFileStorage(storage, hookfiles=hookfiles, project=project)
 
     return _createstorage
 

--- a/tests/unit/util/test_peek.py
+++ b/tests/unit/util/test_peek.py
@@ -1,0 +1,36 @@
+"""Unit tests for cutty.util.peek."""
+from collections.abc import Iterable
+
+from cutty.util.peek import peek
+
+
+def test_peek_empty() -> None:
+    """It returns None."""
+    iterable: Iterable[int]
+    first, iterable = peek([])
+    assert first is None
+    assert not list(iterable)
+
+
+def test_peek_default() -> None:
+    """It returns the default."""
+    iterable: Iterable[int]
+    first, iterable = peek([], default=42)
+    assert first == 42
+    assert not list(iterable)
+
+
+def test_peek_one() -> None:
+    """It returns the first item."""
+    iterable: Iterable[int]
+    first, iterable = peek([1])
+    assert first == 1
+    assert list(iterable) == [1]
+
+
+def test_peek_many() -> None:
+    """It returns the first item."""
+    iterable: Iterable[int]
+    first, iterable = peek([1, 2])
+    assert first == 1
+    assert list(iterable) == [1, 2]


### PR DESCRIPTION
- :sparkles: [filestorage] Do not raise when the project directory already exists
- :sparkles: [filestorage] Only create project directory if the hook exists
- :recycle: [filestorage] Separate deriving project directory from "first" switch
- :recycle: [filestorage] Add optional parameter for project directory
- :recycle: [services] Replace ternary by if statement
- :sparkles: [util] Add utility for peeking at the first item of an iterable
- :white_check_mark: [util] Add tests for peek
- :recycle: [services] Pass project directory to storage
- :recycle: [filestorage] Pass project directory to storage in tests
- :recycle: [filestorage] Remove dead code deriving project directory
