### PR TITLE
:recycle: [services] Minor refactoring of update service

### DIFF
--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -10,6 +10,8 @@ from cutty.filestorage.domain.observers import FileStorageObserver
 
 
 LATEST_BRANCH = "cutty/latest"
+CREATE_MESSAGE = "Initial import"
+UPDATE_MESSAGE = "Update project template"
 
 
 def default_signature(repository: pygit2.Repository) -> pygit2.Signature:
@@ -68,9 +70,9 @@ class GitRepositoryObserver(FileStorageObserver):
                 raise RuntimeError(f"unexpected HEAD: {head}")
 
         message = (
-            "Initial import"
+            CREATE_MESSAGE
             if LATEST_BRANCH not in repository.branches
-            else "Update project template"
+            else UPDATE_MESSAGE
         )
 
         commit(repository, message=message)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -95,7 +95,6 @@ def update() -> None:
             template,
             outputdir=worktree,
             outputdirisproject=True,
-            overwrite_if_exists=True,
             extra_context=context,
         )
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -30,6 +30,13 @@ def getprojectcontext(projectdir: Path) -> dict[str, str]:
     }
 
 
+def checkoutemptytree(repositorypath: Path) -> None:
+    """Check out an empty tree from the repository."""
+    repository = pygit2.Repository(repositorypath)
+    oid = repository.TreeBuilder().write()
+    repository.checkout_tree(repository[oid])
+
+
 @contextmanager
 def createworktree(
     repositorypath: Path,
@@ -47,9 +54,7 @@ def createworktree(
 
         if not checkout:
             # Emulate `--no-checkout` by checking out an empty tree after the fact.
-            worktree_repository = pygit2.Repository(path)
-            oid = worktree_repository.TreeBuilder().write()
-            worktree_repository.checkout_tree(worktree_repository[oid])
+            checkoutemptytree(path)
 
         yield path
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -87,6 +87,7 @@ def update() -> None:
     projectdir = Path.cwd()
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
+
     with createworktree(
         projectdir, LATEST_BRANCH, dirname=projectdir.name, checkout=False
     ) as worktree:
@@ -97,4 +98,5 @@ def update() -> None:
             overwrite_if_exists=True,
             extra_context=context,
         )
+
     cherrypick(projectdir, f"refs/heads/{LATEST_BRANCH}")

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -76,7 +76,7 @@ def cherrypick(repositorypath: Path, reference: str) -> None:
             for side in (ours, theirs)
             if side is not None
         }
-        raise RuntimeError(f"Merge conflicts: {' '.join(paths)}")
+        raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
 
     commit(repository, message="Update project template")
     repository.state_cleanup()

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -10,6 +10,7 @@ import pygit2
 from cutty.compat.contextlib import contextmanager
 from cutty.filestorage.adapters.observers.git import commit
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
+from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
 
 
@@ -78,7 +79,7 @@ def cherrypick(repositorypath: Path, reference: str) -> None:
         }
         raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
 
-    commit(repository, message="Update project template")
+    commit(repository, message=UPDATE_MESSAGE)
     repository.state_cleanup()
 
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,7 +4,6 @@ import json
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Optional
 
 import pygit2
 
@@ -36,18 +35,14 @@ def createworktree(
     repositorypath: Path,
     branch: str,
     *,
-    dirname: Optional[str] = None,
     checkout: bool = True,
 ) -> Iterator[Path]:
     """Create a worktree for the branch in the repository."""
-    if dirname is None:
-        dirname = branch
-
     repository = pygit2.Repository(repositorypath)
 
     with tempfile.TemporaryDirectory() as directory:
         name = hashlib.blake2b(branch.encode(), digest_size=32).hexdigest()
-        path = Path(directory) / dirname
+        path = Path(directory) / name
         worktree = repository.add_worktree(name, path, repository.branches[branch])
 
         if not checkout:
@@ -88,9 +83,7 @@ def update() -> None:
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
 
-    with createworktree(
-        projectdir, LATEST_BRANCH, dirname=projectdir.name, checkout=False
-    ) as worktree:
+    with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:
         create(
             template,
             outputdir=worktree,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -10,6 +10,7 @@ import pygit2
 
 from cutty.compat.contextlib import contextmanager
 from cutty.filestorage.adapters.observers.git import commit
+from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.services.create import create
 
 
@@ -87,7 +88,7 @@ def update() -> None:
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
     with createworktree(
-        projectdir, "cutty/latest", dirname=projectdir.name, checkout=False
+        projectdir, LATEST_BRANCH, dirname=projectdir.name, checkout=False
     ) as worktree:
         create(
             template,
@@ -96,4 +97,4 @@ def update() -> None:
             overwrite_if_exists=True,
             extra_context=context,
         )
-    cherrypick(projectdir, "refs/heads/cutty/latest")
+    cherrypick(projectdir, f"refs/heads/{LATEST_BRANCH}")


### PR DESCRIPTION
- :recycle: [services] Replace literal with constant `LATEST_BRANCH`
- :lipstick: [services] Separate conflicting files by comma in error message
- :art: [services] Add blank lines for readability
- :recycle: [services] Remove redundant `overwrite_if_exists` as worktree has no checkout
- :recycle: [services] Use hashed branch name for the worktree directory
- :recycle: [services] Extract function `checkoutemptytree` from `createworktree`
- :recycle: [filestorage] Extract constants `CREATE_MESSAGE` and `UPDATE_MESSAGE`
