### PR TITLE
:recycle: [filestorage] Use observer pattern to implement Cookiecutter hooks

### DIFF
--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -49,6 +49,7 @@ class CookiecutterFileStorageObserver(FileStorageObserver):
 
     def begin(self) -> None:
         """A storage transaction was started."""
+        self.hooks.run("pre_gen_project")
 
     def commit(self) -> None:
         """A storage transaction was completed."""
@@ -76,7 +77,6 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
     def add(self, file: File) -> None:
         """Add file to storage."""
         if not self.added:
-            self.hooks.run("pre_gen_project")
             self.added = True
 
         super().add(file)

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -77,6 +77,6 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
         self.observers.append(
             CookiecutterFileStorageObserver(
                 _Hooks(hookfiles=hookfiles, cwd=project),
-                overwrite=self.storage.fileexists is FileExistsPolicy.OVERWRITE,
+                overwrite=storage.fileexists is FileExistsPolicy.OVERWRITE,
             )
         )

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -74,10 +74,9 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
     ) -> None:
         """Initialize."""
         super().__init__(storage)
-        self.hooks = _Hooks(hookfiles=hookfiles, cwd=project)
         self.observers.append(
             CookiecutterFileStorageObserver(
-                self.hooks,
+                _Hooks(hookfiles=hookfiles, cwd=project),
                 overwrite=self.storage.fileexists is FileExistsPolicy.OVERWRITE,
             )
         )

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -42,9 +42,11 @@ class _Hooks:
 class CookiecutterFileStorageObserver(FileStorageObserver):
     """Storage observer invoking Cookiecutter hooks."""
 
-    def __init__(self, hooks: _Hooks, *, overwrite: bool) -> None:
+    def __init__(
+        self, *, hookfiles: Iterable[File] = (), project: pathlib.Path, overwrite: bool
+    ) -> None:
         """Initialize."""
-        self.hooks = hooks
+        self.hooks = _Hooks(hookfiles=hookfiles, cwd=project)
         self.overwrite = overwrite
 
     def begin(self) -> None:
