### PR TITLE
:recycle: [services] Separate hook discovery and rendering from storage creation

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -92,12 +92,11 @@ def createstorage(
     project_dir: pathlib.Path,
     overwrite_if_exists: bool,
     skip_if_file_exists: bool,
+    hookfiles: Sequence[File],
     render: Renderer,
     bindings: Sequence[Binding],
 ) -> FileStorage:
     """Create storage for the project files."""
-    hookfiles = tuple(renderfiles(iterhooks(template_dir), render, bindings))
-
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
@@ -147,12 +146,14 @@ def create(
         return
 
     project_dir = get_project_dir(output_dir, file)
+    hookfiles = tuple(renderfiles(iterhooks(template_dir), render, bindings))
 
     with createstorage(
         template_dir,
         project_dir,
         overwrite_if_exists,
         skip_if_file_exists,
+        hookfiles,
         render,
         bindings,
     ) as storage:

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -108,12 +108,13 @@ def createstorage(
         observer: Optional[FileStorageObserver] = None
         hookpaths = tuple(iterhooks(template_dir))
         if not hookpaths:  # pragma: no cover
-            return observer
+            pass
         else:
             hookfiles = renderfiles(hookpaths, render, bindings)
-            return CookiecutterHooksObserver(
+            observer = CookiecutterHooksObserver(
                 hookfiles=hookfiles, project=project_dir, fileexists=fileexists
             )
+        return observer
 
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -96,11 +96,11 @@ def createstorage(
     bindings: Sequence[Binding],
 ) -> FileStorage:
     """Create storage for the project files."""
+    hookpaths = tuple(iterhooks(template_dir))
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
     observer: Optional[FileStorageObserver] = None
-    hookpaths = tuple(iterhooks(template_dir))
     if hookpaths:  # pragma: no branch
         hookfiles = renderfiles(hookpaths, render, bindings)
         observer = CookiecutterHooksObserver(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -101,6 +101,8 @@ def createstorage(
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
     observer: Optional[FileStorageObserver] = None
+    hookfiles: Iterator[File] = iter(())
+
     if hookpaths:  # pragma: no branch
         hookfiles = renderfiles(hookpaths, render, bindings)
         observer = CookiecutterHooksObserver(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -101,9 +101,7 @@ def createstorage(
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
     observer: Optional[FileStorageObserver] = None
-    hookfiles: Sequence[File] = (
-        () if not hookpaths else tuple(renderfiles(hookpaths, render, bindings))
-    )
+    hookfiles = tuple(renderfiles(hookpaths, render, bindings))
 
     if hookpaths:  # pragma: no branch
         observer = CookiecutterHooksObserver(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -96,8 +96,7 @@ def createstorage(
     bindings: Sequence[Binding],
 ) -> FileStorage:
     """Create storage for the project files."""
-    hookpaths = iterhooks(template_dir)
-    hookfiles = tuple(renderfiles(hookpaths, render, bindings))
+    hookfiles = tuple(renderfiles(iterhooks(template_dir), render, bindings))
 
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -103,7 +103,7 @@ def createstorage(
     observer: Optional[FileStorageObserver] = None
     hookfiles = tuple(renderfiles(hookpaths, render, bindings))
 
-    if hookpaths:  # pragma: no branch
+    if hookfiles:  # pragma: no branch
         observer = CookiecutterHooksObserver(
             hookfiles=hookfiles, project=project_dir, fileexists=fileexists
         )

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -96,7 +96,7 @@ def createstorage(
     bindings: Sequence[Binding],
 ) -> FileStorage:
     """Create storage for the project files."""
-    hookpaths = tuple(iterhooks(template_dir))
+    hookpaths = iterhooks(template_dir)
     hookfiles = tuple(renderfiles(hookpaths, render, bindings))
 
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -101,10 +101,9 @@ def createstorage(
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
     observer: Optional[FileStorageObserver] = None
-    hookfiles: Iterator[File] = iter(())
-
-    if hookpaths:  # pragma: no branch
-        hookfiles = renderfiles(hookpaths, render, bindings)
+    hookfiles: Iterator[File] = (
+        iter(()) if not hookpaths else renderfiles(hookpaths, render, bindings)
+    )
 
     if hookpaths:  # pragma: no branch
         observer = CookiecutterHooksObserver(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -97,11 +97,12 @@ def createstorage(
 ) -> FileStorage:
     """Create storage for the project files."""
     hookpaths = tuple(iterhooks(template_dir))
+    hookfiles = tuple(renderfiles(hookpaths, render, bindings))
+
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
     observer: Optional[FileStorageObserver] = None
-    hookfiles = tuple(renderfiles(hookpaths, render, bindings))
 
     if hookfiles:  # pragma: no branch
         observer = CookiecutterHooksObserver(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -109,11 +109,11 @@ def createstorage(
         hookpaths = tuple(iterhooks(template_dir))
         if not hookpaths:  # pragma: no cover
             return observer
-
-        hookfiles = renderfiles(hookpaths, render, bindings)
-        return CookiecutterHooksObserver(
-            hookfiles=hookfiles, project=project_dir, fileexists=fileexists
-        )
+        else:
+            hookfiles = renderfiles(hookpaths, render, bindings)
+            return CookiecutterHooksObserver(
+                hookfiles=hookfiles, project=project_dir, fileexists=fileexists
+            )
 
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -105,9 +105,10 @@ def createstorage(
         fileexists: FileExistsPolicy,
     ) -> Optional[FileStorageObserver]:
         """Create storage observer invoking Cookiecutter hooks."""
+        observer: Optional[FileStorageObserver] = None
         hookpaths = tuple(iterhooks(template_dir))
         if not hookpaths:  # pragma: no cover
-            return None
+            return observer
 
         hookfiles = renderfiles(hookpaths, render, bindings)
         return CookiecutterHooksObserver(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -96,30 +96,18 @@ def createstorage(
     bindings: Sequence[Binding],
 ) -> FileStorage:
     """Create storage for the project files."""
-
-    def createhooksobserver(
-        template_dir: Path,
-        project_dir: pathlib.Path,
-        render: Renderer,
-        bindings: Sequence[Binding],
-        fileexists: FileExistsPolicy,
-    ) -> Optional[FileStorageObserver]:
-        """Create storage observer invoking Cookiecutter hooks."""
-        observer: Optional[FileStorageObserver] = None
-        hookpaths = tuple(iterhooks(template_dir))
-        if hookpaths:  # pragma: no branch
-            hookfiles = renderfiles(hookpaths, render, bindings)
-            observer = CookiecutterHooksObserver(
-                hookfiles=hookfiles, project=project_dir, fileexists=fileexists
-            )
-        return observer
-
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
-    if observer := createhooksobserver(  # pragma: no branch
-        template_dir, project_dir, render, bindings, fileexists
-    ):
+    observer: Optional[FileStorageObserver] = None
+    hookpaths = tuple(iterhooks(template_dir))
+    if hookpaths:  # pragma: no branch
+        hookfiles = renderfiles(hookpaths, render, bindings)
+        observer = CookiecutterHooksObserver(
+            hookfiles=hookfiles, project=project_dir, fileexists=fileexists
+        )
+
+    if observer:  # pragma: no branch
         storage = observe(storage, observer)
 
     storage = observe(storage, GitRepositoryObserver(project=project_dir))

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -87,24 +87,6 @@ def fileexistspolicy(
     )
 
 
-def createhooksobserver(
-    template_dir: Path,
-    project_dir: pathlib.Path,
-    render: Renderer,
-    bindings: Sequence[Binding],
-    fileexists: FileExistsPolicy,
-) -> Optional[FileStorageObserver]:
-    """Create storage observer invoking Cookiecutter hooks."""
-    hookpaths = tuple(iterhooks(template_dir))
-    if not hookpaths:  # pragma: no cover
-        return None
-
-    hookfiles = renderfiles(hookpaths, render, bindings)
-    return CookiecutterHooksObserver(
-        hookfiles=hookfiles, project=project_dir, fileexists=fileexists
-    )
-
-
 def createstorage(
     template_dir: Path,
     project_dir: pathlib.Path,
@@ -114,6 +96,24 @@ def createstorage(
     bindings: Sequence[Binding],
 ) -> FileStorage:
     """Create storage for the project files."""
+
+    def createhooksobserver(
+        template_dir: Path,
+        project_dir: pathlib.Path,
+        render: Renderer,
+        bindings: Sequence[Binding],
+        fileexists: FileExistsPolicy,
+    ) -> Optional[FileStorageObserver]:
+        """Create storage observer invoking Cookiecutter hooks."""
+        hookpaths = tuple(iterhooks(template_dir))
+        if not hookpaths:  # pragma: no cover
+            return None
+
+        hookfiles = renderfiles(hookpaths, render, bindings)
+        return CookiecutterHooksObserver(
+            hookfiles=hookfiles, project=project_dir, fileexists=fileexists
+        )
+
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -93,8 +93,6 @@ def createstorage(
     overwrite_if_exists: bool,
     skip_if_file_exists: bool,
     hookfiles: Sequence[File],
-    render: Renderer,
-    bindings: Sequence[Binding],
 ) -> FileStorage:
     """Create storage for the project files."""
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
@@ -154,8 +152,6 @@ def create(
         overwrite_if_exists,
         skip_if_file_exists,
         hookfiles,
-        render,
-        bindings,
     ) as storage:
         for file in files:
             storage.add(file)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -101,8 +101,8 @@ def createstorage(
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
     observer: Optional[FileStorageObserver] = None
-    hookfiles: Iterator[File] = (
-        iter(()) if not hookpaths else renderfiles(hookpaths, render, bindings)
+    hookfiles: Sequence[File] = (
+        () if not hookpaths else tuple(renderfiles(hookpaths, render, bindings))
     )
 
     if hookpaths:  # pragma: no branch

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -107,9 +107,7 @@ def createstorage(
         """Create storage observer invoking Cookiecutter hooks."""
         observer: Optional[FileStorageObserver] = None
         hookpaths = tuple(iterhooks(template_dir))
-        if not hookpaths:  # pragma: no cover
-            pass
-        else:
+        if hookpaths:  # pragma: no branch
             hookfiles = renderfiles(hookpaths, render, bindings)
             observer = CookiecutterHooksObserver(
                 hookfiles=hookfiles, project=project_dir, fileexists=fileexists

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -105,6 +105,8 @@ def createstorage(
 
     if hookpaths:  # pragma: no branch
         hookfiles = renderfiles(hookpaths, render, bindings)
+
+    if hookpaths:  # pragma: no branch
         observer = CookiecutterHooksObserver(
             hookfiles=hookfiles, project=project_dir, fileexists=fileexists
         )


### PR DESCRIPTION
- :recycle: createhooksobserver: Move function into `createstorage`
- :recycle: createstorage: Extract variable `observer`
- :recycle: createstorage: Introduce explicit `else` branch
- :recycle: createstorage: Use single return statement
- :recycle: createstorage: Remove empty branch
- :recycle: createhooksobserver: Inline function
- :recycle: createstorage: Slide statement initializing `hookpaths`
- :recycle: createstorage: Move variable `hookfiles` outside conditional
- :recycle: createstorage: Split conditional
- :recycle: createstorage: Use ternary instead of `if` statement
- :recycle: createstorage: Copy `hookfiles` into tuple
- :recycle: createstorage: Remove branch with optimization
- :recycle: createstorage: Use equivalent condition
- :recycle: createstorage: Slide statement initializing `hookfiles`
- :recycle: createstorage: Remove copy of `hookpaths` into tuple
- :recycle: createstorage: Inline variable `hookpaths`
- :recycle: createstorage: Replace query with parameter `hookfiles`
- :recycle: createstorage: Remove parameters `render` and `bindings`
