### PR TITLE
:sparkles: [templates] Do not store settings in project configuration

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -70,9 +70,7 @@ def create(
     hookfiles = lazysequence(renderfiles(findhooks(templatedir), render, bindings))
     projectconfigfile = (
         createprojectconfigfile(
-            PurePath(*projectdir.relative_to(outputdir).parts),
-            config.settings,
-            bindings,
+            PurePath(*projectdir.relative_to(outputdir).parts), bindings
         )
         if createconfigfile
         else None

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -1,7 +1,6 @@
 """Configuration for projects generated from Cookiecutter templates."""
 import json
 from collections.abc import Iterable
-from typing import Any
 
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filesystems.domain.purepath import PurePath
@@ -9,11 +8,11 @@ from cutty.templates.domain.bindings import Binding
 
 
 def createprojectconfigfile(
-    project: PurePath, settings: dict[str, Any], bindings: Iterable[Binding]
+    project: PurePath, bindings: Iterable[Binding]
 ) -> RegularFile:
     """Create a JSON file with the settings and bindings for a project."""
     path = project / ".cookiecutter.json"
-    data = settings | {binding.name: binding.value for binding in bindings}
+    data = {binding.name: binding.value for binding in bindings}
     blob = json.dumps(data).encode()
 
     return RegularFile(path, blob)

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -248,3 +248,17 @@ def test_update_dictvariable(runcutty: RunCutty, repository: Path) -> None:
     runcutty("update", f"--cwd={project}")
 
     assert pngimages == projectvariable(project, "images")
+
+
+def test_update_private_variables(
+    runcutty: RunCutty, repository: Path, project: Path
+) -> None:
+    """It does not bind private variables from the project configuration."""
+    # Add another Jinja extension to `_extensions`.
+    extensions: list[str] = projectvariable(project, "_extensions")
+    extensions.append("jinja2.ext.i18n")
+    updateprojectvariable(repository, "_extensions", extensions)
+
+    runcutty("update", f"--cwd={project}")
+
+    assert extensions == projectvariable(project, "_extensions")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -27,8 +27,8 @@ def project(runcutty: RunCutty, repository: Path) -> Path:
     return project
 
 
-def addprojectvariable(repository: Path, name: str, value: Any) -> None:
-    """Add a project variable to the template."""
+def updateprojectvariable(repository: Path, name: str, value: Any) -> None:
+    """Add or update a project variable in the template."""
     path = repository / "cookiecutter.json"
     data = json.loads(path.read_text())
     data[name] = value
@@ -129,7 +129,7 @@ def test_update_new_variables(
     runcutty: RunCutty, repository: Path, project: Path
 ) -> None:
     """It prompts for variables added after the last project generation."""
-    addprojectvariable(repository, "status", ["alpha", "beta", "stable"])
+    updateprojectvariable(repository, "status", ["alpha", "beta", "stable"])
 
     with chdir(project):
         runcutty("update", input="3\n")
@@ -151,7 +151,7 @@ def test_update_extra_context_new_variable(
     runcutty: RunCutty, repository: Path, project: Path
 ) -> None:
     """It allows setting variables on the command-line."""
-    addprojectvariable(repository, "status", ["alpha", "beta", "stable"])
+    updateprojectvariable(repository, "status", ["alpha", "beta", "stable"])
 
     with chdir(project):
         runcutty("update", "status=stable")
@@ -161,7 +161,7 @@ def test_update_extra_context_new_variable(
 
 def test_update_no_input(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It does not prompt for variables added after the last project generation."""
-    addprojectvariable(repository, "status", ["alpha", "beta", "stable"])
+    updateprojectvariable(repository, "status", ["alpha", "beta", "stable"])
 
     with chdir(project):
         runcutty("update", "--no-input", input="3\n")
@@ -221,7 +221,7 @@ def test_update_dictvariable(runcutty: RunCutty, repository: Path) -> None:
         },
     }
 
-    addprojectvariable(repository, "images", images)
+    updateprojectvariable(repository, "images", images)
 
     # Create a project using only PNG images.
     pngimages = {key: value for key, value in images.items() if key == "png"}

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -7,15 +7,11 @@ from cutty.templates.domain.bindings import Binding
 
 
 def test_createprojectconfigfile() -> None:
-    """It creates a JSON file with the settings and bindings."""
+    """It creates a JSON file with the bindings."""
     project = PurePath("example")
-    settings = {
-        "_template": "https://example.com/repository.git",
-        "_extensions": ["jinja2_time.TimeExtension"],
-    }
     bindings = [Binding("project", "example"), Binding("license", "MIT")]
 
-    file = createprojectconfigfile(project, settings, bindings)
+    file = createprojectconfigfile(project, bindings)
 
     data = json.loads(file.blob.decode())
-    assert data.keys() == settings.keys() | {binding.name for binding in bindings}
+    assert data.keys() == {binding.name for binding in bindings}


### PR DESCRIPTION
- :recycle: [functional] Rename `addprojectvariable` to `updateprojectvariable`
- :white_check_mark: [functional] Add test for updating with private variables
- :white_check_mark: [templates] Adapt test for project configuration to omit settings
- :sparkles: [templates] Do not store settings in project configuration
