### PR TITLE
:sparkles: [services] Implement service for updating generated projects

### DIFF
--- a/src/cutty/compat/contextlib.py
+++ b/src/cutty/compat/contextlib.py
@@ -1,0 +1,20 @@
+"""Compatibility shim for contextlib."""
+import contextlib
+from collections.abc import Callable
+from collections.abc import Iterator
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
+
+def contextmanager(
+    func: Callable[..., Iterator[T]]
+) -> Callable[..., contextlib.AbstractContextManager[T]]:
+    """Fix annotations of functions decorated by contextlib.contextmanager."""
+    result = contextlib.contextmanager(func)
+    result.__annotations__ = {
+        **func.__annotations__,
+        "return": contextlib.AbstractContextManager[T],
+    }
+    return result

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -1,7 +1,9 @@
 """Command-line interface for updating projects from Cookiecutter templates."""
 from cutty.entrypoints.cli._main import main as _main
+from cutty.services.update import update as service_update
 
 
 @_main.command()
 def update() -> None:
     """Update a project with changes from its template."""
+    service_update()

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -1,0 +1,5 @@
+"""Update a project with changes from its Cookiecutter template."""
+
+
+def update() -> None:
+    """Update a project with changes from its Cookiecutter template."""

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -1,4 +1,13 @@
 """Update a project with changes from its Cookiecutter template."""
+import json
+from pathlib import Path
+
+
+def getprojecttemplate(projectdir: Path) -> str:
+    """Return the location of the project template."""
+    text = (projectdir / ".cookiecutter.json").read_text()
+    data = json.loads(text)
+    return data["_template"]
 
 
 def update() -> None:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -53,10 +53,13 @@ def update() -> None:
     projectdir = Path.cwd()
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
-    create(
-        template,
-        no_input=True,
-        outputdir=projectdir.parent,
-        overwrite_if_exists=True,
-        extra_context=context,
-    )
+    with createworktree(
+        projectdir, "cutty/latest", dirname=projectdir.name
+    ) as worktree:
+        create(
+            template,
+            no_input=True,
+            outputdir=worktree.parent,
+            overwrite_if_exists=True,
+            extra_context=context,
+        )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -56,6 +56,8 @@ def cherrypick(repositorypath: Path, reference: str) -> None:
     repository = pygit2.Repository(repositorypath)
     oid = repository.references[reference].resolve().target
     repository.cherrypick(oid)
+    if repository.index.conflicts:
+        raise Exception("There were conflicts")
     commit(repository, message="Update project template")
     repository.state_cleanup()
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -12,10 +12,8 @@ from cutty.services.create import create
 
 def getprojecttemplate(projectdir: Path) -> str:
     """Return the location of the project template."""
-    text = (projectdir / ".cookiecutter.json").read_text()
-    data = json.loads(text)
-    result: str = data["_template"]
-    return result
+    context = getprojectcontext(projectdir)
+    return context["_template"]
 
 
 def getprojectcontext(projectdir: Path) -> dict[str, str]:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -16,4 +16,4 @@ def getprojecttemplate(projectdir: Path) -> str:
 def update() -> None:
     """Update a project with changes from its Cookiecutter template."""
     template = getprojecttemplate(Path.cwd())
-    create(template)
+    create(template, no_input=True)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -38,6 +38,7 @@ def createworktree(repositorypath: Path, branch: str) -> Iterator[Path]:
         yield path
 
     # Prune with `force=True` because libgit2 thinks `worktree.path` still exists.
+    # https://github.com/libgit2/libgit2/issues/5280
     worktree.prune(True)
 
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -56,8 +56,15 @@ def cherrypick(repositorypath: Path, reference: str) -> None:
     repository = pygit2.Repository(repositorypath)
     oid = repository.references[reference].resolve().target
     repository.cherrypick(oid)
+
     if repository.index.conflicts:
-        raise Exception("There were conflicts")
+        paths = {
+            path
+            for _, ours, theirs in repository.index.conflicts
+            for path in (ours.path, theirs.path)
+        }
+        raise RuntimeError(f"Merge conflicts: {' '.join(paths)}")
+
     commit(repository, message="Update project template")
     repository.state_cleanup()
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -3,6 +3,7 @@ import json
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Optional
 
 import pygit2
 