@@ -67,7 +69,8 @@ def CookiecutterFileStorage(  # noqa: N802
     """Wrap a disk-based file store with Cookiecutter hooks."""
     storage.observers.append(
         CookiecutterFileStorageObserver(
-            _Hooks(hookfiles=hookfiles, cwd=project),
+            hookfiles=hookfiles,
+            project=project,
             overwrite=storage.fileexists is FileExistsPolicy.OVERWRITE,
         )
     )

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -65,15 +65,3 @@ class CookiecutterFileStorageObserver(FileStorageObserver):
         """A storage transaction was aborted."""
         if self.fileexists is not FileExistsPolicy.OVERWRITE:
             shutil.rmtree(self.hooks.cwd, ignore_errors=True)
-
-
-def CookiecutterFileStorage(  # noqa: N802
-    storage: DiskFileStorage, *, hookfiles: Iterable[File] = (), project: pathlib.Path
-) -> DiskFileStorage:
-    """Wrap a disk-based file store with Cookiecutter hooks."""
-    storage.observers.append(
-        CookiecutterFileStorageObserver(
-            hookfiles=hookfiles, project=project, fileexists=storage.fileexists
-        )
-    )
-    return storage

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -11,7 +11,6 @@ from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.domain.files import File
 from cutty.filestorage.domain.storage import FileStorageObserver
-from cutty.filestorage.domain.storage import FileStorageWrapper
 
 
 class _Hooks:
@@ -62,21 +61,14 @@ class CookiecutterFileStorageObserver(FileStorageObserver):
             shutil.rmtree(self.hooks.cwd, ignore_errors=True)
 
 
-class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
+def CookiecutterFileStorage(  # noqa: N802
+    storage: DiskFileStorage, *, hookfiles: Iterable[File] = (), project: pathlib.Path
+) -> DiskFileStorage:
     """Wrap a disk-based file store with Cookiecutter hooks."""
-
-    def __init__(
-        self,
-        storage: DiskFileStorage,
-        *,
-        hookfiles: Iterable[File] = (),
-        project: pathlib.Path
-    ) -> None:
-        """Initialize."""
-        super().__init__(storage)
-        self.observers.append(
-            CookiecutterFileStorageObserver(
-                _Hooks(hookfiles=hookfiles, cwd=project),
-                overwrite=storage.fileexists is FileExistsPolicy.OVERWRITE,
-            )
+    storage.observers.append(
+        CookiecutterFileStorageObserver(
+            _Hooks(hookfiles=hookfiles, cwd=project),
+            overwrite=storage.fileexists is FileExistsPolicy.OVERWRITE,
         )
+    )
+    return storage

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -14,7 +14,7 @@ from cutty.filestorage.domain.storage import FileStorageObserver
 
 
 class _Hooks:
-    def __init__(self, *, hookfiles: Iterable[File] = (), cwd: pathlib.Path) -> None:
+    def __init__(self, *, hookfiles: Iterable[File], cwd: pathlib.Path) -> None:
         self.hooks = {hook.path.stem: hook for hook in hookfiles}
         self.cwd = cwd
 
@@ -45,7 +45,7 @@ class CookiecutterFileStorageObserver(FileStorageObserver):
     def __init__(
         self,
         *,
-        hookfiles: Iterable[File] = (),
+        hookfiles: Iterable[File],
         project: pathlib.Path,
         fileexists: FileExistsPolicy,
     ) -> None:

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.domain.files import File
+from cutty.filestorage.domain.storage import FileStorageObserver
 from cutty.filestorage.domain.storage import FileStorageWrapper
 
 
@@ -37,6 +38,19 @@ class _Hooks:
         shell = platform.system() == "Windows"
         self.cwd.mkdir(parents=True, exist_ok=True)
         subprocess.run(command, shell=shell, cwd=self.cwd, check=True)  # noqa: S602
+
+
+class CookiecutterFileStorageObserver(FileStorageObserver):
+    """Storage observer invoking Cookiecutter hooks."""
+
+    def begin(self) -> None:
+        """A storage transaction was started."""
+
+    def commit(self) -> None:
+        """A storage transaction was completed."""
+
+    def rollback(self) -> None:
+        """A storage transaction was aborted."""
 
 
 class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -75,28 +75,9 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
         """Initialize."""
         super().__init__(storage)
         self.hooks = _Hooks(hookfiles=hookfiles, cwd=project)
-        self.added = False
         self.observers.append(
             CookiecutterFileStorageObserver(
                 self.hooks,
                 overwrite=self.storage.fileexists is FileExistsPolicy.OVERWRITE,
             )
         )
-
-    def add(self, file: File) -> None:
-        """Add file to storage."""
-        if not self.added:
-            self.added = True
-
-        super().add(file)
-
-    def commit(self) -> None:
-        """Commit the stores."""
-        if self.added:
-            pass
-
-        super().commit()
-
-    def rollback(self) -> None:
-        """Roll back the stores."""
-        super().rollback()

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -43,6 +43,10 @@ class _Hooks:
 class CookiecutterFileStorageObserver(FileStorageObserver):
     """Storage observer invoking Cookiecutter hooks."""
 
+    def __init__(self, hooks: _Hooks) -> None:
+        """Initialize."""
+        self.hooks = hooks
+
     def begin(self) -> None:
         """A storage transaction was started."""
 
@@ -67,7 +71,7 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
         super().__init__(storage)
         self.hooks = _Hooks(hookfiles=hookfiles, cwd=project)
         self.added = False
-        self.observers.append(CookiecutterFileStorageObserver())
+        self.observers.append(CookiecutterFileStorageObserver(self.hooks))
 
     def add(self, file: File) -> None:
         """Add file to storage."""

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -53,6 +53,7 @@ class CookiecutterFileStorageObserver(FileStorageObserver):
 
     def commit(self) -> None:
         """A storage transaction was completed."""
+        self.hooks.run("post_gen_project")
 
     def rollback(self) -> None:
         """A storage transaction was aborted."""
@@ -84,7 +85,7 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
     def commit(self) -> None:
         """Commit the stores."""
         if self.added:
-            self.hooks.run("post_gen_project")
+            pass
 
         super().commit()
 

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -67,6 +67,7 @@ class CookiecutterFileStorage(FileStorageWrapper[DiskFileStorage]):
         super().__init__(storage)
         self.hooks = _Hooks(hookfiles=hookfiles, cwd=project)
         self.added = False
+        self.observers.append(CookiecutterFileStorageObserver())
 
     def add(self, file: File) -> None:
         """Add file to storage."""

--- a/src/cutty/filestorage/adapters/disk.py
+++ b/src/cutty/filestorage/adapters/disk.py
@@ -48,6 +48,7 @@ class DiskFileStorage(FileStorage):
         fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
     ) -> None:
         """Initialize."""
+        super().__init__()
         self.root = root
         self.fileexists = fileexists
         self.undo: list[Callable[[], None]] = []

--- a/src/cutty/filestorage/domain/storage.py
+++ b/src/cutty/filestorage/domain/storage.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import abc
 from types import TracebackType
-from typing import Generic
 from typing import Optional
 from typing import TypeVar
 
@@ -66,24 +65,3 @@ class FileStorage(abc.ABC):
             self.rollback()
             for observer in self.observers:
                 observer.rollback()
-
-
-class FileStorageWrapper(FileStorage, Generic[T]):
-    """Wrapper for file storage implementations."""
-
-    def __init__(self, storage: T) -> None:
-        """Initialize."""
-        super().__init__()
-        self.storage = storage
-
-    def add(self, file: File) -> None:
-        """Add the file to the storage."""
-        self.storage.add(file)
-
-    def commit(self) -> None:
-        """Commit all stores."""
-        self.storage.commit()
-
-    def rollback(self) -> None:
-        """Rollback all stores."""
-        self.storage.rollback()

--- a/src/cutty/filestorage/domain/storage.py
+++ b/src/cutty/filestorage/domain/storage.py
@@ -46,6 +46,9 @@ class FileStorage(abc.ABC):
 
     def __enter__(self: T) -> T:
         """Enter the runtime context."""
+        for observer in self.observers:
+            observer.begin()
+
         return self
 
     def __exit__(
@@ -57,8 +60,12 @@ class FileStorage(abc.ABC):
         """Exit the runtime context."""
         if exception is None:
             self.commit()
+            for observer in self.observers:
+                observer.commit()
         else:
             self.rollback()
+            for observer in self.observers:
+                observer.rollback()
 
 
 class FileStorageWrapper(FileStorage, Generic[T]):

--- a/src/cutty/filestorage/domain/storage.py
+++ b/src/cutty/filestorage/domain/storage.py
@@ -29,6 +29,10 @@ class FileStorageObserver:
 class FileStorage(abc.ABC):
     """Interface for file storage implementations."""
 
+    def __init__(self) -> None:
+        """Initialize."""
+        self.observers: list[FileStorageObserver] = []
+
     @abc.abstractmethod
     def add(self, file: File) -> None:
         """Add the file to the storage."""
@@ -62,6 +66,7 @@ class FileStorageWrapper(FileStorage, Generic[T]):
 
     def __init__(self, storage: T) -> None:
         """Initialize."""
+        super().__init__()
         self.storage = storage
 
     def add(self, file: File) -> None:

--- a/src/cutty/filestorage/domain/storage.py
+++ b/src/cutty/filestorage/domain/storage.py
@@ -13,6 +13,19 @@ from cutty.filestorage.domain.files import File
 T = TypeVar("T", bound="FileStorage")
 
 
+class FileStorageObserver:
+    """Base class for file storage observers."""
+
+    def begin(self) -> None:
+        """A storage transaction was started."""
+
+    def commit(self) -> None:
+        """A storage transaction was completed."""
+
+    def rollback(self) -> None:
+        """A storage transaction was aborted."""
+
+
 class FileStorage(abc.ABC):
     """Interface for file storage implementations."""
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import appdirs
 
-from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorage
+from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorageObserver
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.domain.files import File
@@ -112,8 +112,10 @@ def create(
         file, files = peek(files)
         if file is not None:
             project = storage.resolve(file.path.parents[-2])
-            storage = CookiecutterFileStorage(
-                storage, hookfiles=hookfiles, project=project
+            storage.observers.append(
+                CookiecutterFileStorageObserver(
+                    hookfiles=hookfiles, project=project, fileexists=storage.fileexists
+                )
             )
 
     with storage:

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -6,7 +6,7 @@ from typing import Protocol
 
 import pytest
 
-from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorage
+from cutty.filestorage.adapters.cookiecutter import CookiecutterFileStorageObserver
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.domain.files import Executable
@@ -55,7 +55,14 @@ def createstorage(tmp_path: pathlib.Path) -> CreateFileStorage:
             for hook in hooks
         ]
         project = storage.resolve(PurePath("example"))
-        return CookiecutterFileStorage(storage, hookfiles=hookfiles, project=project)
+
+        storage.observers.append(
+            CookiecutterFileStorageObserver(
+                hookfiles=hookfiles, project=project, fileexists=storage.fileexists
+            )
+        )
+
+        return storage
 
     return _createstorage
 

--- a/tests/unit/filestorage/adapters/test_cookiecutter.py
+++ b/tests/unit/filestorage/adapters/test_cookiecutter.py
@@ -87,7 +87,7 @@ def test_hooks(
 
 
 def test_no_files(tmp_path: pathlib.Path, createstorage: CreateFileStorage) -> None:
-    """It does nothing."""
+    """It executes the hook."""
     hooks = ["pre_gen_project", "post_gen_project"]
     storage = createstorage(hooks)
 
@@ -96,7 +96,7 @@ def test_no_files(tmp_path: pathlib.Path, createstorage: CreateFileStorage) -> N
 
     for hook in hooks:
         path = tmp_path / "example" / hook
-        assert not path.is_file()
+        assert path.is_file()
 
 
 def test_rollback_default(


### PR DESCRIPTION
- :sparkles: [filestorage] Add class FileStorageObserver
- :sparkles: [filestorage] Add observers attribute to FileStorage
- :sparkles: [filestorage] Notify observers after begin, commit, and rollback
- :sparkles: [filestorage] Add class CookiecutterFileStorageObserver
- :sparkles: [filestorage] Add Cookiecutter observer to Cookiecutter storage
- :sparkles: [filestorage] Add hooks attribute to Cookiecutter observer
- :white_check_mark: [filestorage] Change test to expect hook execution without files
- :recycle: [filestorage] Invoke pre_gen_project hook from observer
- :recycle: [filestorage] Invoke post_gen_project hook from observer
- :recycle: [filestorage] Perform cleanup on rollback in observer
- :coffin: [filestorage] Remove Cookiecutter storage methods
- :coffin: [filestorage] Remove hooks attribute in Cookiecutter storage
- :recycle: [filestorage] Simplify attribute access in Cookiecutter storage
- :recycle: [filestorage] Replace Cookiecutter storage class by function
- :coffin: [filestorage] Remove class FileStorageWrapper
- :recycle: [filestorage] Move _Hooks creation to observer
- :recycle: [filestorage] Move derivation of overwrite to observer and inline
- :recycle: [filestorage] Inline function CookiecutterFileStorage in test
- :recycle: [services] Inline function CookiecutterFileStorage
- :coffin: [filestorage] Remove CookiecutterFileStorage
- :recycle: [filestorage] Remove default value for `hookfiles` parameter
- :recycle: [filestorage] Rename attribute {cwd => project} in hooks class
