### PR TITLE
:bug: [services] Do not prepend directory to project files when `cutty create --directory` is used

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -56,10 +56,13 @@ def create(
     if not projectfiles:  # pragma: no cover
         return
 
+    strip = 0 if directory is None else len(directory.parts)
+
     if outputdirisproject:
         projectdir = outputdir
+        strip += 1
     else:
-        projectdir = outputdir / projectfiles[0].path.parts[0]
+        projectdir = outputdir / projectfiles[0].path.parts[strip]
 
     hookfiles = lazysequence(renderfiles(findhooks(templatedir), render, bindings))
 
@@ -71,7 +74,7 @@ def create(
         hookfiles,
     ) as storage:
         for projectfile in projectfiles.release():
-            if outputdirisproject:
-                path = PurePath(*projectfile.path.parts[1:])
+            if strip:
+                path = PurePath(*projectfile.path.parts[strip:])
                 projectfile = projectfile.withpath(path)
             storage.add(projectfile)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -36,7 +36,7 @@ def create(
     templatedir = getdefaultrepositoryprovider(cachedir)(template, revision=checkout)
 
     if directory is not None:
-        templatedir = templatedir.joinpath(*directory.parts)  # pragma: no cover
+        templatedir = templatedir.joinpath(*directory.parts)
 
     if outputdir is None:  # pragma: no branch
         outputdir = pathlib.Path.cwd()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -29,6 +29,7 @@ def template_directory(tmp_path: Path) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(text)
 
+    template = tmp_path / "template"
     context = {
         "project": "example",
         "license": ["MIT", "GPL-3.0", "Apache-2.0"],
@@ -36,30 +37,30 @@ def template_directory(tmp_path: Path) -> Path:
         "_extensions": ["jinja2_time.TimeExtension"],
     }
 
-    create(tmp_path / "cookiecutter.json", json.dumps(context))
+    create(template / "cookiecutter.json", json.dumps(context))
 
     create(
-        tmp_path / "{{ cookiecutter.project }}" / "README.md",
+        template / "{{ cookiecutter.project }}" / "README.md",
         """
         # {{ cookiecutter.project }}
         """,
     )
 
     create(
-        tmp_path / "{{ cookiecutter.project }}" / ".cookiecutter.json",
+        template / "{{ cookiecutter.project }}" / ".cookiecutter.json",
         """
         {{ cookiecutter | jsonify }}
         """,
     )
 
     create(
-        tmp_path / "hooks" / "post_gen_project.py",
+        template / "hooks" / "post_gen_project.py",
         """
         open("post_gen_project", mode="w")
         """,
     )
 
-    return tmp_path
+    return template
 
 
 def commit(repository: pygit2.Repository, *, message: str) -> None:

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -1,9 +1,11 @@
 """Functional tests for the create CLI."""
 from pathlib import Path
 
+import pygit2
 from click.testing import CliRunner
 
 from cutty.entrypoints.cli import main
+from tests.functional.conftest import commit
 
 
 def test_create_help(runner: CliRunner) -> None:
@@ -33,3 +35,31 @@ def test_create_inplace(runner: CliRunner, repository: Path) -> None:
     assert Path("README.md").read_text() == "# example\n"
     assert Path("post_gen_project").is_file()
     assert Path(".cookiecutter.json").is_file()
+
+
+def test_directory(runner: CliRunner, repository: Path, tmp_path: Path) -> None:
+    """It uses the template in the given subdirectory."""
+
+    def move_repository_files_to_subdirectory(
+        repositorypath: Path, directory: str
+    ) -> None:
+        repository = pygit2.Repository(repositorypath)
+        builder = repository.TreeBuilder()
+        builder.insert(
+            directory, repository.head.peel().tree.id, pygit2.GIT_FILEMODE_TREE
+        )
+        tree = repository[builder.write()]
+        repository.checkout_tree(tree)
+        commit(repository, message=f"Move files to subdirectory {directory}")
+
+    directory = "a"
+    move_repository_files_to_subdirectory(repository, directory)
+
+    result = runner.invoke(
+        main,
+        ["create", f"--directory={directory}", str(repository)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert Path("example", "README.md").is_file()


### PR DESCRIPTION
- :recycle: [functional] Store `template_directory` fixture in separate subdirectory
- :white_check_mark: [functional] Add test for `cutty create --directory=<directory>`
- :bug: [services] Strip template subdirectory from project files
- :white_check_mark: [services] Remove unused `pragma: no cover` for `directory`
