### PR TITLE
:sparkles: [filestorage] Update `cutty/latest` branch in existing repository

### DIFF
--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -54,12 +54,13 @@ class GitRepositoryObserver(FileStorageObserver):
         except pygit2.GitError:
             repository = pygit2.init_repository(self.project)
 
-        commit(repository, message="Initial")
-
-        if LATEST_BRANCH not in repository.branches:
-            repository.branches.create(LATEST_BRANCH, repository.head.peel())
-        else:
+        if LATEST_BRANCH in repository.branches:
             # HEAD must point to latest branch if it exists.
             head = repository.references["HEAD"].target
             if head != f"refs/heads/{LATEST_BRANCH}":
                 raise RuntimeError(f"unexpected HEAD: {head}")
+
+        commit(repository, message="Initial")
+
+        if LATEST_BRANCH not in repository.branches:
+            repository.branches.create(LATEST_BRANCH, repository.head.peel())

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -2,6 +2,7 @@
 import contextlib
 import os
 import pathlib
+from typing import Optional
 
 import pygit2
 
@@ -18,12 +19,20 @@ def default_signature(repository: pygit2.Repository) -> pygit2.Signature:
     return repository.default_signature  # pragma: no cover
 
 
-def commit(repository: pygit2.Repository, *, message: str) -> None:
+def commit(
+    repository: pygit2.Repository,
+    *,
+    message: str,
+    signature: Optional[pygit2.Signature] = None,
+) -> None:
     """Commit all changes in the repository."""
     repository.index.add_all()
     tree = repository.index.write_tree()
     repository.index.write()
-    signature = default_signature(repository)
+
+    if signature is None:
+        signature = default_signature(repository)
+
     parents = [] if repository.head_is_unborn else [repository.head.target]
     repository.create_commit("HEAD", signature, signature, message, tree, parents)
 

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -9,6 +9,9 @@ import pygit2
 from cutty.filestorage.domain.observers import FileStorageObserver
 
 
+LATEST_BRANCH = "cutty/latest"
+
+
 def default_signature(repository: pygit2.Repository) -> pygit2.Signature:
     """Return the default signature."""
     with contextlib.suppress(KeyError):
@@ -53,10 +56,10 @@ class GitRepositoryObserver(FileStorageObserver):
 
         commit(repository, message="Initial")
 
-        if "cutty/latest" not in repository.branches:
-            repository.branches.create("cutty/latest", repository.head.peel())
+        if LATEST_BRANCH not in repository.branches:
+            repository.branches.create(LATEST_BRANCH, repository.head.peel())
         else:
-            # HEAD must point to `cutty/latest` if that branch exists.
+            # HEAD must point to latest branch if it exists.
             head = repository.references["HEAD"].target
-            if head != "refs/heads/cutty/latest":
+            if head != f"refs/heads/{LATEST_BRANCH}":
                 raise RuntimeError(f"unexpected HEAD: {head}")

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -41,3 +41,8 @@ class GitRepositoryObserver(FileStorageObserver):
 
         if "cutty/latest" not in repository.branches:
             repository.branches.create("cutty/latest", repository.head.peel())
+        else:
+            # HEAD must point to `cutty/latest` if that branch exists.
+            head = repository.references["HEAD"].target
+            if head != "refs/heads/cutty/latest":
+                raise RuntimeError(f"unexpected HEAD: {head}")

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -38,4 +38,6 @@ class GitRepositoryObserver(FileStorageObserver):
         signature = default_signature(repository)
         parents = [] if repository.head_is_unborn else [repository.head.target]
         repository.create_commit("HEAD", signature, signature, "Initial", tree, parents)
-        repository.branches.create("cutty/latest", repository.head.peel())
+
+        if "cutty/latest" not in repository.branches:
+            repository.branches.create("cutty/latest", repository.head.peel())

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -8,6 +8,8 @@ import pygit2
 import pytest
 from click.testing import CliRunner
 
+from cutty.filestorage.adapters.observers.git import commit as _commit
+
 
 @pytest.fixture
 def runner() -> Iterator[CliRunner]:
@@ -55,11 +57,8 @@ def template_directory(tmp_path: Path) -> Path:
 
 def commit(repository: pygit2.Repository, *, message: str) -> None:
     """Commit all changes in the repository."""
