### PR TITLE
:sparkles: [entrypoints] Add `cutty update --no-input`

### DIFF
--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -8,6 +8,15 @@ from cutty.services.update import update as service_update
 
 @_main.command()
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
-def update(extra_context: dict[str, str]) -> None:
+@click.option(
+    "--no-input",
+    is_flag=True,
+    default=False,
+    help="Do not prompt for template variables.",
+)
+def update(
+    extra_context: dict[str, str],
+    no_input: bool,
+) -> None:
     """Update a project with changes from its template."""
-    service_update(extra_context=extra_context)
+    service_update(extra_context=extra_context, no_input=no_input)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -88,6 +88,7 @@ def cherrypick(repositorypath: Path, reference: str) -> None:
 def update(
     *,
     extra_context: Mapping[str, str] = MappingProxyType({}),
+    no_input: bool = False,
 ) -> None:
     """Update a project with changes from its Cookiecutter template."""
     projectdir = Path.cwd()
@@ -100,6 +101,7 @@ def update(
             outputdir=worktree,
             outputdirisproject=True,
             extra_context={**context, **extra_context},
+            no_input=no_input,
         )
 
     cherrypick(projectdir, f"refs/heads/{LATEST_BRANCH}")


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty update --no-input`
- :sparkles: [entrypoints] Add `cutty update --no-input`
