### PR TITLE
:sparkles: [services] Read project configuration from cutty.json when updating

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -29,7 +29,7 @@ def getprojecttemplate(projectdir: Path) -> str:
 
 def getprojectcontext(projectdir: Path) -> dict[str, Any]:
     """Return the Cookiecutter context of the project."""
-    text = (projectdir / ".cookiecutter.json").read_text()
+    text = (projectdir / "cutty.json").read_text()
     data = json.loads(text)
     return {key: value for key, value in data.items() if isinstance(key, str)}
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -262,3 +262,16 @@ def test_update_private_variables(
     runcutty("update", f"--cwd={project}")
 
     assert extensions == projectvariable(project, "_extensions")
+
+
+def test_update_no_dot_cookiecutter_json(runcutty: RunCutty, repository: Path) -> None:
+    """It does not require .cookiecutter.json in the project."""
+    removefile(repository / "{{ cookiecutter.project }}" / ".cookiecutter.json")
+
+    project = Path("example")
+
+    runcutty("create", str(repository))
+
+    updatefile(repository / "{{ cookiecutter.project }}" / "LICENSE", "")
+
+    runcutty("update", f"--cwd={project}")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -13,10 +13,10 @@ from tests.util.git import commit
 
 
 def test_getprojecttemplate(tmp_path: Path) -> None:
-    """It returns the `_template` key from .cookiecutter.json."""
+    """It returns the `_template` key from cutty.json."""
     template = "https://example.com/repository.git"
     text = json.dumps({"_template": template})
-    (tmp_path / ".cookiecutter.json").write_text(text)
+    (tmp_path / "cutty.json").write_text(text)
 
     assert template == getprojecttemplate(tmp_path)
 
@@ -25,7 +25,7 @@ def test_getprojecttemplate_typeerror(tmp_path: Path) -> None:
     """It checks that `_template` key is a string."""
     template = None
     text = json.dumps({"_template": template})
-    (tmp_path / ".cookiecutter.json").write_text(text)
+    (tmp_path / "cutty.json").write_text(text)
 
     with pytest.raises(TypeError):
         getprojecttemplate(tmp_path)
@@ -35,7 +35,7 @@ def test_getprojectcontext(tmp_path: Path) -> None:
     """It returns the persisted Cookiecutter context."""
     context = {"project": "example"}
     text = json.dumps(context)
-    (tmp_path / ".cookiecutter.json").write_text(text)
+    (tmp_path / "cutty.json").write_text(text)
 
     assert context == getprojectcontext(tmp_path)
 


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty update` without .cookiecutter.json
- :white_check_mark: [services] Use cutty.json in tests for `getproject{context,template}`
- :sparkles: [services] Read project configuration from cutty.json when updating
