### PR TITLE
:sparkles: [entrypoints] Add `cutty update <variable>=<value>`

### DIFF
--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -10,4 +10,4 @@ from cutty.services.update import update as service_update
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 def update(extra_context: dict[str, str]) -> None:
     """Update a project with changes from its template."""
-    service_update()
+    service_update(extra_context=extra_context)

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -1,9 +1,13 @@
 """Command-line interface for updating projects from Cookiecutter templates."""
+import click
+
 from cutty.entrypoints.cli._main import main as _main
+from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.update import update as service_update
 
 
 @_main.command()
-def update() -> None:
+@click.argument("extra-context", nargs=-1, callback=extra_context_callback)
+def update(extra_context: dict[str, str]) -> None:
     """Update a project with changes from its template."""
     service_update()

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -3,7 +3,9 @@ import hashlib
 import json
 import tempfile
 from collections.abc import Iterator
+from collections.abc import Mapping
 from pathlib import Path
+from types import MappingProxyType
 
 import pygit2
 
@@ -83,7 +85,10 @@ def cherrypick(repositorypath: Path, reference: str) -> None:
     repository.state_cleanup()
 
 
-def update() -> None:
+def update(
+    *,
+    extra_context: Mapping[str, str] = MappingProxyType({}),
+) -> None:
     """Update a project with changes from its Cookiecutter template."""
     projectdir = Path.cwd()
     template = getprojecttemplate(projectdir)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -99,7 +99,7 @@ def update(
             template,
             outputdir=worktree,
             outputdirisproject=True,
-            extra_context=context,
+            extra_context={**context, **extra_context},
         )
 
     cherrypick(projectdir, f"refs/heads/{LATEST_BRANCH}")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -156,6 +156,32 @@ def test_update_new_variables(runner: CliRunner, repository: Path) -> None:
     assert "stable" == data["status"]
 
 
+def test_update_extra_context_new_variable(runner: CliRunner, repository: Path) -> None:
+    """It allows setting variables on the command-line."""
+    runner.invoke(
+        main,
+        ["create", "--no-input", str(repository), "project=awesome"],
+        catch_exceptions=False,
+    )
+
+    # Add project variable `status`.
+    path = repository / "cookiecutter.json"
+    data = json.loads(path.read_text())
+    data["status"] = ["alpha", "beta", "stable"]
+    path.write_text(json.dumps(data))
+    commit(pygit2.Repository(repository), message="Add status variable")
+
+    # Update the project.
+    os.chdir("awesome")
+    result = runner.invoke(main, ["update", "status=stable"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # Verify that the variable was bound.
+    path = Path(".cookiecutter.json")
+    data = json.loads(path.read_text())
+    assert "stable" == data["status"]
+
+
 def test_update_rename_projectdir(runner: CliRunner, repository: Path) -> None:
     """It generates the project in the project directory irrespective of its name."""
     runner.invoke(

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -156,6 +156,27 @@ def test_update_new_variables(runner: CliRunner, repository: Path) -> None:
     assert "stable" == data["status"]
 
 
+def test_update_extra_context_old_variable(runner: CliRunner, repository: Path) -> None:
+    """It allows setting variables on the command-line."""
+    runner.invoke(
+        main,
+        ["create", "--no-input", str(repository), "project=awesome"],
+        catch_exceptions=False,
+    )
+
+    # Update the project.
+    os.chdir("awesome")
+    result = runner.invoke(
+        main, ["update", "project=excellent"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+
+    # Verify that the variable was bound.
+    path = Path(".cookiecutter.json")
+    data = json.loads(path.read_text())
+    assert "excellent" == data["project"]
+
+
 def test_update_extra_context_new_variable(runner: CliRunner, repository: Path) -> None:
     """It allows setting variables on the command-line."""
     runner.invoke(


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty update <variable>=<value>` with new variable
- :white_check_mark: [functional] Add test for `cutty update <variable>=<value>` with existing variable
- :sparkles: [entrypoints] Add `cutty update <variable>=<value>` argument
- :sparkles: [services] Add `extra_context` parameter
- :sparkles: [services] Override .cookiecutter.json with extra-context when updating
