### PR TITLE
:art: Rename exception classes with an `Error` suffix

### DIFF
--- a/src/cutty/templates/adapters/jinja.py
+++ b/src/cutty/templates/adapters/jinja.py
@@ -18,7 +18,7 @@ from cutty.util.reraise import reraise
 
 
 @dataclass
-class TemplateExtensionNotFound(Exception):
+class TemplateExtensionNotFoundError(Exception):
     """The template extension was not found."""
 
     extension: str
@@ -60,7 +60,7 @@ def import_object(import_path: str) -> Any:
 
 def load_extension(import_path: str) -> type[jinja2.ext.Extension]:
     """Import a Jinja extension from the specified path."""
-    with reraise(TemplateExtensionNotFound(import_path)):
+    with reraise(TemplateExtensionNotFoundError(import_path)):
         extension = import_object(import_path)
 
     if not (

--- a/tests/unit/util/test_exceptionhandlers.py
+++ b/tests/unit/util/test_exceptionhandlers.py
@@ -9,69 +9,69 @@ from cutty.util.exceptionhandlers import exceptionhandler
 from cutty.util.exceptionhandlers import nullhandler
 
 
-class Red(Exception):
+class RedError(Exception):
     """Exception for testing."""
 
 
-class Green(Exception):
+class GreenError(Exception):
     """Exception for testing."""
 
 
-class Blue(Exception):
+class BlueError(Exception):
     """Exception for testing."""
 
 
-class Indigo(Blue):
+class IndigoError(BlueError):
     """Exception for testing."""
 
 
 @exceptionhandler
-def suppress_red(error: Red) -> bool:
-    """Suppress Red exceptions."""
+def suppress_red(error: RedError) -> bool:
+    """Suppress RedError exceptions."""
     return True
 
 
 @exceptionhandler()  # empty parentheses are equivalent to none
-def suppress_green(error: Green) -> bool:
-    """Suppress Green exceptions."""
+def suppress_green(error: GreenError) -> bool:
+    """Suppress GreenError exceptions."""
     return True
 
 
 @exceptionhandler
-def suppress_blue(error: Blue) -> bool:
-    """Suppress Blue exceptions."""
+def suppress_blue(error: BlueError) -> bool:
+    """Suppress BlueError exceptions."""
     return True
 
 
 @exceptionhandler
-def suppress_indigo(error: Indigo) -> bool:
-    """Suppress Indigo exceptions."""
+def suppress_indigo(error: IndigoError) -> bool:
+    """Suppress IndigoError exceptions."""
     return True
 
 
-@exceptionhandler(Red, Blue)
-def suppress_red_and_blue(error: Union[Red, Blue]) -> bool:
-    """Suppress Red and Blue exceptions."""
+@exceptionhandler(RedError, BlueError)
+def suppress_red_and_blue(error: Union[RedError, BlueError]) -> bool:
+    """Suppress RedError and BlueError exceptions."""
     return True
 
 
-@exceptionhandler(Red, Green)
-def suppress_red_and_green(error: Union[Red, Green]) -> bool:
-    """Suppress Red and Green exceptions."""
+@exceptionhandler(RedError, GreenError)
+def suppress_red_and_green(error: Union[RedError, GreenError]) -> bool:
+    """Suppress RedError and GreenError exceptions."""
     return True
 
 
-@exceptionhandler(Red, Green, Blue)
-def suppress_red_green_blue(error: Union[Red, Green, Blue]) -> bool:
-    """Suppress Red, Green, and Blue exceptions."""
+@exceptionhandler(RedError, GreenError, BlueError)
+def suppress_red_green_blue(error: Union[RedError, GreenError, BlueError]) -> bool:
+    """Suppress RedError, GreenError, and BlueError exceptions."""
     return True
 
 
 def test_nullhandler() -> None:
     """It does not swallow the error."""
-    with pytest.raises(Blue):
+    with pytest.raises(BlueError):
         with nullhandler:
-            raise Blue()
+            raise BlueError()
 
 
 def test_decorator_missing_annotation() -> None:
@@ -88,7 +88,7 @@ def test_decorator_decorator() -> None:
 
     @suppress_blue
     def raise_blue() -> None:
-        raise Blue()
+        raise BlueError()
 
     raise_blue()  # does not throw
 
@@ -105,7 +105,7 @@ def test_decorator_decorator() -> None:
 def test_decorator_positive(handler: ExceptionHandler) -> None:
     """The exception is handled."""
     with handler:
-        raise Indigo()
+        raise IndigoError()
 
 
 @pytest.mark.parametrize(
@@ -120,9 +120,9 @@ def test_decorator_positive(handler: ExceptionHandler) -> None:
 )
 def test_decorator_negative(handler: ExceptionHandler) -> None:
     """The exception is not handled."""
-    with pytest.raises(Blue):
+    with pytest.raises(BlueError):
         with handler:
-            raise Blue()
+            raise BlueError()
 
 
 @pytest.mark.parametrize(
@@ -138,7 +138,7 @@ def test_compose_lshift(handlers: tuple[ExceptionHandler]) -> None:
     """The exception is handled."""
     handler = reduce(lambda a, b: a << b, handlers)
     with handler:
-        raise Indigo()
+        raise IndigoError()
 
 
 @pytest.mark.parametrize(
@@ -156,4 +156,4 @@ def test_compose_rshift(handlers: tuple[ExceptionHandler]) -> None:
     """The exception is handled."""
     handler = reduce(lambda a, b: a >> b, handlers)
     with handler:
-        raise Indigo()
+        raise IndigoError()


### PR DESCRIPTION
- :art: [util] Rename exception classes in tests with `Error` suffix
- :art: [templates] Rename exception `TemplateExtensionNotFound{ => Error}`
