### PR TITLE
:sparkles: [entrypoints] Add `cutty update --cwd=<projectdir>`

### DIFF
--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -1,4 +1,7 @@
 """Command-line interface for updating projects from Cookiecutter templates."""
+import pathlib
+from typing import Optional
+
 import click
 
 from cutty.entrypoints.cli._main import main as _main
@@ -14,9 +17,19 @@ from cutty.services.update import update as service_update
     default=False,
     help="Do not prompt for template variables.",
 )
+@click.option(
+    "-C",
+    "--cwd",
+    metavar="DIR",
+    type=click.Path(
+        exists=True, file_okay=False, dir_okay=True, path_type=pathlib.Path
+    ),
+    help="Directory of the generated project.",
+)
 def update(
     extra_context: dict[str, str],
     no_input: bool,
+    cwd: Optional[pathlib.Path],
 ) -> None:
     """Update a project with changes from its template."""
-    service_update(extra_context=extra_context, no_input=no_input)
+    service_update(extra_context=extra_context, no_input=no_input, projectdir=cwd)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
+from typing import Optional
 
 import pygit2
 
@@ -87,11 +88,14 @@ def cherrypick(repositorypath: Path, reference: str) -> None:
 
 def update(
     *,
+    projectdir: Optional[Path] = None,
     extra_context: Mapping[str, str] = MappingProxyType({}),
     no_input: bool = False,
 ) -> None:
     """Update a project with changes from its Cookiecutter template."""
-    projectdir = Path.cwd()
+    if projectdir is None:
+        projectdir = Path.cwd()
+
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -254,3 +254,23 @@ def test_update_rename_projectdir(runner: CliRunner, repository: Path) -> None:
 
     # Verify that the README was updated.
     assert Path("README.md").read_text() == "# awesome\nAn awesome project.\n"
+
+
+def test_update_cwd(runner: CliRunner, repository: Path) -> None:
+    """It updates the project in the specified directory."""
+    runner.invoke(
+        main,
+        ["create", "--no-input", str(repository), "project=awesome"],
+        catch_exceptions=False,
+    )
+
+    # Update README.md in the template.
+    path = repository / "{{ cookiecutter.project }}" / "README.md"
+    path.write_text(path.read_text() + "An awesome project.\n")
+    commit(pygit2.Repository(repository), message="Update README.md")
+
+    # Update the project.
+    projectdir = Path("awesome")
+    runner.invoke(main, ["update", f"--cwd={projectdir}"], catch_exceptions=False)
+
+    assert (projectdir / "README.md").read_text() == "# awesome\nAn awesome project.\n"


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty update --cwd=<projectdir>`
- :sparkles: [services] Add parameter `projectdir` for update service
- :sparkles: [entrypoints] Add `cutty update --cwd`
