### PR TITLE
:sparkles: [templates] Store template location in cutty.json

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -69,7 +69,7 @@ def create(
     hookfiles = lazysequence(renderfiles(findhooks(templatedir), render, bindings))
     projectconfigfile = (
         createprojectconfigfile(
-            PurePath(*projectdir.relative_to(outputdir).parts), bindings
+            PurePath(*projectdir.relative_to(outputdir).parts), bindings, template
         )
         if createconfigfile
         else None

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -8,7 +8,7 @@ from cutty.templates.domain.bindings import Binding
 
 
 def createprojectconfigfile(
-    project: PurePath, bindings: Iterable[Binding], template: str = ""
+    project: PurePath, bindings: Iterable[Binding], template: str
 ) -> RegularFile:
     """Create a JSON file with the settings and bindings for a project."""
     path = project / "cutty.json"

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -8,11 +8,13 @@ from cutty.templates.domain.bindings import Binding
 
 
 def createprojectconfigfile(
-    project: PurePath, bindings: Iterable[Binding]
+    project: PurePath, bindings: Iterable[Binding], template: str = ""
 ) -> RegularFile:
     """Create a JSON file with the settings and bindings for a project."""
     path = project / "cutty.json"
-    data = {binding.name: binding.value for binding in bindings}
+    data = {binding.name: binding.value for binding in bindings} | {
+        "_template": template
+    }
     blob = json.dumps(data).encode()
 
     return RegularFile(path, blob)

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -8,10 +8,11 @@ from cutty.templates.domain.bindings import Binding
 
 def test_createprojectconfigfile_bindings() -> None:
     """It creates a JSON file with the bindings."""
+    template = "https://example.com/repository.git"
     project = PurePath("example")
     bindings = [Binding("project", "example"), Binding("license", "MIT")]
 
-    file = createprojectconfigfile(project, bindings)
+    file = createprojectconfigfile(project, bindings, template)
 
     data = json.loads(file.blob.decode())
     assert all(binding.name in data for binding in bindings)

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -15,3 +15,14 @@ def test_createprojectconfigfile_bindings() -> None:
 
     data = json.loads(file.blob.decode())
     assert all(binding.name in data for binding in bindings)
+
+
+def test_createprojectconfigfile_template() -> None:
+    """It creates a JSON file containing the template location."""
+    template = "https://example.com/repository.git"
+    project = PurePath("example")
+    bindings = [Binding("Project", "example")]
+
+    file = createprojectconfigfile(project, bindings, template)
+
+    assert "_template" in json.loads(file.blob.decode())

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -6,7 +6,7 @@ from cutty.templates.adapters.cookiecutter.projectconfig import createprojectcon
 from cutty.templates.domain.bindings import Binding
 
 
-def test_createprojectconfigfile() -> None:
+def test_createprojectconfigfile_bindings() -> None:
     """It creates a JSON file with the bindings."""
     project = PurePath("example")
     bindings = [Binding("project", "example"), Binding("license", "MIT")]
@@ -14,4 +14,4 @@ def test_createprojectconfigfile() -> None:
     file = createprojectconfigfile(project, bindings)
 
     data = json.loads(file.blob.decode())
-    assert data.keys() == {binding.name for binding in bindings}
+    assert all(binding.name in data for binding in bindings)


### PR DESCRIPTION
- :white_check_mark: [templates] Modify test for `createprojectconfigfile` to allow additional entries
- :white_check_mark: [templates] Add test for `createprojectconfigfile` with template
- :sparkles: [templates] Store template location in cutty.json
- :sparkles: [services] Store template location in cutty.json
- :recycle: [templates] Require `template` argument in `createprojectconfigfile`
