### PR TITLE
:recycle: [templates] Extract Cookiecutter bind adapter from services.create

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -56,7 +56,7 @@ def bindvariables(
     interactive: bool,
 ) -> Sequence[Binding]:
     """Bind the template variables."""
-    binder: Binder = binddefault if not interactive else prompt
+    binder: Binder = prompt if interactive else binddefault
     bindings = [Binding(key, value) for key, value in extra_context.items()]
     binder = override(binder, bindings)
     return renderbindwith(binder)(render, variables)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -12,13 +12,9 @@ from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filestorage.domain.files import File
 from cutty.filesystems.domain.path import Path
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
+from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
 from cutty.templates.adapters.cookiecutter.config import loadconfig
-from cutty.templates.adapters.cookiecutter.prompts import prompt
 from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
-from cutty.templates.domain.binders import binddefault
-from cutty.templates.domain.binders import Binder
-from cutty.templates.domain.binders import override
-from cutty.templates.domain.binders import renderbindwith
 from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.config import Config
 from cutty.templates.domain.render import Renderer
@@ -56,9 +52,9 @@ def bindvariables(
     bindings: Sequence[Binding],
 ) -> Sequence[Binding]:
     """Bind the template variables."""
-    binder: Binder = prompt if interactive else binddefault
-    binder = override(binder, bindings)
-    return renderbindwith(binder)(render, variables)
+    return bindcookiecuttervariables(
+        variables, render, interactive=interactive, bindings=bindings
+    )
 
 
 def get_project_dir(output_dir: Optional[pathlib.Path], file: File) -> pathlib.Path:

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -2,7 +2,6 @@
 import pathlib
 from collections.abc import Iterator
 from collections.abc import Mapping
-from collections.abc import Sequence
 from types import MappingProxyType
 from typing import Optional
 
