### PR TITLE
:recycle: [services] Extract functions from create service

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -118,16 +118,20 @@ def create(
 
     project_dir = output_dir / file.path.parts[0]
     hookpaths = tuple(iterhooks(template_dir))
-    if hookpaths:  # pragma: no branch
 
-        def createhooksobserver() -> FileStorageObserver:
-            """Create storage observer invoking Cookiecutter hooks."""
-            hookfiles = renderfiles(hookpaths, render, bindings)
-            return CookiecutterHooksObserver(
-                hookfiles=hookfiles, project=project_dir, fileexists=fileexists
-            )
+    def createhooksobserver() -> Optional[FileStorageObserver]:
+        """Create storage observer invoking Cookiecutter hooks."""
+        if not hookpaths:  # pragma: no cover
+            return None
 
-        storage = observe(storage, createhooksobserver())
+        hookfiles = renderfiles(hookpaths, render, bindings)
+        return CookiecutterHooksObserver(
+            hookfiles=hookfiles, project=project_dir, fileexists=fileexists
+        )
+
+    if observer := createhooksobserver():  # pragma: no branch
+        storage = observe(storage, observer)
+
     storage = observe(storage, GitRepositoryObserver(project=project_dir))
 
     with storage:

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -119,10 +119,10 @@ def create(
     project_dir = output_dir / file.path.parts[0]
     hookpaths = tuple(iterhooks(template_dir))
     if hookpaths:  # pragma: no branch
-        hookfiles = renderfiles(hookpaths, render, bindings)
 
         def createhooksobserver() -> FileStorageObserver:
             """Create storage observer invoking Cookiecutter hooks."""
+            hookfiles = renderfiles(hookpaths, render, bindings)
             return CookiecutterHooksObserver(
                 hookfiles=hookfiles, project=project_dir, fileexists=fileexists
             )

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -98,6 +98,29 @@ def createhooksobserver(
     )
 
 
+def createstorage(
+    template_dir: Path,
+    project_dir: pathlib.Path,
+    output_dir: pathlib.Path,
+    overwrite_if_exists: bool,
+    skip_if_file_exists: bool,
+    render: Renderer,
+    bindings: Sequence[Binding],
+) -> FileStorage:
+    """Create storage for the project files."""
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    storage: FileStorage = DiskFileStorage(output_dir, fileexists=fileexists)
+
+    if observer := createhooksobserver(  # pragma: no branch
+        template_dir, project_dir, render, bindings, fileexists
+    ):
+        storage = observe(storage, observer)
+
+    storage = observe(storage, GitRepositoryObserver(project=project_dir))
+
+    return storage
+
+
 def create(
     template: str,
     *,
@@ -133,22 +156,14 @@ def create(
 
     project_dir = output_dir / file.path.parts[0]
 
-    def createstorage() -> FileStorage:
-        """Create storage for the project files."""
-        assert output_dir is not None  # noqa: S101
-
-        fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
-        storage: FileStorage = DiskFileStorage(output_dir, fileexists=fileexists)
-
-        if observer := createhooksobserver(  # pragma: no branch
-            template_dir, project_dir, render, bindings, fileexists
-        ):
-            storage = observe(storage, observer)
-
-        storage = observe(storage, GitRepositoryObserver(project=project_dir))
-
-        return storage
-
-    with createstorage() as storage:
+    with createstorage(
+        template_dir,
+        project_dir,
+        output_dir,
+        overwrite_if_exists,
+        skip_if_file_exists,
+        render,
+        bindings,
+    ) as storage:
         for file in files:
             storage.add(file)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -61,10 +61,8 @@ def bindvariables(
 ) -> Sequence[Binding]:
     """Bind the template variables."""
     binder: Binder = binddefault if no_input else prompt
-    binder = override(
-        binder,
-        [Binding(key, value) for key, value in extra_context.items()],
-    )
+    bindings = [Binding(key, value) for key, value in extra_context.items()]
+    binder = override(binder, bindings)
     return renderbindwith(binder)(render, variables)
 
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -115,17 +115,17 @@ def create(
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(output_dir, fileexists=fileexists)
 
-    project = output_dir / file.path.parts[0]
+    project_dir = output_dir / file.path.parts[0]
     hookpaths = tuple(iterhooks(template_dir))
     if hookpaths:  # pragma: no branch
         hookfiles = renderfiles(hookpaths, render, bindings)
         storage = observe(
             storage,
             CookiecutterHooksObserver(
-                hookfiles=hookfiles, project=project, fileexists=fileexists
+                hookfiles=hookfiles, project=project_dir, fileexists=fileexists
             ),
         )
-    storage = observe(storage, GitRepositoryObserver(project=project))
+    storage = observe(storage, GitRepositoryObserver(project=project_dir))
 
     with storage:
         for file in files:

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -17,14 +17,12 @@ from cutty.filesystems.domain.path import Path
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
 from cutty.templates.adapters.cookiecutter.config import loadconfig
 from cutty.templates.adapters.cookiecutter.prompts import prompt
-from cutty.templates.adapters.cookiecutter.render import registerrenderers
+from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
 from cutty.templates.domain.binders import binddefault
 from cutty.templates.domain.binders import override
 from cutty.templates.domain.binders import renderbindwith
 from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.config import Config
-from cutty.templates.domain.render import createrenderer
-from cutty.templates.domain.render import defaultrenderregistry
 from cutty.templates.domain.renderfiles import renderfiles
 from cutty.util.peek import peek
 
@@ -88,8 +86,7 @@ def create(
     )
 
     config = loadconfig(template, path)
-    renderregistry = registerrenderers(path, config)
-    render = createrenderer({**defaultrenderregistry, **renderregistry})
+    render = createcookiecutterrenderer(path, config)
     renderbind = renderbindwith(binder)
     bindings = renderbind(render, config.variables)
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -74,8 +74,7 @@ def create(
 ) -> None:
     """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(appdirs.user_cache_dir("cutty"))
-    provider = getdefaultrepositoryprovider(cachedir)
-    template_dir = provider(template, revision=checkout)
+    template_dir = getdefaultrepositoryprovider(cachedir)(template, revision=checkout)
 
     if directory is not None:
         template_dir = template_dir.joinpath(*directory.parts)  # pragma: no cover

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -101,7 +101,6 @@ def createhooksobserver(
 def createstorage(
     template_dir: Path,
     project_dir: pathlib.Path,
-    output_dir: pathlib.Path,
     overwrite_if_exists: bool,
     skip_if_file_exists: bool,
     render: Renderer,
@@ -109,7 +108,7 @@ def createstorage(
 ) -> FileStorage:
     """Create storage for the project files."""
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
-    storage: FileStorage = DiskFileStorage(output_dir, fileexists=fileexists)
+    storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
     if observer := createhooksobserver(  # pragma: no branch
         template_dir, project_dir, render, bindings, fileexists
@@ -159,7 +158,6 @@ def create(
     with createstorage(
         template_dir,
         project_dir,
-        output_dir,
         overwrite_if_exists,
         skip_if_file_exists,
         render,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -117,10 +117,10 @@ def create(
     storage: FileStorage = DiskFileStorage(output_dir, fileexists=fileexists)
 
     project_dir = output_dir / file.path.parts[0]
-    hookpaths = tuple(iterhooks(template_dir))
 
     def createhooksobserver() -> Optional[FileStorageObserver]:
         """Create storage observer invoking Cookiecutter hooks."""
+        hookpaths = tuple(iterhooks(template_dir))
         if not hookpaths:  # pragma: no cover
             return None
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -80,13 +80,13 @@ def create(
     if directory is not None:
         path = path.joinpath(*directory.parts)  # pragma: no cover
 
+    config = loadconfig(template, path)
+    render = createcookiecutterrenderer(path, config)
+
     binder = override(
         binddefault if no_input else prompt,
         [Binding(key, value) for key, value in extra_context.items()],
     )
-
-    config = loadconfig(template, path)
-    render = createcookiecutterrenderer(path, config)
     bindings = renderbindwith(binder)(render, config.variables)
 
     paths = iterpaths(path, config)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -75,13 +75,13 @@ def create(
     """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(appdirs.user_cache_dir("cutty"))
     provider = getdefaultrepositoryprovider(cachedir)
-    path = provider(template, revision=checkout)
+    template_dir = provider(template, revision=checkout)
 
     if directory is not None:
-        path = path.joinpath(*directory.parts)  # pragma: no cover
+        template_dir = template_dir.joinpath(*directory.parts)  # pragma: no cover
 
-    config = loadconfig(template, path)
-    render = createcookiecutterrenderer(path, config)
+    config = loadconfig(template, template_dir)
+    render = createcookiecutterrenderer(template_dir, config)
 
     binder = override(
         binddefault if no_input else prompt,
@@ -89,7 +89,7 @@ def create(
     )
     bindings = renderbindwith(binder)(render, config.variables)
 
-    paths = iterpaths(path, config)
+    paths = iterpaths(template_dir, config)
     files = renderfiles(paths, render, bindings)
     file, files = peek(files)
     if file is None:  # pragma: no cover
@@ -102,7 +102,7 @@ def create(
     storage: FileStorage = DiskFileStorage(output_dir, fileexists=fileexists)
 
     project = output_dir / file.path.parts[0]
-    hookpaths = tuple(iterhooks(path))
+    hookpaths = tuple(iterhooks(template_dir))
     if hookpaths:  # pragma: no branch
         hookfiles = renderfiles(hookpaths, render, bindings)
         storage = observe(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -87,8 +87,7 @@ def create(
 
     config = loadconfig(template, path)
     render = createcookiecutterrenderer(path, config)
-    renderbind = renderbindwith(binder)
-    bindings = renderbind(render, config.variables)
+    bindings = renderbindwith(binder)(render, config.variables)
 
     paths = iterpaths(path, config)
     files = renderfiles(paths, render, bindings)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -12,6 +12,7 @@ from cutty.filestorage.adapters.cookiecutter import CookiecutterHooksObserver
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.adapters.git import GitRepositoryObserver
+from cutty.filestorage.domain.files import File
 from cutty.filestorage.domain.observers import FileStorageObserver
 from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
@@ -65,6 +66,12 @@ def bindvariables(
     bindings = [Binding(key, value) for key, value in extra_context.items()]
     binder = override(binder, bindings)
     return renderbindwith(binder)(render, variables)
+
+
+def get_project_dir(output_dir: Optional[pathlib.Path], file: File) -> pathlib.Path:
+    """Determine the location of the generated project."""
+    parent = output_dir if output_dir is not None else pathlib.Path.cwd()
+    return parent / file.path.parts[0]
 
 
 def fileexistspolicy(
@@ -150,14 +157,7 @@ def create(
     if file is None:  # pragma: no cover
         return
 
-    def get_project_dir() -> pathlib.Path:
-        """Determine the location of the generated project."""
-        assert file is not None  # noqa: S101
-
-        parent = output_dir if output_dir is not None else pathlib.Path.cwd()
-        return parent / file.path.parts[0]
-
-    project_dir = get_project_dir()
+    project_dir = get_project_dir(output_dir, file)
 
     with createstorage(
         template_dir,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -20,6 +20,7 @@ from cutty.templates.adapters.cookiecutter.config import loadconfig
 from cutty.templates.adapters.cookiecutter.prompts import prompt
 from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
 from cutty.templates.domain.binders import binddefault
+from cutty.templates.domain.binders import Binder
 from cutty.templates.domain.binders import override
 from cutty.templates.domain.binders import renderbindwith
 from cutty.templates.domain.bindings import Binding
@@ -59,8 +60,9 @@ def bindvariables(
     no_input: bool,
 ) -> Sequence[Binding]:
     """Bind the template variables."""
+    binder: Binder = binddefault if no_input else prompt
     binder = override(
-        binddefault if no_input else prompt,
+        binder,
         [Binding(key, value) for key, value in extra_context.items()],
     )
     return renderbindwith(binder)(render, variables)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -63,8 +63,7 @@ def bindvariables(
         binddefault if no_input else prompt,
         [Binding(key, value) for key, value in extra_context.items()],
     )
-    bindings = renderbindwith(binder)(render, variables)
-    return bindings
+    return renderbindwith(binder)(render, variables)
 
 
 def fileexistspolicy(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -150,10 +150,14 @@ def create(
     if file is None:  # pragma: no cover
         return
 
-    if output_dir is None:
-        output_dir = pathlib.Path.cwd()  # pragma: no cover
+    def get_project_dir() -> pathlib.Path:
+        """Determine the location of the generated project."""
+        assert file is not None  # noqa: S101
 
-    project_dir = output_dir / file.path.parts[0]
+        parent = output_dir if output_dir is not None else pathlib.Path.cwd()
+        return parent / file.path.parts[0]
+
+    project_dir = get_project_dir()
 
     with createstorage(
         template_dir,

--- a/src/cutty/templates/adapters/cookiecutter/render.py
+++ b/src/cutty/templates/adapters/cookiecutter/render.py
@@ -13,6 +13,8 @@ from cutty.templates.adapters.jinja import createjinjarenderer
 from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.config import Config
 from cutty.templates.domain.render import asrendercontinuation
+from cutty.templates.domain.render import createrenderer
+from cutty.templates.domain.render import defaultrenderregistry
 from cutty.templates.domain.render import Renderer
 from cutty.templates.domain.render import RenderRegistry
 from cutty.templates.domain.render import T
@@ -88,3 +90,9 @@ def registerrenderers(path: Path, config: Config) -> RenderRegistry:  # noqa: C9
         dict: renderdict,
         RegularFile: renderregularfile,
     }
+
+
+def createcookiecutterrenderer(path: Path, config: Config) -> Renderer:
+    """Create Cookiecutter renderer."""
+    renderregistry = registerrenderers(path, config)
+    return createrenderer({**defaultrenderregistry, **renderregistry})

--- a/tests/unit/templates/adapters/cookiecutter/test_render.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_render.py
@@ -8,11 +8,9 @@ from cutty.filestorage.domain.files import RegularFile
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.templates.adapters.cookiecutter.render import registerrenderers
+from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
 from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.config import Config
-from cutty.templates.domain.render import createrenderer
-from cutty.templates.domain.render import defaultrenderregistry
 from cutty.templates.domain.render import Renderer
 
 
@@ -23,8 +21,7 @@ def rendererfactory() -> Callable[..., Renderer]:
     def _create(**settings: Any) -> Renderer:
         searchpath = Path(filesystem=DictFilesystem({}))
         config = Config(settings, ())
-        renderregistry = registerrenderers(searchpath, config)
-        return createrenderer({**defaultrenderregistry, **renderregistry})
+        return createcookiecutterrenderer(searchpath, config)
 
     return _create
 


### PR DESCRIPTION
- :recycle: [templates] Extract function `createcookiecutterrenderer`
- :recycle: [services] Inline variable `renderbind`
- :recycle: [services] Slide statement initializing `binder`
- :recycle: [services] Rename variable {path => template_dir}
- :recycle: [services] Inline variable `provider`
- :recycle: [services] Extract function `bindvariables`
- :recycle: [services] Inline variable `bindings`
- :recycle: [services] Extract variable `binder`
- :recycle: [services] Extract variable `bindings`
- :recycle: [services] Rename variable project{ => _dir}
- :recycle: [services] Extract function `createhooksobserver`
- :recycle: [services] Move statement into function `createhooksobserver`
- :recycle: [services] Move conditional into function `createhooksobserver`
- :recycle: [services] Move statement into function `createhooksobserver`
- :recycle: [services] Move function `createhooksobserver` to module level
- :recycle: [services] Extract function `createstorage`
- :recycle: [services] Move function `createstorage` to module level
- :recycle: [services] Replace parameter `output_dir` with query in `createstorage`
- :recycle: [service] Extract function `get_project_dir`
- :recycle: [services] Move function `get_project_dir` to module level
