### PR TITLE
:sparkles: Support update when the project directory was renamed

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -91,7 +91,8 @@ def update() -> None:
     ) as worktree:
         create(
             template,
-            outputdir=worktree.parent,
+            outputdir=worktree,
+            outputdirisproject=True,
             overwrite_if_exists=True,
             extra_context=context,
         )


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for updating in renamed project directory
- :sparkles: [services] Allow updating projects with renamed directory
