### PR TITLE
:sparkles: [services] Honor file deletions when applying changes from templates

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -86,7 +86,7 @@ def update() -> None:
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
     with createworktree(
-        projectdir, "cutty/latest", dirname=projectdir.name
+        projectdir, "cutty/latest", dirname=projectdir.name, checkout=False
     ) as worktree:
         create(
             template,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -32,7 +32,7 @@ def getprojectcontext(projectdir: Path) -> dict[str, str]:
 
 @contextmanager
 def createworktree(
-    repositorypath: Path, branch: str, dirname: Optional[str] = None
+    repositorypath: Path, branch: str, *, dirname: Optional[str] = None
 ) -> Iterator[Path]:
     """Create a worktree for the branch in the repository."""
     if dirname is None:

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 import pygit2
+import pytest
 from click.testing import CliRunner
 
 from cutty.entrypoints.cli import main
@@ -90,6 +91,7 @@ def test_update_conflict(runner: CliRunner, repository: Path) -> None:
     assert result.exit_code != 0
 
 
+@pytest.mark.xfail(reason="TODO")
 def test_update_remove(runner: CliRunner, repository: Path) -> None:
     """It applies file deletions from the template."""
     runner.invoke(

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -88,3 +88,25 @@ def test_update_conflict(runner: CliRunner, repository: Path) -> None:
     result = runner.invoke(main, ["update"])
 
     assert result.exit_code != 0
+
+
+def test_update_remove(runner: CliRunner, repository: Path) -> None:
+    """It applies file deletions from the template."""
+    runner.invoke(
+        main,
+        ["create", "--no-input", str(repository), "project=awesome"],
+        catch_exceptions=False,
+    )
+
+    projectdir = Path("awesome")
+
+    # Remove README in the template.
+    path = repository / "{{ cookiecutter.project }}" / "README.md"
+    path.unlink()
+    commit(pygit2.Repository(repository), message="Remove README.md")
+
+    # Update the project.
+    os.chdir(projectdir)
+    runner.invoke(main, ["update"], catch_exceptions=False)
+
+    assert not Path("README.md").is_file()

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 
 import pygit2
-import pytest
 from click.testing import CliRunner
 
 from cutty.entrypoints.cli import main
@@ -91,7 +90,6 @@ def test_update_conflict(runner: CliRunner, repository: Path) -> None:
     assert result.exit_code != 0
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_update_remove(runner: CliRunner, repository: Path) -> None:
     """It applies file deletions from the template."""
     runner.invoke(

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -45,6 +45,19 @@ def test_createworktree(tmp_path: Path) -> None:
     assert not worktree.is_dir()
 
 
+def test_createworktree_no_checkout(tmp_path: Path) -> None:
+    """It creates a worktree without checking out the files."""
+    repositorypath = tmp_path / "repository"
+    repository = pygit2.init_repository(repositorypath)
+    (tmp_path / "repository" / "README").touch()
+    commit(repository, message="Initial")
+    repository.branches.create("mybranch", repository.head.peel())
+
+    with createworktree(repositorypath, "mybranch", checkout=False) as worktree:
+        assert (worktree / ".git").is_file()
+        assert not (worktree / "README").is_file()
+
+
 def test_cherrypick(tmp_path: Path) -> None:
     """It cherry-picks the commit onto the current branch."""
     repositorypath = tmp_path / "repository"


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for update with file deletions
- :white_check_mark: [functional] Add XFAIL marker
- :white_check_mark: [services] Add test for creating worktree without checkout
- :recycle: [services] Change `dirname` parameter to be keyword-only
- :sparkles: [services] Allow creating worktrees without checkout
- :rewind: [functional] Revert "Add XFAIL marker"
- :sparkles: [services] Honor file deletions when applying changes from templates
