### PR TITLE
:racehorse: [util] Avoid O(n) for cached items in lazy sequence

### DIFF
--- a/src/cutty/util/lazysequence.py
+++ b/src/cutty/util/lazysequence.py
@@ -60,8 +60,7 @@ class LazySequence(Sequence[_T_co]):
         except IndexError:
             pass
 
-        for position, item in enumerate(self._iter):
-            self._cache.append(item)
+        for position, item in enumerate(self._readitems()):
             if index == position:
                 return item
 

--- a/src/cutty/util/lazysequence.py
+++ b/src/cutty/util/lazysequence.py
@@ -17,14 +17,17 @@ class LazySequence(Sequence[_T_co]):
         self._iter = iter(iterable)
         self._cache: list[_T_co] = []
 
+    def _readitems(self) -> Iterator[_T_co]:
+        for item in self._iter:
+            self._cache.append(item)
+            yield item
+
     def __iter__(self) -> Iterator[_T_co]:
         """Iterate over the items in the sequence."""
         for item in self._cache:
             yield item
 
-        for item in self._iter:
-            self._cache.append(item)
-            yield item
+        yield from self._readitems()
 
     def __bool__(self) -> bool:
         """Return True if there are any items in the sequence."""

--- a/src/cutty/util/lazysequence.py
+++ b/src/cutty/util/lazysequence.py
@@ -54,7 +54,13 @@ class LazySequence(Sequence[_T_co]):
         if index < 0:
             index += len(self)
 
-        for position, item in enumerate(self):
+        try:
+            return self._cache[index]
+        except IndexError:
+            pass
+
+        for position, item in enumerate(self._iter):
+            self._cache.append(item)
             if index == position:
                 return item
 

--- a/src/cutty/util/lazysequence.py
+++ b/src/cutty/util/lazysequence.py
@@ -24,9 +24,7 @@ class LazySequence(Sequence[_T_co]):
 
     def __iter__(self) -> Iterator[_T_co]:
         """Iterate over the items in the sequence."""
-        for item in self._cache:
-            yield item
-
+        yield from self._cache
         yield from self._readitems()
 
     def __bool__(self) -> bool:

--- a/src/cutty/util/lazysequence.py
+++ b/src/cutty/util/lazysequence.py
@@ -17,7 +17,7 @@ class LazySequence(Sequence[_T_co]):
         self._iter = iter(iterable)
         self._cache: list[_T_co] = []
 
-    def _readitems(self) -> Iterator[_T_co]:
+    def _read(self) -> Iterator[_T_co]:
         for item in self._iter:
             self._cache.append(item)
             yield item
@@ -25,7 +25,7 @@ class LazySequence(Sequence[_T_co]):
     def __iter__(self) -> Iterator[_T_co]:
         """Iterate over the items in the sequence."""
         yield from self._cache
-        yield from self._readitems()
+        yield from self._read()
 
     def __bool__(self) -> bool:
         """Return True if there are any items in the sequence."""
@@ -60,7 +60,7 @@ class LazySequence(Sequence[_T_co]):
         except IndexError:
             pass
 
-        for position, item in enumerate(self._readitems()):
+        for position, item in enumerate(self._read()):
             if index == position:
                 return item
 

--- a/src/cutty/util/lazysequence.py
+++ b/src/cutty/util/lazysequence.py
@@ -35,7 +35,7 @@ class LazySequence(Sequence[_T_co]):
 
     def __len__(self) -> int:
         """Return the number of items in the sequence."""
-        return sum(1 for _ in self)
+        return len(self._cache) + sum(1 for _ in self._read())
 
     @overload
     def __getitem__(self, index: int) -> _T_co:

--- a/tests/unit/util/test_lazysequence.py
+++ b/tests/unit/util/test_lazysequence.py
@@ -19,6 +19,11 @@ def test_getitem() -> None:
     assert 1 == LazySequence([1])[0]
 
 
+def test_getitem_second() -> None:
+    """It returns the item at the given position."""
+    assert 2 == LazySequence([1, 2])[1]
+
+
 def test_getitem_negative() -> None:
     """It returns the item at the given position."""
     assert 2 == LazySequence([1, 2])[-1]


### PR DESCRIPTION
- :sparkles: LazySequence: Support negative indices
- :racehorse: __getitem__: Avoid O(n) for cached items
- :recycle: Extract function `_readitems`
- :recycle: Replace loop with `yield from`
- :recycle: Replace inline code with call to `_readitems`
- :recycle: Rename function `_readitems` to `_read`
- :racehorse: __len__: Avoid O(n) for cached items
