### PR TITLE
:recycle: [filestorage] Extract Cookiecutter storage adapter from services.create

### DIFF
--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -1,14 +1,12 @@
 """File storage for Cookiecutter projects."""
 import pathlib
 from collections.abc import Sequence
-from typing import Optional
 
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.adapters.observers.cookiecutter import CookiecutterHooksObserver
 from cutty.filestorage.adapters.observers.git import GitRepositoryObserver
 from cutty.filestorage.domain.files import File
-from cutty.filestorage.domain.observers import FileStorageObserver
 from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.path import Path
@@ -38,14 +36,10 @@ def createcookiecutterstorage(
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
-    observer: Optional[FileStorageObserver] = None
-
     if hookfiles:  # pragma: no branch
         observer = CookiecutterHooksObserver(
             hookfiles=hookfiles, project=project_dir, fileexists=fileexists
         )
-
-    if observer:  # pragma: no branch
         storage = observe(storage, observer)
 
     storage = observe(storage, GitRepositoryObserver(project=project_dir))

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -1,0 +1,1 @@
+"""File storage for Cookiecutter projects."""

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -1,10 +1,30 @@
 """File storage for Cookiecutter projects."""
 import pathlib
 from collections.abc import Sequence
+from typing import Optional
 
+from cutty.filestorage.adapters.disk import DiskFileStorage
+from cutty.filestorage.adapters.disk import FileExistsPolicy
+from cutty.filestorage.adapters.observers.cookiecutter import CookiecutterHooksObserver
+from cutty.filestorage.adapters.observers.git import GitRepositoryObserver
 from cutty.filestorage.domain.files import File
+from cutty.filestorage.domain.observers import FileStorageObserver
+from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.path import Path
+
+
+def fileexistspolicy(
+    overwrite_if_exists: bool, skip_if_file_exists: bool
+) -> FileExistsPolicy:
+    """Return the policy for overwriting existing files."""
+    return (
+        FileExistsPolicy.RAISE
+        if not overwrite_if_exists
+        else FileExistsPolicy.SKIP
+        if skip_if_file_exists
+        else FileExistsPolicy.OVERWRITE
+    )
 
 
 def createcookiecutterstorage(
@@ -15,8 +35,19 @@ def createcookiecutterstorage(
     hookfiles: Sequence[File],
 ) -> FileStorage:
     """Create storage for Cookiecutter project files."""
-    from cutty.services.create import createstorage
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    storage: FileStorage = DiskFileStorage(project_dir.parent, fileexists=fileexists)
 
-    return createstorage(
-        template_dir, project_dir, overwrite_if_exists, skip_if_file_exists, hookfiles
-    )
+    observer: Optional[FileStorageObserver] = None
+
+    if hookfiles:  # pragma: no branch
+        observer = CookiecutterHooksObserver(
+            hookfiles=hookfiles, project=project_dir, fileexists=fileexists
+        )
+
+    if observer:  # pragma: no branch
+        storage = observe(storage, observer)
+
+    storage = observe(storage, GitRepositoryObserver(project=project_dir))
+
+    return storage

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -1,1 +1,22 @@
 """File storage for Cookiecutter projects."""
+import pathlib
+from collections.abc import Sequence
+
+from cutty.filestorage.domain.files import File
+from cutty.filestorage.domain.storage import FileStorage
+from cutty.filesystems.domain.path import Path
+
+
+def createcookiecutterstorage(
+    template_dir: Path,
+    project_dir: pathlib.Path,
+    overwrite_if_exists: bool,
+    skip_if_file_exists: bool,
+    hookfiles: Sequence[File],
+) -> FileStorage:
+    """Create storage for Cookiecutter project files."""
+    from cutty.services.create import createstorage
+
+    return createstorage(
+        template_dir, project_dir, overwrite_if_exists, skip_if_file_exists, hookfiles
+    )

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import appdirs
 
+from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.adapters.observers.cookiecutter import CookiecutterHooksObserver
@@ -146,7 +147,7 @@ def create(
     project_dir = get_project_dir(output_dir, file)
     hookfiles = tuple(renderfiles(iterhooks(template_dir), render, bindings))
 
-    with createstorage(
+    with createcookiecutterstorage(
         template_dir,
         project_dir,
         overwrite_if_exists,


### PR DESCRIPTION
- :tada: Add module filestorage.adapters.cookiecutter
- :recycle: Add function `createcookiecutterstorage` delegating to `createstorage`
- :recycle: services.create: Use `createcookiecutterstorage` instead of `createstorage`
- :recycle: createstorage: Inline function