@@ -68,11 +67,11 @@ def create(
 
     config = loadconfig(template, template_dir)
     render = createcookiecutterrenderer(template_dir, config)
-    bindings: Sequence[Binding] = [
-        Binding(key, value) for key, value in extra_context.items()
-    ]
     bindings = bindcookiecuttervariables(
-        config.variables, render, interactive=not no_input, bindings=bindings
+        config.variables,
+        render,
+        interactive=not no_input,
+        bindings=[Binding(key, value) for key, value in extra_context.items()],
     )
 
     paths = iterpaths(template_dir, config)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -52,7 +52,6 @@ def bindvariables(
     variables: Sequence[Variable],
     render: Renderer,
     *,
-    extra_context: Mapping[str, str],
     interactive: bool,
     bindings: Sequence[Binding],
 ) -> Sequence[Binding]:
@@ -92,11 +91,7 @@ def create(
         Binding(key, value) for key, value in extra_context.items()
     ]
     bindings = bindvariables(
-        config.variables,
-        render,
-        extra_context=extra_context,
-        interactive=not no_input,
-        bindings=bindings,
+        config.variables, render, interactive=not no_input, bindings=bindings
     )
 
     paths = iterpaths(template_dir, config)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -54,10 +54,10 @@ def bindvariables(
     *,
     extra_context: Mapping[str, str],
     interactive: bool,
+    bindings: Sequence[Binding],
 ) -> Sequence[Binding]:
     """Bind the template variables."""
     binder: Binder = prompt if interactive else binddefault
-    bindings = [Binding(key, value) for key, value in extra_context.items()]
     binder = override(binder, bindings)
     return renderbindwith(binder)(render, variables)
 
@@ -88,8 +88,15 @@ def create(
 
     config = loadconfig(template, template_dir)
     render = createcookiecutterrenderer(template_dir, config)
+    bindings: Sequence[Binding] = [
+        Binding(key, value) for key, value in extra_context.items()
+    ]
     bindings = bindvariables(
-        config.variables, render, extra_context=extra_context, interactive=not no_input
+        config.variables,
+        render,
+        extra_context=extra_context,
+        interactive=not no_input,
+        bindings=bindings,
     )
 
     paths = iterpaths(template_dir, config)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -17,9 +17,7 @@ from cutty.templates.adapters.cookiecutter.config import loadconfig
 from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
 from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.config import Config
-from cutty.templates.domain.render import Renderer
 from cutty.templates.domain.renderfiles import renderfiles
-from cutty.templates.domain.variables import Variable
 from cutty.util.peek import peek
 
 
@@ -42,19 +40,6 @@ def iterhooks(path: Path) -> Iterator[Path]:
         for path in hookdir.iterdir():
             if path.is_file() and not path.name.endswith("~") and path.stem in hooks:
                 yield path
-
-
-def bindvariables(
-    variables: Sequence[Variable],
-    render: Renderer,
-    *,
-    interactive: bool,
-    bindings: Sequence[Binding],
-) -> Sequence[Binding]:
-    """Bind the template variables."""
-    return bindcookiecuttervariables(
-        variables, render, interactive=interactive, bindings=bindings
-    )
 
 
 def get_project_dir(output_dir: Optional[pathlib.Path], file: File) -> pathlib.Path:
@@ -86,7 +71,7 @@ def create(
     bindings: Sequence[Binding] = [
         Binding(key, value) for key, value in extra_context.items()
     ]
-    bindings = bindvariables(
+    bindings = bindcookiecuttervariables(
         config.variables, render, interactive=not no_input, bindings=bindings
     )
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -53,10 +53,10 @@ def bindvariables(
     render: Renderer,
     *,
     extra_context: Mapping[str, str],
-    no_input: bool,
+    interactive: bool,
 ) -> Sequence[Binding]:
     """Bind the template variables."""
-    binder: Binder = binddefault if no_input else prompt
+    binder: Binder = binddefault if not interactive else prompt
     bindings = [Binding(key, value) for key, value in extra_context.items()]
     binder = override(binder, bindings)
     return renderbindwith(binder)(render, variables)
@@ -89,7 +89,7 @@ def create(
     config = loadconfig(template, template_dir)
     render = createcookiecutterrenderer(template_dir, config)
     bindings = bindvariables(
-        config.variables, render, extra_context=extra_context, no_input=no_input
+        config.variables, render, extra_context=extra_context, interactive=not no_input
     )
 
     paths = iterpaths(template_dir, config)

--- a/src/cutty/templates/adapters/cookiecutter/binders.py
+++ b/src/cutty/templates/adapters/cookiecutter/binders.py
@@ -11,7 +11,7 @@ from cutty.templates.domain.render import Renderer
 from cutty.templates.domain.variables import Variable
 
 
-def bindvariables(
+def bindcookiecuttervariables(
     variables: Sequence[Variable],
     render: Renderer,
     *,

--- a/src/cutty/templates/adapters/cookiecutter/binders.py
+++ b/src/cutty/templates/adapters/cookiecutter/binders.py
@@ -1,0 +1,1 @@
+"""Binding variables in Cookiecutter templates."""

--- a/src/cutty/templates/adapters/cookiecutter/binders.py
+++ b/src/cutty/templates/adapters/cookiecutter/binders.py
@@ -1,1 +1,24 @@
 """Binding variables in Cookiecutter templates."""
+from collections.abc import Sequence
+
+from cutty.templates.adapters.cookiecutter.prompts import prompt
+from cutty.templates.domain.binders import binddefault
+from cutty.templates.domain.binders import Binder
+from cutty.templates.domain.binders import override
+from cutty.templates.domain.binders import renderbindwith
+from cutty.templates.domain.bindings import Binding
+from cutty.templates.domain.render import Renderer
+from cutty.templates.domain.variables import Variable
+
+
+def bindvariables(
+    variables: Sequence[Variable],
+    render: Renderer,
+    *,
+    interactive: bool,
+    bindings: Sequence[Binding],
+) -> Sequence[Binding]:
+    """Bind the template variables."""
+    binder: Binder = prompt if interactive else binddefault
+    binder = override(binder, bindings)
+    return renderbindwith(binder)(render, variables)


### PR DESCRIPTION
- :recycle: bindvariables: Replace parameter `no_input` by `interactive`
- :recycle: bindvariables: Simplify ternary expression
- :recycle: bindvariables: Replace query with parameter `bindings`
- :recycle: bindvariables: Remove parameter `extra_context`
- :tada: Add package templates.adapters.cookiecutter.binders
- :recycle: bindvariables: Copy function to templates.adapters.cookiecutter.binders
- :recycle: bindvariables: Rename function to bindcookiecuttervariables
- :recycle: bindvariables: Replace body by calling `bindcookiecuttervariables`
- :recycle: bindvariables: Inline function
- :recycle: services.create: Inline variable `bindings`
