### PR TITLE
:sparkles: [services] Support dict variables when updating projects

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -7,7 +7,8 @@ import click
 
 from cutty.entrypoints.cli._main import main as _main
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.create import create as service_create
+from cutty.services.create import create2 as service_create
+from cutty.templates.domain.bindings import Binding
 
 
 @_main.command()
@@ -66,9 +67,10 @@ def cookiecutter(
     skip_if_file_exists: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
+    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
     service_create(
         template,
-        extra_context=extra_context,
+        extrabindings=extrabindings,
         no_input=no_input,
         checkout=checkout,
         outputdir=output_dir,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -7,7 +7,7 @@ import click
 
 from cutty.entrypoints.cli._main import main as _main
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.create import create2 as service_create
+from cutty.services.create import create as service_create
 from cutty.templates.domain.bindings import Binding
 
 

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -6,7 +6,8 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli._main import main as _main
-from cutty.services.create import create as service_create
+from cutty.services.create import create2 as service_create
+from cutty.templates.domain.bindings import Binding
 
 
 def extra_context_callback(
@@ -92,9 +93,10 @@ def create(
     in_place: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
+    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
     service_create(
         template,
-        extra_context=extra_context,
+        extrabindings=extrabindings,
         no_input=no_input,
         checkout=checkout,
         outputdir=output_dir,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli._main import main as _main
-from cutty.services.create import create2 as service_create
+from cutty.services.create import create as service_create
 from cutty.templates.domain.bindings import Binding
 
 

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -6,7 +6,8 @@ import click
 
 from cutty.entrypoints.cli._main import main as _main
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.update import update as service_update
+from cutty.services.update import update2 as service_update
+from cutty.templates.domain.bindings import Binding
 
 
 @_main.command()
@@ -32,4 +33,5 @@ def update(
     cwd: Optional[pathlib.Path],
 ) -> None:
     """Update a project with changes from its template."""
-    service_update(extra_context=extra_context, no_input=no_input, projectdir=cwd)
+    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+    service_update(extrabindings=extrabindings, no_input=no_input, projectdir=cwd)

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -6,7 +6,7 @@ import click
 
 from cutty.entrypoints.cli._main import main as _main
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.update import update2 as service_update
+from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
 
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -23,7 +23,7 @@ from cutty.templates.domain.renderfiles import renderfiles
 def create2(
     template: str,
     *,
-    extrabindings: Sequence[Binding],
+    extrabindings: Sequence[Binding] = (),
     no_input: bool = False,
     checkout: Optional[str] = None,
     outputdir: Optional[pathlib.Path] = None,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -36,6 +36,8 @@ def create(
     createconfigfile: bool = True,
 ) -> None:
     """Generate a project from a Cookiecutter template."""
+    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+
     cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
     templatedir = getdefaultrepositoryprovider(cachedir)(template, revision=checkout)
 
@@ -51,7 +53,7 @@ def create(
         config.variables,
         render,
         interactive=not no_input,
-        bindings=[Binding(key, value) for key, value in extra_context.items()],
+        bindings=extrabindings,
     )
 
     projectfiles = lazysequence(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -20,7 +20,7 @@ from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.renderfiles import renderfiles
 
 
-def create2(
+def create(
     template: str,
     *,
     extrabindings: Sequence[Binding] = (),

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -1,9 +1,7 @@
 """Create a project from a Cookiecutter template."""
 import contextlib
 import pathlib
-from collections.abc import Mapping
 from collections.abc import Sequence
-from types import MappingProxyType
 from typing import Optional
 
 import platformdirs
@@ -20,37 +18,6 @@ from cutty.templates.adapters.cookiecutter.projectconfig import createprojectcon
 from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
 from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.renderfiles import renderfiles
-
-
-def create(
-    template: str,
-    *,
-    extra_context: Mapping[str, str] = MappingProxyType({}),
-    no_input: bool = False,
-    checkout: Optional[str] = None,
-    outputdir: Optional[pathlib.Path] = None,
-    directory: Optional[pathlib.PurePosixPath] = None,
-    overwrite_if_exists: bool = False,
-    skip_if_file_exists: bool = False,
-    outputdirisproject: bool = False,
-    createrepository: bool = True,
-    createconfigfile: bool = True,
-) -> None:
-    """Generate a project from a Cookiecutter template."""
-    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-    create2(
-        template,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        checkout=checkout,
-        outputdir=outputdir,
-        directory=directory,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
-        outputdirisproject=outputdirisproject,
-        createrepository=createrepository,
-        createconfigfile=createconfigfile,
-    )
 
 
 def create2(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -2,6 +2,7 @@
 import contextlib
 import pathlib
 from collections.abc import Mapping
+from collections.abc import Sequence
 from types import MappingProxyType
 from typing import Optional
 
@@ -37,7 +38,36 @@ def create(
 ) -> None:
     """Generate a project from a Cookiecutter template."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+    create2(
+        template,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        outputdir=outputdir,
+        directory=directory,
+        overwrite_if_exists=overwrite_if_exists,
+        skip_if_file_exists=skip_if_file_exists,
+        outputdirisproject=outputdirisproject,
+        createrepository=createrepository,
+        createconfigfile=createconfigfile,
+    )
 
+
+def create2(
+    template: str,
+    *,
+    extrabindings: Sequence[Binding],
+    no_input: bool = False,
+    checkout: Optional[str] = None,
+    outputdir: Optional[pathlib.Path] = None,
+    directory: Optional[pathlib.PurePosixPath] = None,
+    overwrite_if_exists: bool = False,
+    skip_if_file_exists: bool = False,
+    outputdirisproject: bool = False,
+    createrepository: bool = True,
+    createconfigfile: bool = True,
+) -> None:
+    """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
     templatedir = getdefaultrepositoryprovider(cachedir)(template, revision=checkout)
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -86,7 +86,7 @@ def cherrypick(repositorypath: Path, reference: str) -> None:
     repository.state_cleanup()
 
 
-def update2(
+def update(
     *,
     projectdir: Optional[Path] = None,
     extrabindings: Sequence[Binding] = (),

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -14,7 +14,8 @@ from cutty.compat.contextlib import contextmanager
 from cutty.filestorage.adapters.observers.git import commit
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
-from cutty.services.create import create
+from cutty.services.create import create2
+from cutty.templates.domain.bindings import Binding
 
 
 def getprojecttemplate(projectdir: Path) -> str:
@@ -100,11 +101,13 @@ def update(
     context = getprojectcontext(projectdir)
 
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:
-        create(
+        extra_context = {**context, **extra_context}
+        extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+        create2(
             template,
             outputdir=worktree,
             outputdirisproject=True,
-            extra_context={**context, **extra_context},
+            extrabindings=extrabindings,
             no_input=no_input,
         )
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -21,7 +21,9 @@ from cutty.templates.domain.bindings import Binding
 def getprojecttemplate(projectdir: Path) -> str:
     """Return the location of the project template."""
     context = getprojectcontext(projectdir)
-    result: str = context["_template"]
+    result = context["_template"]
+    if not isinstance(result, str):
+        raise TypeError(f"{projectdir}: _template must be 'str', got {result!r}")
     return result
 
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,6 +4,7 @@ import json
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 from typing import Optional
 from typing import Sequence
 
@@ -20,18 +21,15 @@ from cutty.templates.domain.bindings import Binding
 def getprojecttemplate(projectdir: Path) -> str:
     """Return the location of the project template."""
     context = getprojectcontext(projectdir)
-    return context["_template"]
+    result: str = context["_template"]
+    return result
 
 
-def getprojectcontext(projectdir: Path) -> dict[str, str]:
+def getprojectcontext(projectdir: Path) -> dict[str, Any]:
     """Return the Cookiecutter context of the project."""
     text = (projectdir / ".cookiecutter.json").read_text()
     data = json.loads(text)
-    return {
-        key: value
-        for key, value in data.items()
-        if isinstance(key, str) and isinstance(value, str)
-    }
+    return {key: value for key, value in data.items() if isinstance(key, str)}
 
 
 def getprojectbindings(projectdir: Path) -> Sequence[Binding]:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -3,9 +3,7 @@ import hashlib
 import json
 import tempfile
 from collections.abc import Iterator
-from collections.abc import Mapping
 from pathlib import Path
-from types import MappingProxyType
 from typing import Optional
 from typing import Sequence
 
@@ -86,17 +84,6 @@ def cherrypick(repositorypath: Path, reference: str) -> None:
 
     commit(repository, message=UPDATE_MESSAGE)
     repository.state_cleanup()
-
-
-def update(
-    *,
-    projectdir: Optional[Path] = None,
-    extra_context: Mapping[str, str] = MappingProxyType({}),
-    no_input: bool = False,
-) -> None:
-    """Update a project with changes from its Cookiecutter template."""
-    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-    update2(projectdir=projectdir, extrabindings=extrabindings, no_input=no_input)
 
 
 def update2(

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -94,13 +94,14 @@ def update(
     no_input: bool = False,
 ) -> None:
     """Update a project with changes from its Cookiecutter template."""
+    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+
     if projectdir is None:
         projectdir = Path.cwd()
 
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
     bindings = [Binding(key, value) for key, value in context.items()]
-    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
     extrabindings = bindings + extrabindings
 
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 from typing import Optional
+from typing import Sequence
 
 import pygit2
 
@@ -95,14 +96,23 @@ def update(
 ) -> None:
     """Update a project with changes from its Cookiecutter template."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+    update2(projectdir=projectdir, extrabindings=extrabindings, no_input=no_input)
 
+
+def update2(
+    *,
+    projectdir: Optional[Path] = None,
+    extrabindings: Sequence[Binding] = (),
+    no_input: bool = False,
+) -> None:
+    """Update a project with changes from its Cookiecutter template."""
     if projectdir is None:
         projectdir = Path.cwd()
 
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
     bindings = [Binding(key, value) for key, value in context.items()]
-    extrabindings = bindings + extrabindings
+    extrabindings = bindings + list(extrabindings)
 
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:
         create(

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -99,8 +99,9 @@ def update(
 
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
-    extra_context = {**context, **extra_context}
+    bindings = [Binding(key, value) for key, value in context.items()]
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+    extrabindings = bindings + extrabindings
 
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:
         create(

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -34,6 +34,12 @@ def getprojectcontext(projectdir: Path) -> dict[str, str]:
     }
 
 
+def getprojectbindings(projectdir: Path) -> Sequence[Binding]:
+    """Return the variable bindings of the project."""
+    context = getprojectcontext(projectdir)
+    return [Binding(key, value) for key, value in context.items()]
+
+
 def checkoutemptytree(repositorypath: Path) -> None:
     """Check out an empty tree from the repository."""
     repository = pygit2.Repository(repositorypath)
@@ -97,9 +103,8 @@ def update(
         projectdir = Path.cwd()
 
     template = getprojecttemplate(projectdir)
-    context = getprojectcontext(projectdir)
-    bindings = [Binding(key, value) for key, value in context.items()]
-    extrabindings = bindings + list(extrabindings)
+    bindings = getprojectbindings(projectdir)
+    extrabindings = list(bindings) + list(extrabindings)
 
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:
         create(

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -99,10 +99,10 @@ def update(
 
     template = getprojecttemplate(projectdir)
     context = getprojectcontext(projectdir)
+    extra_context = {**context, **extra_context}
+    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
 
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:
-        extra_context = {**context, **extra_context}
-        extrabindings = [Binding(key, value) for key, value in extra_context.items()]
         create(
             template,
             outputdir=worktree,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -14,7 +14,7 @@ from cutty.compat.contextlib import contextmanager
 from cutty.filestorage.adapters.observers.git import commit
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
-from cutty.services.create import create2
+from cutty.services.create import create
 from cutty.templates.domain.bindings import Binding
 
 
@@ -103,7 +103,7 @@ def update(
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:
         extra_context = {**context, **extra_context}
         extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-        create2(
+        create(
             template,
             outputdir=worktree,
             outputdirisproject=True,

--- a/src/cutty/templates/adapters/cookiecutter/render.py
+++ b/src/cutty/templates/adapters/cookiecutter/render.py
@@ -17,7 +17,6 @@ from cutty.templates.domain.render import createrenderer
 from cutty.templates.domain.render import defaultrenderregistry
 from cutty.templates.domain.render import Renderer
 from cutty.templates.domain.render import RenderRegistry
-from cutty.templates.domain.render import T
 
 
 def is_binary(blob: bytes) -> bool:
@@ -35,16 +34,20 @@ def asstringlist(settings: dict[str, Any], name: str) -> list[str]:
     return value
 
 
+# Avoid generic render functions for lists and dicts.
+# https://github.com/agronholm/typeguard/issues/196
+
+
 def renderlist(
-    values: list[T], bindings: Sequence[Binding], render: Renderer
-) -> list[T]:
+    values: list[Any], bindings: Sequence[Binding], render: Renderer
+) -> list[Any]:
     """Render a list."""
     return [render(value, bindings) for value in values]
 
 
 def renderdict(
-    mapping: dict[str, T], bindings: Sequence[Binding], render: Renderer
-) -> dict[str, T]:
+    mapping: dict[str, Any], bindings: Sequence[Binding], render: Renderer
+) -> dict[str, Any]:
     """Render a dictionary."""
     return {
         render(key, bindings): render(value, bindings) for key, value in mapping.items()

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -205,7 +205,6 @@ def test_update_cwd(runcutty: RunCutty, repository: Path, project: Path) -> None
     assert (project / "README.md").read_text() == "# awesome\nAn awesome project.\n"
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_update_dictvariable(runcutty: RunCutty, repository: Path) -> None:
     """It loads dict variables from the project configuration."""
     # Add a dict variable with image types to the template.

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -205,6 +205,7 @@ def test_update_cwd(runcutty: RunCutty, repository: Path, project: Path) -> None
     assert (project / "README.md").read_text() == "# awesome\nAn awesome project.\n"
 
 
+@pytest.mark.xfail(reason="TODO")
 def test_update_dictvariable(runcutty: RunCutty, repository: Path) -> None:
     """It loads dict variables from the project configuration."""
     # Add a dict variable with image types to the template.

--- a/tests/unit/entrypoints/cli/test_create.py
+++ b/tests/unit/entrypoints/cli/test_create.py
@@ -2,12 +2,14 @@
 from typing import Any
 from typing import Callable
 from typing import Protocol
+from typing import Sequence
 
 import click
 import pytest
 from click.testing import CliRunner
 
 from cutty.entrypoints.cli.create import create
+from cutty.templates.domain.bindings import Binding
 
 
 RunnerDecorator = Callable[[Callable[..., None]], Callable[..., None]]
@@ -50,9 +52,9 @@ def test_extra_context_happy(runner: RunnerDecoratorFactory) -> None:
     """It parses additional arguments into key-value pairs."""
 
     @runner(create, monkeypatch="cutty.entrypoints.cli.create.service_create")
-    def invoke(*args: Any, extra_context: dict[str, str], **kwargs: Any) -> None:
+    def invoke(*args: Any, extrabindings: Sequence[Binding], **kwargs: Any) -> None:
         """Main function."""
-        assert extra_context == {"project": "example"}
+        assert extrabindings == [Binding("project", "example")]
 
     invoke("https://example.com/repository.git", "project=example")
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -21,6 +21,16 @@ def test_getprojecttemplate(tmp_path: Path) -> None:
     assert template == getprojecttemplate(tmp_path)
 
 
+def test_getprojecttemplate_typeerror(tmp_path: Path) -> None:
+    """It checks that `_template` key is a string."""
+    template = None
+    text = json.dumps({"_template": template})
+    (tmp_path / ".cookiecutter.json").write_text(text)
+
+    with pytest.raises(TypeError):
+        getprojecttemplate(tmp_path)
+
+
 def test_getprojectcontext(tmp_path: Path) -> None:
     """It returns the persisted Cookiecutter context."""
     context = {"project": "example"}


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty update` with dict variables
- :white_check_mark: [functional] Apply XFAIL marker
- :recycle: [services] Extract variable `extrabindings`
- :recycle: [services] Extract function `create2`
- :recycle: [services] Inline function `create` in update service
- :recycle: [entrypoints] Inline function `create` in `cutty cookiecutter`
- :recycle: [entrypoints] Inline function `create` in `cutty create`
- :recycle: [services] Remove function `create`
- :recycle: [services] Provide default argument for `extrabindings`
- :recycle: [entrypoints] Adapt monkeypatch in test to `create` signature
- :recycle: [service] Rename function `create2` to `create`
- :recycle: [service] Slide statements
- :recycle: [services] Concatenate bindings instead of merging dicts
- :recycle: [services] Slide statement
- :recycle: [services] Extract function `update2`
- :recycle: [entrypoints] Inline function `update` in `cutty update`
- :recycle: [services] Remove function `update`
- :recycle: [services] Rename function `update2` to `update`
- :recycle: [services] Extract function `getprojectbindings`
- :rewind: [functional] Revert "Apply XFAIL marker"
- :sparkles: [services] Do not restrict project context to `str` entries
- :white_check_mark: [services] Add test for type check when reading `_template`
- :sparkles: [services] Add type check for `_template` entry in project config