@@ -28,12 +29,17 @@ def getprojectcontext(projectdir: Path) -> dict[str, str]:
 
 
 @contextmanager
-def createworktree(repositorypath: Path, branch: str) -> Iterator[Path]:
+def createworktree(
+    repositorypath: Path, branch: str, dirname: Optional[str] = None
+) -> Iterator[Path]:
     """Create a worktree for the branch in the repository."""
+    if dirname is None:
+        dirname = branch
+
     repository = pygit2.Repository(repositorypath)
 
     with tempfile.TemporaryDirectory() as directory:
-        path = Path(directory) / branch
+        path = Path(directory) / dirname
         worktree = repository.add_worktree(branch, path, repository.branches[branch])
         yield path
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -2,6 +2,8 @@
 import json
 from pathlib import Path
 
+from cutty.services.create import create
+
 
 def getprojecttemplate(projectdir: Path) -> str:
     """Return the location of the project template."""
@@ -12,3 +14,5 @@ def getprojecttemplate(projectdir: Path) -> str:
 
 def update() -> None:
     """Update a project with changes from its Cookiecutter template."""
+    template = getprojecttemplate(Path.cwd())
+    create(template)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -1,5 +1,4 @@
 """Update a project with changes from its Cookiecutter template."""
-import contextlib
 import json
 import tempfile
 from collections.abc import Iterator
@@ -7,6 +6,7 @@ from pathlib import Path
 
 import pygit2
 
+from cutty.compat.contextlib import contextmanager
 from cutty.services.create import create
 
 
@@ -29,7 +29,7 @@ def getprojectcontext(projectdir: Path) -> dict[str, str]:
     }
 
 
-@contextlib.contextmanager
+@contextmanager
 def createworktree(repositorypath: Path, branch: str) -> Iterator[Path]:
     """Create a worktree for the branch in the repository."""
     repository = pygit2.Repository(repositorypath)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -13,6 +13,17 @@ def getprojecttemplate(projectdir: Path) -> str:
     return result
 
 
