### PR TITLE
:bug: [filestorage] Commit modifications made by Cookiecutter hooks

### DIFF
--- a/src/cutty/filestorage/adapters/git.py
+++ b/src/cutty/filestorage/adapters/git.py
@@ -2,11 +2,9 @@
 import contextlib
 import os
 import pathlib
-from typing import Optional
 
 import pygit2
 
-from cutty.filestorage.domain.files import File
 from cutty.filestorage.domain.storage import FileStorageObserver
 
 
@@ -26,22 +24,12 @@ class GitRepositoryObserver(FileStorageObserver):
     def __init__(self, *, project: pathlib.Path) -> None:
         """Initialize."""
         self.project = project
-        self.repository: Optional[pygit2.Repository] = None
-
-    def begin(self) -> None:
-        """A storage transaction was started."""
-        self.repository = pygit2.init_repository(self.project)
-
-    def add(self, file: File) -> None:
-        """A file was added to the transaction."""
-        path = "/".join(file.path.parts[1:])
-        assert self.repository is not None  # noqa: S101
-        self.repository.index.add(path)
 
     def commit(self) -> None:
         """A storage transaction was completed."""
-        assert self.repository is not None  # noqa: S101
-        tree = self.repository.index.write_tree()
-        self.repository.index.write()
-        signature = default_signature(self.repository)
-        self.repository.create_commit("HEAD", signature, signature, "Initial", tree, [])
+        repository = pygit2.init_repository(self.project)
+        repository.index.add_all()
+        tree = repository.index.write_tree()
+        repository.index.write()
+        signature = default_signature(repository)
+        repository.create_commit("HEAD", signature, signature, "Initial", tree, [])

--- a/tests/unit/filestorage/adapters/test_git.py
+++ b/tests/unit/filestorage/adapters/test_git.py
@@ -75,3 +75,15 @@ def test_hook_edits(
     repository = pygit2.Repository(project)
     blob = repository.head.peel().tree / file.path.name
     assert b"teapot" == blob.data
+
+
+def test_hook_deletes(
+    storage: DiskFileStorage, file: RegularFile, project: pathlib.Path
+) -> None:
+    """It does not commit files deleted by hooks."""
+    with storage:
+        storage.add(file)
+        (project / file.path.name).unlink()
+
+    repository = pygit2.Repository(project)
+    assert file.path.name not in repository.head.peel().tree

--- a/tests/unit/filestorage/adapters/test_git.py
+++ b/tests/unit/filestorage/adapters/test_git.py
@@ -87,3 +87,13 @@ def test_hook_deletes(
 
     repository = pygit2.Repository(project)
     assert file.path.name not in repository.head.peel().tree
+
+
+def test_hook_additions(storage: DiskFileStorage, project: pathlib.Path) -> None:
+    """It commits files created by hooks."""
+    with storage:
+        project.mkdir()
+        (project / "marker").touch()
+
+    repository = pygit2.Repository(project)
+    assert "marker" in repository.head.peel().tree

--- a/tests/unit/filestorage/adapters/test_git.py
+++ b/tests/unit/filestorage/adapters/test_git.py
@@ -62,3 +62,16 @@ def test_index(
 
     repository = pygit2.Repository(project)
     assert file.path.name in repository.index
+
+
+def test_hook_edits(
+    storage: DiskFileStorage, file: RegularFile, project: pathlib.Path
+) -> None:
+    """It commits file modifications applied by hooks."""
+    with storage:
+        storage.add(file)
+        (project / file.path.name).write_bytes(b"teapot")
+
+    repository = pygit2.Repository(project)
+    blob = repository.head.peel().tree / file.path.name
+    assert b"teapot" == blob.data


### PR DESCRIPTION
- :white_check_mark: [filestorage] Add failing test for hook edits
- :white_check_mark: [filestorage] Add failing test for hook deletes
- :white_check_mark: [filestorage] Add failing test for files created by hooks
- :bug: [filestorage] Create repository after hook execution
