### PR TITLE
:recycle: [filestorage] Extract class to invoke Cookiecutter hooks

### DIFF
--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -18,7 +18,7 @@ class _Hooks:
         self.hooks = {hook.path.stem: hook for hook in hookfiles}
         self.cwd = cwd
 
-    def _runhook(self, hook: str) -> None:
+    def run(self, hook: str) -> None:
         hookfile = self.hooks.get(hook)
         if hookfile is not None:
             with tempfile.TemporaryDirectory() as root:
@@ -54,7 +54,7 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
     def add(self, file: File) -> None:
         """Add file to storage."""
         if not self.added:
-            self.hooks._runhook("pre_gen_project")
+            self.hooks.run("pre_gen_project")
             self.added = True
 
         super().add(file)
@@ -62,7 +62,7 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
     def commit(self) -> None:
         """Commit the stores."""
         if self.added:
-            self.hooks._runhook("post_gen_project")
+            self.hooks.run("post_gen_project")
 
         super().commit()
 

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -25,15 +25,15 @@ class _Hooks:
                 with DiskFileStorage(pathlib.Path(root)) as storage:
                     storage.add(hookfile)
                     path = storage.resolve(hookfile.path)
-                    self._runcommand(path, cwd=self.cwd)
+                    self._runcommand(path)
 
-    def _runcommand(self, path: pathlib.Path, *, cwd: pathlib.Path) -> None:
+    def _runcommand(self, path: pathlib.Path) -> None:
         command = (
             [pathlib.Path(sys.executable), path] if path.suffix == ".py" else [path]
         )
         shell = platform.system() == "Windows"
-        cwd.mkdir(parents=True, exist_ok=True)
-        subprocess.run(command, shell=shell, cwd=cwd, check=True)  # noqa: S602
+        self.cwd.mkdir(parents=True, exist_ok=True)
+        subprocess.run(command, shell=shell, cwd=self.cwd, check=True)  # noqa: S602
 
 
 class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -28,9 +28,9 @@ class _Hooks:
             with DiskFileStorage(pathlib.Path(root)) as storage:
                 storage.add(hookfile)
                 path = storage.resolve(hookfile.path)
-                self._runcommand(path)
+                self._runpath(path)
 
-    def _runcommand(self, path: pathlib.Path) -> None:
+    def _runpath(self, path: pathlib.Path) -> None:
         command = (
             [pathlib.Path(sys.executable), path] if path.suffix == ".py" else [path]
         )

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -21,11 +21,14 @@ class _Hooks:
     def run(self, hook: str) -> None:
         hookfile = self.hooks.get(hook)
         if hookfile is not None:
-            with tempfile.TemporaryDirectory() as root:
-                with DiskFileStorage(pathlib.Path(root)) as storage:
-                    storage.add(hookfile)
-                    path = storage.resolve(hookfile.path)
-                    self._runcommand(path)
+            self._runfile(hookfile)
+
+    def _runfile(self, hookfile: File) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            with DiskFileStorage(pathlib.Path(root)) as storage:
+                storage.add(hookfile)
+                path = storage.resolve(hookfile.path)
+                self._runcommand(path)
 
     def _runcommand(self, path: pathlib.Path) -> None:
         command = (

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -20,23 +20,19 @@ def _runcommand(path: pathlib.Path, *, cwd: pathlib.Path) -> None:
     subprocess.run(command, shell=shell, cwd=cwd, check=True)  # noqa: S602
 
 
-def _runhook(hooks: dict[str, File], hook: str, *, cwd: pathlib.Path) -> None:
-    hookfile = hooks.get(hook)
-    if hookfile is not None:
-        with tempfile.TemporaryDirectory() as root:
-            with DiskFileStorage(pathlib.Path(root)) as storage:
-                storage.add(hookfile)
-                path = storage.resolve(hookfile.path)
-                _runcommand(path, cwd=cwd)
-
-
 class _Hooks:
     def __init__(self, *, hookfiles: Iterable[File] = (), cwd: pathlib.Path) -> None:
         self.hooks = {hook.path.stem: hook for hook in hookfiles}
         self.cwd = cwd
 
     def _runhook(self, hook: str) -> None:
-        _runhook(self.hooks, hook, cwd=self.cwd)
+        hookfile = self.hooks.get(hook)
+        if hookfile is not None:
+            with tempfile.TemporaryDirectory() as root:
+                with DiskFileStorage(pathlib.Path(root)) as storage:
+                    storage.add(hookfile)
+                    path = storage.resolve(hookfile.path)
+                    _runcommand(path, cwd=self.cwd)
 
 
 class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):


### PR DESCRIPTION
- :recycle: [filestorage] Extract _Hooks class
- :recycle: [filestorage] Inline function _runhook
- :recycle: [filestorage] Move function _runcommand into _Hooks
- :recycle: [filestorage] Remove parameter `cwd` and use `self.cwd`
- :recycle: [filestorage] Rename function {_runhook => run}
- :recycle: [filestorage] Extract function `_runfile`
- :recycle: [filestorage] Rename function _run{command => path}
