### PR TITLE
:recycle: [templates] Move function for locating hooks from services.create

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -32,11 +32,6 @@ def iterpaths(path: Path, config: Config) -> Iterator[Path]:
     yield template_dir
 
 
-def iterhooks(path: Path) -> Iterator[Path]:
-    """Load hooks in a Cookiecutter template."""
-    return findhooks(path)
-
-
 def get_project_dir(output_dir: Optional[pathlib.Path], file: File) -> pathlib.Path:
     """Determine the location of the generated project."""
     parent = output_dir if output_dir is not None else pathlib.Path.cwd()
@@ -77,7 +72,7 @@ def create(
         return
 
     project_dir = get_project_dir(output_dir, file)
-    hookfiles = tuple(renderfiles(iterhooks(template_dir), render, bindings))
+    hookfiles = tuple(renderfiles(findhooks(template_dir), render, bindings))
 
     with createcookiecutterstorage(
         template_dir,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -12,6 +12,7 @@ from cutty.filestorage.domain.files import File
 from cutty.filesystems.domain.path import Path
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
+from cutty.templates.adapters.cookiecutter.config import findhooks
 from cutty.templates.adapters.cookiecutter.config import loadconfig
 from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
 from cutty.templates.domain.bindings import Binding
@@ -33,12 +34,7 @@ def iterpaths(path: Path, config: Config) -> Iterator[Path]:
 
 def iterhooks(path: Path) -> Iterator[Path]:
     """Load hooks in a Cookiecutter template."""
-    hooks = {"pre_gen_project", "post_gen_project"}
-    hookdir = path / "hooks"
-    if hookdir.is_dir():
-        for path in hookdir.iterdir():
-            if path.is_file() and not path.name.endswith("~") and path.stem in hooks:
-                yield path
+    return findhooks(path)
 
 
 def get_project_dir(output_dir: Optional[pathlib.Path], file: File) -> pathlib.Path:

--- a/src/cutty/templates/adapters/cookiecutter/config.py
+++ b/src/cutty/templates/adapters/cookiecutter/config.py
@@ -1,5 +1,6 @@
 """Cookiecutter loader."""
 import json
+from collections.abc import Iterator
 from typing import Any
 
 from cutty.filesystems.domain.path import Path
@@ -63,3 +64,13 @@ def loadconfig(template: str, path: Path) -> Config:
     )
 
     return Config(settings, variables)
+
+
+def iterhooks(path: Path) -> Iterator[Path]:
+    """Load hooks in a Cookiecutter template."""
+    hooks = {"pre_gen_project", "post_gen_project"}
+    hookdir = path / "hooks"
+    if hookdir.is_dir():
+        for path in hookdir.iterdir():
+            if path.is_file() and not path.name.endswith("~") and path.stem in hooks:
+                yield path

--- a/src/cutty/templates/adapters/cookiecutter/config.py
+++ b/src/cutty/templates/adapters/cookiecutter/config.py
@@ -66,7 +66,7 @@ def loadconfig(template: str, path: Path) -> Config:
     return Config(settings, variables)
 
 
-def iterhooks(path: Path) -> Iterator[Path]:
+def findhooks(path: Path) -> Iterator[Path]:
     """Load hooks in a Cookiecutter template."""
     hooks = {"pre_gen_project", "post_gen_project"}
     hookdir = path / "hooks"

--- a/tests/unit/services/test_create.py
+++ b/tests/unit/services/test_create.py
@@ -2,7 +2,6 @@
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.services.create import iterpaths
-from cutty.templates.adapters.cookiecutter.config import findhooks
 from cutty.templates.domain.config import Config
 
 
@@ -30,42 +29,4 @@ def test_iterpaths_other_directories() -> None:
     paths = iterpaths(path, config)
 
     assert next(paths) == path / "{{ cookiecutter.project }}"
-    assert next(paths, None) is None
-
-
-def test_findhooks_none() -> None:
-    """It does not yield if there is no hook directory."""
-    filesystem = DictFilesystem({"{{ cookiecutter.project }}": {}})
-    path = Path(filesystem=filesystem)
-    paths = findhooks(path)
-
-    assert next(paths, None) is None
-
-
-def test_findhooks_paths() -> None:
-    """It returns paths to hooks."""
-    filesystem = DictFilesystem(
-        {
-            "hooks": {"pre_gen_project.py": ""},
-            "{{ cookiecutter.project }}": {},
-        }
-    )
-    path = Path(filesystem=filesystem)
-    paths = findhooks(path)
-
-    assert next(paths) == path / "hooks" / "pre_gen_project.py"
-    assert next(paths, None) is None
-
-
-def test_findhooks_bogus_hooks() -> None:
-    """It ignores hooks with a backup extension."""
-    filesystem = DictFilesystem(
-        {
-            "hooks": {"pre_gen_project.py~": ""},
-            "{{ cookiecutter.project }}": {},
-        }
-    )
-    path = Path(filesystem=filesystem)
-    paths = findhooks(path)
-
     assert next(paths, None) is None

--- a/tests/unit/services/test_create.py
+++ b/tests/unit/services/test_create.py
@@ -1,8 +1,8 @@
 """Unit tests for cutty.services.create."""
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
-from cutty.services.create import iterhooks
 from cutty.services.create import iterpaths
+from cutty.templates.adapters.cookiecutter.config import findhooks
 from cutty.templates.domain.config import Config
 
 
@@ -33,16 +33,16 @@ def test_iterpaths_other_directories() -> None:
     assert next(paths, None) is None
 
 
-def test_iterhooks_none() -> None:
+def test_findhooks_none() -> None:
     """It does not yield if there is no hook directory."""
     filesystem = DictFilesystem({"{{ cookiecutter.project }}": {}})
     path = Path(filesystem=filesystem)
-    paths = iterhooks(path)
+    paths = findhooks(path)
 
     assert next(paths, None) is None
 
 
-def test_iterhooks_paths() -> None:
+def test_findhooks_paths() -> None:
     """It returns paths to hooks."""
     filesystem = DictFilesystem(
         {
@@ -51,13 +51,13 @@ def test_iterhooks_paths() -> None:
         }
     )
     path = Path(filesystem=filesystem)
-    paths = iterhooks(path)
+    paths = findhooks(path)
 
     assert next(paths) == path / "hooks" / "pre_gen_project.py"
     assert next(paths, None) is None
 
 
-def test_iterhooks_bogus_hooks() -> None:
+def test_findhooks_bogus_hooks() -> None:
     """It ignores hooks with a backup extension."""
     filesystem = DictFilesystem(
         {
@@ -66,6 +66,6 @@ def test_iterhooks_bogus_hooks() -> None:
         }
     )
     path = Path(filesystem=filesystem)
-    paths = iterhooks(path)
+    paths = findhooks(path)
 
     assert next(paths, None) is None

--- a/tests/unit/templates/domain/test_config.py
+++ b/tests/unit/templates/domain/test_config.py
@@ -1,4 +1,7 @@
 """Unit tests for cutty.templates.domain.config."""
+from cutty.filesystems.adapters.dict import DictFilesystem
+from cutty.filesystems.domain.path import Path
+from cutty.templates.adapters.cookiecutter.config import findhooks
 from cutty.templates.domain.config import Config
 from cutty.templates.domain.variables import Variable
 
@@ -6,3 +9,41 @@ from cutty.templates.domain.variables import Variable
 def test_config(variable: Variable) -> None:
     """It can store settings and variables."""
     Config(settings={"a-setting": "value"}, variables=(variable,))
+
+
+def test_findhooks_none() -> None:
+    """It does not yield if there is no hook directory."""
+    filesystem = DictFilesystem({"{{ cookiecutter.project }}": {}})
+    path = Path(filesystem=filesystem)
+    paths = findhooks(path)
+
+    assert next(paths, None) is None
+
+
+def test_findhooks_paths() -> None:
+    """It returns paths to hooks."""
+    filesystem = DictFilesystem(
+        {
+            "hooks": {"pre_gen_project.py": ""},
+            "{{ cookiecutter.project }}": {},
+        }
+    )
+    path = Path(filesystem=filesystem)
+    paths = findhooks(path)
+
+    assert next(paths) == path / "hooks" / "pre_gen_project.py"
+    assert next(paths, None) is None
+
+
+def test_findhooks_bogus_hooks() -> None:
+    """It ignores hooks with a backup extension."""
+    filesystem = DictFilesystem(
+        {
+            "hooks": {"pre_gen_project.py~": ""},
+            "{{ cookiecutter.project }}": {},
+        }
+    )
+    path = Path(filesystem=filesystem)
+    paths = findhooks(path)
+
+    assert next(paths, None) is None


### PR DESCRIPTION
- :recycle: iterhooks: Copy function from services.create
- :recycle: iterhooks: Rename function to `findhooks`
- :recycle: services.create.iterhooks: Replace body with call to `findhooks`
- :recycle: services.create.iterhooks: Inline function
- :recycle: Move `findhooks` tests to `tests.unit.templates`
