### PR TITLE
:sparkles: Add option `--in-place` for generating files with leading path component stripped off

### DIFF
--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -102,4 +102,5 @@ def create(
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,
+        outputdirisproject=in_place,
     )

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -73,6 +73,13 @@ def extra_context_callback(
     default=False,
     help="Skip the files in the corresponding directories if they already exist.",
 )
+@click.option(
+    "-i",
+    "--in-place",
+    is_flag=True,
+    default=False,
+    help="Strip the leading path component from generated files.",
+)
 @click.version_option()
 def create(
     template: str,
@@ -83,6 +90,7 @@ def create(
     directory: Optional[pathlib.Path],
     overwrite_if_exists: bool,
     skip_if_file_exists: bool,
+    in_place: bool,
 ) -> None:
     """cutty."""
     service_create(

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -20,3 +20,16 @@ def test_create_cookiecutter(runner: CliRunner, repository: Path) -> None:
     assert Path("foobar", "README.md").read_text() == "# foobar\n"
     assert Path("foobar", "post_gen_project").is_file()
     assert Path("foobar", ".cookiecutter.json").is_file()
+
+
+def test_create_inplace(runner: CliRunner, repository: Path) -> None:
+    """It generates the project files in the current directory."""
+    result = runner.invoke(
+        main,
+        ["create", "--no-input", "--in-place", str(repository)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert Path("README.md").read_text() == "# example\n"
+    assert Path("post_gen_project").is_file()
+    assert Path(".cookiecutter.json").is_file()


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for --in-place creation
- :sparkles: [entrypoints] Add option `--in-place`
- :sparkles: [services] Implement in-project generation in create service
- :sparkles: [entryppoints] Implement `cutty create --in-place`