-    repository.index.add_all()
-    tree = repository.index.write_tree()
     signature = pygit2.Signature("you", "you@example.com")
-    parents = [] if repository.head_is_unborn else [repository.head.target]
-    repository.create_commit("HEAD", signature, signature, message, tree, parents)
+    _commit(repository, message=message, signature=signature)
 
 
 @pytest.fixture

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -169,3 +169,5 @@ def test_existing_branch_not_head(
     with pytest.raises(Exception):
         with storage:
             storage.add(file)
+
+    assert file.path.name not in tree(repository)

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -157,3 +157,17 @@ def test_existing_branch(
         storage.add(file)
 
     assert file.path.name in tree(repository)
+
+
+def test_existing_branch_not_head(
+    storage: FileStorage, file: RegularFile, project: pathlib.Path
+) -> None:
+    """It raises an exception."""
+    repository = pygit2.init_repository(project)
+    commit(repository)
+    branchname = "cutty/latest"
+    repository.branches.create(branchname, repository.head.peel())
+
+    with pytest.raises(Exception):
+        with storage:
+            storage.add(file)

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -112,14 +112,14 @@ def commit(repository: pygit2.Repository) -> None:
 def test_existing_repository(
     storage: FileStorage, file: RegularFile, project: pathlib.Path
 ) -> None:
-    """It does nothing if the repository already exists."""
+    """It creates the commit in an existing repository."""
     repository = pygit2.init_repository(project)
     commit(repository)
 
     with storage:
         storage.add(file)
 
-    assert file.path.name not in tree(repository)
+    assert file.path.name in tree(repository)
 
 
 def test_branch(storage: FileStorage, file: RegularFile, project: pathlib.Path) -> None:

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -5,6 +5,7 @@ import pygit2
 import pytest
 
 from cutty.filestorage.adapters.disk import DiskFileStorage
+from cutty.filestorage.adapters.observers.git import commit as _commit
 from cutty.filestorage.adapters.observers.git import GitRepositoryObserver
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.observers import observe
@@ -103,10 +104,8 @@ def test_hook_additions(storage: FileStorage, project: pathlib.Path) -> None:
 
 def commit(repository: pygit2.Repository) -> None:
     """Create an initial empty commit."""
-    tree = repository.index.write_tree()
-    repository.index.write()
     signature = pygit2.Signature("you", "you@example.com")
-    repository.create_commit("HEAD", signature, signature, "Initial", tree, [])
+    _commit(repository, message="Initial", signature=signature)
 
 
 def test_existing_repository(

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -141,3 +141,19 @@ def test_branch_not_checked_out(
 
     repository = pygit2.Repository(project)
     assert repository.references["HEAD"].target != "refs/heads/cutty/latest"
+
+
+def test_existing_branch(
+    storage: FileStorage, file: RegularFile, project: pathlib.Path
+) -> None:
+    """It updates an existing branch."""
+    repository = pygit2.init_repository(project)
+    commit(repository)
+    branchname = "cutty/latest"
+    repository.branches.create(branchname, repository.head.peel())
+    repository.set_head(f"refs/heads/{branchname}")
+
+    with storage:
+        storage.add(file)
+
+    assert file.path.name in tree(repository)


### PR DESCRIPTION
- :white_check_mark: [filestorage] Modify test to expect commits in existing repositories
- :sparkles: [filestorage] Create commit in existing repository
- :white_check_mark: [filestorage] Add test for updating existing branches
- :sparkles: [filestorage] Do not create branch if it already exists
- :white_check_mark: [filestorage] Add test for existing branch but not HEAD
- :sparkles: [filestorage] Bail out if branch exists but HEAD points elsewhere
- :recycle: [filestorage] Extract function `commit` from git observer
- :recycle: [filestorage] Allow overriding the default signature in `commit`
- :recycle: [functional] Replace inline code with function call to `commit`
- :recycle: [filestorage] Replace inline code with function call to `commit`
- :recycle: [filestorage] Extract constant `LATEST_BRANCH`
- :recycle: [filestorage] Use LATEST_BRANCH constant in tests
- :white_check_mark: [filestorage] Test that we don't commit to a wrong HEAD
- :sparkles: [filestorage] Check for latest branch before committing