+def getprojectcontext(projectdir: Path) -> dict[str, str]:
+    """Return the Cookiecutter context of the project."""
+    text = (projectdir / ".cookiecutter.json").read_text()
+    data = json.loads(text)
+    return {
+        key: value
+        for key, value in data.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+
+
 def update() -> None:
     """Update a project with changes from its Cookiecutter template."""
     projectdir = Path.cwd()

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -16,4 +16,6 @@ def getprojecttemplate(projectdir: Path) -> str:
 def update() -> None:
     """Update a project with changes from its Cookiecutter template."""
     template = getprojecttemplate(Path.cwd())
-    create(template, no_input=True, outputdir=Path.cwd().parent)
+    create(
+        template, no_input=True, outputdir=Path.cwd().parent, overwrite_if_exists=True
+    )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -9,6 +9,7 @@ from typing import Optional
 import pygit2
 
 from cutty.compat.contextlib import contextmanager
+from cutty.filestorage.adapters.observers.git import commit
 from cutty.services.create import create
 
 
@@ -48,6 +49,15 @@ def createworktree(
     # Prune with `force=True` because libgit2 thinks `worktree.path` still exists.
     # https://github.com/libgit2/libgit2/issues/5280
     worktree.prune(True)
+
+
+def cherrypick(repositorypath: Path, reference: str) -> None:
+    """Cherry-pick the commit onto the current branch."""
+    repository = pygit2.Repository(repositorypath)
+    oid = repository.references[reference].resolve().target
+    repository.cherrypick(oid)
+    commit(repository, message="Update project template")
+    repository.state_cleanup()
 
 
 def update() -> None:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -1,6 +1,11 @@
 """Update a project with changes from its Cookiecutter template."""
+import contextlib
 import json
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
+
+import pygit2
 
 from cutty.services.create import create
 
@@ -22,6 +27,20 @@ def getprojectcontext(projectdir: Path) -> dict[str, str]:
         for key, value in data.items()
         if isinstance(key, str) and isinstance(value, str)
     }
+
+
+@contextlib.contextmanager
+def createworktree(repositorypath: Path, branch: str) -> Iterator[Path]:
+    """Create a worktree for the branch in the repository."""
+    repository = pygit2.Repository(repositorypath)
+
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / branch
+        worktree = repository.add_worktree(branch, path, repository.branches[branch])
+        yield path
+
+    # Prune with `force=True` because libgit2 thinks `worktree.path` still exists.
+    worktree.prune(True)
 
 
 def update() -> None:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -1,4 +1,5 @@
 """Update a project with changes from its Cookiecutter template."""
+import hashlib
 import json
 import tempfile
 from collections.abc import Iterator
@@ -39,8 +40,9 @@ def createworktree(
     repository = pygit2.Repository(repositorypath)
 
     with tempfile.TemporaryDirectory() as directory:
+        name = hashlib.blake2b(branch.encode(), digest_size=32).hexdigest()
         path = Path(directory) / dirname
-        worktree = repository.add_worktree(branch, path, repository.branches[branch])
+        worktree = repository.add_worktree(name, path, repository.branches[branch])
         yield path
 
     # Prune with `force=True` because libgit2 thinks `worktree.path` still exists.

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -28,6 +28,11 @@ def update() -> None:
     """Update a project with changes from its Cookiecutter template."""
     projectdir = Path.cwd()
     template = getprojecttemplate(projectdir)
+    context = getprojectcontext(projectdir)
     create(
-        template, no_input=True, outputdir=projectdir.parent, overwrite_if_exists=True
+        template,
+        no_input=True,
+        outputdir=projectdir.parent,
+        overwrite_if_exists=True,
+        extra_context=context,
     )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -9,7 +9,8 @@ def getprojecttemplate(projectdir: Path) -> str:
     """Return the location of the project template."""
     text = (projectdir / ".cookiecutter.json").read_text()
     data = json.loads(text)
-    return data["_template"]
+    result: str = data["_template"]
+    return result
 
 
 def update() -> None:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -16,4 +16,4 @@ def getprojecttemplate(projectdir: Path) -> str:
 def update() -> None:
     """Update a project with changes from its Cookiecutter template."""
     template = getprojecttemplate(Path.cwd())
-    create(template, no_input=True)
+    create(template, no_input=True, outputdir=Path.cwd().parent)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -75,3 +75,4 @@ def update() -> None:
             overwrite_if_exists=True,
             extra_context=context,
         )
+    cherrypick(projectdir, "refs/heads/cutty/latest")

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -15,7 +15,8 @@ def getprojecttemplate(projectdir: Path) -> str:
 
 def update() -> None:
     """Update a project with changes from its Cookiecutter template."""
-    template = getprojecttemplate(Path.cwd())
+    projectdir = Path.cwd()
+    template = getprojecttemplate(projectdir)
     create(
-        template, no_input=True, outputdir=Path.cwd().parent, overwrite_if_exists=True
+        template, no_input=True, outputdir=projectdir.parent, overwrite_if_exists=True
     )

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -46,6 +46,13 @@ def template_directory(tmp_path: Path) -> Path:
     )
 
     create(
+        tmp_path / "{{ cookiecutter.project }}" / ".cookiecutter.json",
+        """
+        {{ cookiecutter | jsonify }}
+        """,
+    )
+
+    create(
         tmp_path / "hooks" / "post_gen_project.py",
         """
         open("post_gen_project", mode="w")

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -19,3 +19,4 @@ def test_create_cookiecutter(runner: CliRunner, repository: Path) -> None:
     )
     assert Path("foobar", "README.md").read_text() == "# foobar\n"
     assert Path("foobar", "post_gen_project").is_file()
+    assert Path("foobar", ".cookiecutter.json").is_file()

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -15,7 +15,7 @@ def test_help(runner: CliRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_update(runner: CliRunner, repository: Path) -> None:
+def test_update_trivial(runner: CliRunner, repository: Path) -> None:
     """It applies changes from the template."""
     runner.invoke(
         main,
@@ -34,3 +34,31 @@ def test_update(runner: CliRunner, repository: Path) -> None:
 
     runner.invoke(main, ["update"], catch_exceptions=False)
     assert Path("README.md").read_text() == "# awesome\nAn awesome project.\n"
+
+
+def test_update_merge(runner: CliRunner, repository: Path) -> None:
+    """It merges changes from the template."""
+    runner.invoke(
+        main,
+        ["create", "--no-input", str(repository), "project=awesome"],
+        catch_exceptions=False,
+    )
+
+    projectdir = Path("awesome")
+
+    # Update README.md in the project.
+    path = projectdir / "README.md"
+    path.write_text(path.read_text() + "An awesome project.\n")
+    commit(pygit2.Repository(projectdir), message="Update README.md")
+
+    # Add LICENSE in the template.
+    path = repository / "{{ cookiecutter.project }}" / "LICENSE"
+    path.touch()
+    commit(pygit2.Repository(repository), message="Add LICENSE")
+
+    # Update the project.
+    os.chdir(projectdir)
+    runner.invoke(main, ["update"], catch_exceptions=False)
+
+    assert Path("README.md").read_text() == "# awesome\nAn awesome project.\n"
+    assert Path("LICENSE").is_file()

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -1,4 +1,5 @@
 """Functional tests for the update CLI."""
+import os
 from pathlib import Path
 
 import pygit2
@@ -27,7 +28,7 @@ def test_update(runner: CliRunner, repository: Path) -> None:
     # Commit the changes.
     commit(pygit2.Repository(repository), message="Update README.md")
 
+    os.chdir("example")
+
     runner.invoke(main, ["update"], catch_exceptions=False)
-    assert (
-        Path("example", "README.md").read_text() == "# example\nAn awesome project.\n"
-    )
+    assert Path("README.md").read_text() == "# example\nAn awesome project.\n"

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -18,7 +18,9 @@ def test_help(runner: CliRunner) -> None:
 def test_update(runner: CliRunner, repository: Path) -> None:
     """It applies changes from the template."""
     runner.invoke(
-        main, ["create", "--no-input", str(repository)], catch_exceptions=False
+        main,
+        ["create", "--no-input", str(repository), "project=awesome"],
+        catch_exceptions=False,
     )
 
     # Update README.md.
@@ -28,7 +30,7 @@ def test_update(runner: CliRunner, repository: Path) -> None:
     # Commit the changes.
     commit(pygit2.Repository(repository), message="Update README.md")
 
-    os.chdir("example")
+    os.chdir("awesome")
 
     runner.invoke(main, ["update"], catch_exceptions=False)
-    assert Path("README.md").read_text() == "# example\nAn awesome project.\n"
+    assert Path("README.md").read_text() == "# awesome\nAn awesome project.\n"

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 
 import pygit2
-import pytest
 from click.testing import CliRunner
 
 from cutty.entrypoints.cli import main
@@ -15,7 +14,6 @@ def test_help(runner: CliRunner) -> None:
     assert result.exit_code == 0
 
 
-@pytest.mark.xfail(reason="not implemented")
 def test_update(runner: CliRunner, repository: Path) -> None:
     """It applies changes from the template."""
     runner.invoke(

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -23,16 +23,15 @@ def test_update_trivial(runner: CliRunner, repository: Path) -> None:
         catch_exceptions=False,
     )
 
-    # Update README.md.
+    # Update README.md in the template.
     path = repository / "{{ cookiecutter.project }}" / "README.md"
     path.write_text(path.read_text() + "An awesome project.\n")
-
-    # Commit the changes.
     commit(pygit2.Repository(repository), message="Update README.md")
 
+    # Update the project.
     os.chdir("awesome")
-
     runner.invoke(main, ["update"], catch_exceptions=False)
+
     assert Path("README.md").read_text() == "# awesome\nAn awesome project.\n"
 
 

--- a/tests/unit/services/__init__.py
+++ b/tests/unit/services/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for cutty.services."""

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -2,6 +2,7 @@
 import json
 from pathlib import Path
 
+from cutty.services.update import getprojectcontext
 from cutty.services.update import getprojecttemplate
 
 
@@ -12,3 +13,12 @@ def test_getprojecttemplate(tmp_path: Path) -> None:
     (tmp_path / ".cookiecutter.json").write_text(text)
 
     assert template == getprojecttemplate(tmp_path)
+
+
+def test_getprojectcontext(tmp_path: Path) -> None:
+    """It returns the persisted Cookiecutter context."""
+    context = {"project": "example"}
+    text = json.dumps(context)
+    (tmp_path / ".cookiecutter.json").write_text(text)
+
+    assert context == getprojectcontext(tmp_path)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -1,1 +1,20 @@
 """Unit tests for cutty.services.update."""
+import json
+from pathlib import Path
+
+from cutty.services.update import getprojecttemplate
+from cutty.services.update import update
+
+
+def test_update() -> None:
+    """It does not raise."""
+    update()
+
+
+def test_getprojecttemplate(tmp_path: Path) -> None:
+    """It does not raise."""
+    template = "https://example.com/repository.git"
+    text = json.dumps({"_template": template})
+    (tmp_path / ".cookiecutter.json").write_text(text)
+
+    assert template == getprojecttemplate(tmp_path)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -1,0 +1,1 @@
+"""Unit tests for cutty.services.update."""

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -6,7 +6,7 @@ from cutty.services.update import getprojecttemplate
 
 
 def test_getprojecttemplate(tmp_path: Path) -> None:
-    """It does not raise."""
+    """It returns the `_template` key from .cookiecutter.json."""
     template = "https://example.com/repository.git"
     text = json.dumps({"_template": template})
     (tmp_path / ".cookiecutter.json").write_text(text)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -84,5 +84,5 @@ def test_cherrypick_conflict(tmp_path: Path) -> None:
 
     repository.checkout(mainbranch)
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="README"):
         cherrypick(repositorypath, otherbranch.name)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -3,12 +3,6 @@ import json
 from pathlib import Path
 
 from cutty.services.update import getprojecttemplate
