### PR TITLE
:sparkles: [services] Create .cookiecutter.json if template does not provide it

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -76,4 +76,5 @@ def cookiecutter(
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,
         createrepository=False,
+        createconfigfile=False,
     )

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -1,4 +1,5 @@
 """Create a project from a Cookiecutter template."""
+import contextlib
 import pathlib
 from collections.abc import Mapping
 from types import MappingProxyType
@@ -14,6 +15,7 @@ from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariab
 from cutty.templates.adapters.cookiecutter.config import findhooks
 from cutty.templates.adapters.cookiecutter.config import findpaths
 from cutty.templates.adapters.cookiecutter.config import loadcookiecutterconfig
+from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
 from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
 from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.renderfiles import renderfiles
@@ -66,6 +68,9 @@ def create(
         projectdir = outputdir / projectfiles[0].path.parts[strip]
 
     hookfiles = lazysequence(renderfiles(findhooks(templatedir), render, bindings))
+    projectconfigfile = createprojectconfigfile(
+        PurePath(*projectdir.relative_to(outputdir).parts), config.settings, bindings
+    )
 
     with createcookiecutterstorage(
         outputdir,
@@ -79,4 +84,9 @@ def create(
             if strip:
                 path = PurePath(*projectfile.path.parts[strip:])
                 projectfile = projectfile.withpath(path)
+
             storage.add(projectfile)
+
+        # FIXME: do not overwrite project config with --overwrite-if-exists
+        with contextlib.suppress(FileExistsError):
+            storage.add(projectconfigfile)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -33,6 +33,7 @@ def create(
     skip_if_file_exists: bool = False,
     outputdirisproject: bool = False,
     createrepository: bool = True,
+    createconfigfile: bool = True,
 ) -> None:
     """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
@@ -68,8 +69,14 @@ def create(
         projectdir = outputdir / projectfiles[0].path.parts[strip]
 
     hookfiles = lazysequence(renderfiles(findhooks(templatedir), render, bindings))
-    projectconfigfile = createprojectconfigfile(
-        PurePath(*projectdir.relative_to(outputdir).parts), config.settings, bindings
+    projectconfigfile = (
+        createprojectconfigfile(
+            PurePath(*projectdir.relative_to(outputdir).parts),
+            config.settings,
+            bindings,
+        )
+        if createconfigfile
+        else None
     )
 
     with createcookiecutterstorage(
@@ -87,6 +94,7 @@ def create(
 
             storage.add(projectfile)
 
-        # FIXME: do not overwrite project config with --overwrite-if-exists
-        with contextlib.suppress(FileExistsError):
-            storage.add(projectconfigfile)
+        if projectconfigfile is not None:
+            # FIXME: do not overwrite project config with --overwrite-if-exists
+            with contextlib.suppress(FileExistsError):
+                storage.add(projectconfigfile)

--- a/src/cutty/templates/adapters/cookiecutter/config.py
+++ b/src/cutty/templates/adapters/cookiecutter/config.py
@@ -45,7 +45,7 @@ def loadvariable(name: str, value: Any) -> Variable:
 
 
 def loadcookiecutterconfig(template: str, path: Path) -> Config:
-    """Load the configurations for a Cookiecutter template."""
+    """Load the configuration for a Cookiecutter template."""
     text = (path / "cookiecutter.json").read_text()
     data = json.loads(text)
 

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -1,1 +1,19 @@
 """Configuration for projects generated from Cookiecutter templates."""
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from cutty.filestorage.domain.files import RegularFile
+from cutty.filesystems.domain.purepath import PurePath
+from cutty.templates.domain.bindings import Binding
+
+
+def createprojectconfigfile(
+    project: PurePath, settings: dict[str, Any], bindings: Iterable[Binding]
+) -> RegularFile:
+    """Create a JSON file with the settings and bindings for a project."""
+    path = project / ".cookiecutter.json"
+    data = settings | {binding.name: binding.value for binding in bindings}
+    blob = json.dumps(data).encode()
+
+    return RegularFile(path, blob)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -1,0 +1,1 @@
+"""Configuration for projects generated from Cookiecutter templates."""

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -7,6 +7,7 @@ from tests.functional.conftest import RunCutty
 from tests.util.files import project_files
 from tests.util.files import template_files
 from tests.util.git import move_repository_files_to_subdirectory
+from tests.util.git import removefile
 from tests.util.git import updatefile
 
 
@@ -32,6 +33,15 @@ def test_no_repository(runcutty: RunCutty, repository: Path) -> None:
     runcutty("cookiecutter", str(repository))
 
     assert not Path("example", ".git").is_dir()
+
+
+def test_no_cookiecutter_json(runcutty: RunCutty, repository: Path) -> None:
+    """It does not create .cookiecutter.json unless the template provides it."""
+    removefile(repository / "{{ cookiecutter.project }}" / ".cookiecutter.json")
+
+    runcutty("cookiecutter", str(repository))
+
+    assert not Path("example", ".cookiecutter.json").is_file()
 
 
 def test_no_input(runcutty: RunCutty, repository: Path) -> None:

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -5,6 +5,7 @@ from tests.functional.conftest import RunCutty
 from tests.util.files import project_files
 from tests.util.files import template_files
 from tests.util.git import move_repository_files_to_subdirectory
+from tests.util.git import removefile
 
 
 def test_help(runcutty: RunCutty) -> None:
@@ -33,6 +34,15 @@ def test_files(runcutty: RunCutty, repository: Path) -> None:
     assert template_files(repository) == project_files("example") - {
         Path("post_gen_project")
     }
+
+
+def test_cookiecutter_json(runcutty: RunCutty, repository: Path) -> None:
+    """It always creates .cookiecutter.json."""
+    removefile(repository / "{{ cookiecutter.project }}" / ".cookiecutter.json")
+
+    runcutty("create", str(repository))
+
+    assert Path("example", ".cookiecutter.json").is_file()
 
 
 def test_create_inplace(runcutty: RunCutty, repository: Path) -> None:

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -1,8 +1,6 @@
 """Functional tests for the create CLI."""
 from pathlib import Path
 
-import pytest
-
 from tests.functional.conftest import RunCutty
 from tests.util.files import project_files
 from tests.util.files import template_files
@@ -38,7 +36,6 @@ def test_files(runcutty: RunCutty, repository: Path) -> None:
     }
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_cookiecutter_json(runcutty: RunCutty, repository: Path) -> None:
     """It always creates .cookiecutter.json."""
     removefile(repository / "{{ cookiecutter.project }}" / ".cookiecutter.json")

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -1,6 +1,8 @@
 """Functional tests for the create CLI."""
 from pathlib import Path
 
+import pytest
+
 from tests.functional.conftest import RunCutty
 from tests.util.files import project_files
 from tests.util.files import template_files
@@ -36,6 +38,7 @@ def test_files(runcutty: RunCutty, repository: Path) -> None:
     }
 
 
+@pytest.mark.xfail(reason="TODO")
 def test_cookiecutter_json(runcutty: RunCutty, repository: Path) -> None:
     """It always creates .cookiecutter.json."""
     removefile(repository / "{{ cookiecutter.project }}" / ".cookiecutter.json")

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -1,0 +1,21 @@
+"""Unit tests for cutty.templates.adapters.cookiecutter.projectconfig."""
+import json
+
+from cutty.filesystems.domain.purepath import PurePath
+from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
+from cutty.templates.domain.bindings import Binding
+
+
+def test_createprojectconfigfile() -> None:
+    """It creates a JSON file with the settings and bindings."""
+    project = PurePath("example")
+    settings = {
+        "_template": "https://example.com/repository.git",
+        "_extensions": ["jinja2_time.TimeExtension"],
+    }
+    bindings = [Binding("project", "example"), Binding("license", "MIT")]
+
+    file = createprojectconfigfile(project, settings, bindings)
+
+    data = json.loads(file.blob.decode())
+    assert data.keys() == settings.keys() | {binding.name for binding in bindings}


### PR DESCRIPTION
- :recycle: [functional] Break up `cutty create` tests
- :white_check_mark: [functional] Add test for .cookiecutter.json creation
- :bulb: [templates] Fix typo in docstring
- :white_check_mark: [functional] Apply XFAIL marker
- :white_check_mark: [templates] Add test for createprojectconfigfile
- :tada: [templates] Add module cookiecutter.projectconfig to adapters
- :sparkles: [templates] Add createprojectconfigfile function to adapters.cookiecutter
- :rewind: [functional] Revert "Apply XFAIL marker"
- :sparkles: [services] Write .cookiecutter.json if the project does not provide it
- :white_check_mark: [functional] Add test that `cookiecutter` does not create .cookiecutter.json
- :sparkles: [services] Do not create .cookiecutter.json with `cutty cookiecutter`
