### PR TITLE
:sparkles: [entrypoints] Add `cutty --version` option

### DIFF
--- a/src/cutty/entrypoints/cli/_main.py
+++ b/src/cutty/entrypoints/cli/_main.py
@@ -3,5 +3,6 @@ import click
 
 
 @click.group()
+@click.version_option()
 def main() -> None:
     """An experimental Cookiecutter clone."""

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -80,7 +80,6 @@ def extra_context_callback(
     default=False,
     help="Strip the leading path component from generated files.",
 )
-@click.version_option()
 def create(
     template: str,
     extra_context: dict[str, str],

--- a/tests/functional/test_main.py
+++ b/tests/functional/test_main.py
@@ -1,4 +1,6 @@
 """Functional tests for the cutty CLI."""
+from importlib.metadata import version
+
 from click.testing import CliRunner
 
 from cutty.entrypoints.cli import main
@@ -8,3 +10,9 @@ def test_help(runner: CliRunner) -> None:
     """It exits with a status code of zero."""
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
+
+
+def test_version(runner: CliRunner) -> None:
+    """It displays the version."""
+    result = runner.invoke(main, ["--version"])
+    assert version("cutty") in result.output


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty --version`
- :sparkles: [entrypoints] Add `cutty --version`
- :fire: [entrypoints] Remove `cutty create --version`