-from cutty.services.update import update
-
-
-def test_update() -> None:
-    """It does not raise."""
-    update()
 
 
 def test_getprojecttemplate(tmp_path: Path) -> None:


### PR DESCRIPTION
- :sparkles: [services] Add update service stub
- :tada: [services] Add package tests.unit.services
- :tada: [services] Add unit tests for update service
- :white_check_mark: [services] Add failing test for determining the template location
- :sparkles: [services] Determine template location in update service
- :white_check_mark: [functional] Remove XFAIL marker from FT for updating projects
- :sparkles: [services] Implement update service stub using create
- :label: [services] Fix type error in getprojecttemplate
- :bug: [services] Do not prompt when updating
- :fire: [services] Remove functional test in disguise
- :white_check_mark: [functional] Add .cookiecutter.json to test fixture
- :white_check_mark: [functional] Check for .cookiecutter.json in create test
- :white_check_mark: [functional] Chdir into project before update
- :bug: [services] Generate project in parent directory
- :bug: [services] Overwrite existing files
- :recycle: [services] Extract variable `projectdir` in update service
- :white_check_mark: [services] Do not use project defaults in update test
- :white_check_mark: [functional] Update docstring
- :white_check_mark: [services] Add unit test for getprojectcontext
- :sparkles: [services] Add getprojectcontext function
- :sparkles: [services] Load persisted Cookiecutter context when updating
- :white_check_mark: [functional] Add functional test for update requiring merge
- :white_check_mark: [services] Add test for creating worktrees
- :sparkles: [services] Add function for creating worktrees
- :rewind: [compat] Revert "Drop contextlib.contextmanager shim"
- :label: [services] Use Typeguard-compatible `contextmanager` for createworktree
- :recycle: [services] Replace inline code with function call
- :bulb: [services] Add comment with libgit2 issue
- :sparkles: [services] Add optional `dirname` parameter to createworktree
- :sparkles: [services] Create project in worktree when updating
- :sparkles: [services] Hash branch to ensure valid worktree name
- :art: [functional] Whitespace and comment cleanup
- :white_check_mark: [services] Add test for cherrypick function
- :sparkles: [services] Add function to cherry-pick a commit onto the current branch
- :sparkles: [services] Cherry-pick the tip of the latest branch
- :white_check_mark: [functional] Add test for merge conflicts when updating
- :bug: [repositories] Fix leakage from fixture setting git search path
- :white_check_mark: [services] Add test for cherrypick with merge conflict
- :sparkles: [services] Raise exception if cherrypick results in conflicts
- :white_check_mark: [services] Extend merge conflict test to check error message
- :sparkles: [services] Report files with merge conflicts in error message
