### PR TITLE
:recycle: [functional] Remove .cookiecutter.json from template fixture

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -72,13 +72,6 @@ def template_directory(tmp_path: Path) -> Path:
     )
 
     create(
-        template / "{{ cookiecutter.project }}" / ".cookiecutter.json",
-        """
-        {{ cookiecutter | jsonify }}
-        """,
-    )
-
-    create(
         template / "hooks" / "post_gen_project.py",
         """
         open("post_gen_project", mode="w")

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -44,6 +44,13 @@ def test_no_cookiecutter_json(runcutty: RunCutty, repository: Path) -> None:
     assert not Path("example", ".cookiecutter.json").is_file()
 
 
+def test_no_cutty_json(runcutty: RunCutty, repository: Path) -> None:
+    """It does not create a cutty.json file."""
+    runcutty("cookiecutter", str(repository))
+
+    assert not Path("example", "cutty.json").is_file()
+
+
 def test_no_input(runcutty: RunCutty, repository: Path) -> None:
     """It does not prompt for variables."""
     runcutty("cookiecutter", "--no-input", str(repository))

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -7,7 +7,6 @@ from tests.functional.conftest import RunCutty
 from tests.util.files import project_files
 from tests.util.files import template_files
 from tests.util.git import move_repository_files_to_subdirectory
-from tests.util.git import removefile
 from tests.util.git import updatefile
 
 
@@ -33,15 +32,6 @@ def test_no_repository(runcutty: RunCutty, repository: Path) -> None:
     runcutty("cookiecutter", str(repository))
 
     assert not Path("example", ".git").is_dir()
-
-
-def test_no_cookiecutter_json(runcutty: RunCutty, repository: Path) -> None:
-    """It does not create .cookiecutter.json unless the template provides it."""
-    removefile(repository / "{{ cookiecutter.project }}" / ".cookiecutter.json")
-
-    runcutty("cookiecutter", str(repository))
-
-    assert not Path("example", ".cookiecutter.json").is_file()
 
 
 def test_no_cutty_json(runcutty: RunCutty, repository: Path) -> None:

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -18,13 +18,18 @@ def test_create_help(runcutty: RunCutty) -> None:
     runcutty("cookiecutter", "--help")
 
 
-def test_create_cookiecutter(runcutty: RunCutty, repository: Path) -> None:
+def test_default(runcutty: RunCutty, repository: Path) -> None:
+    """It generates a project."""
+    runcutty("cookiecutter", str(repository))
+
+    assert template_files(repository) == project_files("example") - {EXTRA}
+
+
+def test_input(runcutty: RunCutty, repository: Path) -> None:
     """It generates a project."""
     runcutty("cookiecutter", str(repository), input="foobar\n\n\n")
 
     assert Path("foobar", "README.md").read_text() == "# foobar\n"
-    assert Path("foobar", "post_gen_project").is_file()
-    assert Path("foobar", ".cookiecutter.json").is_file()
 
 
 def test_no_repository(runcutty: RunCutty, repository: Path) -> None:

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -58,9 +58,7 @@ def test_create_inplace(runcutty: RunCutty, repository: Path) -> None:
     """It generates the project files in the current directory."""
     runcutty("create", "--no-input", "--in-place", str(repository))
 
-    assert Path("README.md").read_text() == "# example\n"
-    assert Path("post_gen_project").is_file()
-    assert Path(".cookiecutter.json").is_file()
+    assert template_files(repository) == project_files(".") - EXTRA
 
 
 def test_directory(runcutty: RunCutty, repository: Path, tmp_path: Path) -> None:

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -255,13 +255,15 @@ def test_update_private_variables(
 ) -> None:
     """It does not bind private variables from the project configuration."""
     # Add another Jinja extension to `_extensions`.
-    extensions: list[str] = projectvariable(project, "_extensions")
+    context = json.loads((project / ".cookiecutter.json").read_text())
+    extensions: list[str] = context["_extensions"]
     extensions.append("jinja2.ext.i18n")
     updateprojectvariable(repository, "_extensions", extensions)
 
     runcutty("update", f"--cwd={project}")
 
-    assert extensions == projectvariable(project, "_extensions")
+    context = json.loads((project / ".cookiecutter.json").read_text())
+    assert extensions == context["_extensions"]
 
 
 def test_update_no_dot_cookiecutter_json(runcutty: RunCutty, repository: Path) -> None:

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -105,9 +105,8 @@ def test_update_conflict(runcutty: RunCutty, repository: Path, project: Path) ->
 
 def test_update_remove(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It applies file deletions from the template."""
-    removefile(
-        repository / "{{ cookiecutter.project }}" / "README.md",
-    )
+    removefile(repository / "{{ cookiecutter.project }}" / "README.md")
+    updatefile(repository / "{{ cookiecutter.project }}" / ".keep", "")
 
     with chdir(project):
         runcutty("update")
@@ -250,10 +249,19 @@ def test_update_dictvariable(runcutty: RunCutty, repository: Path) -> None:
     assert pngimages == projectvariable(project, "images")
 
 
-def test_update_private_variables(
-    runcutty: RunCutty, repository: Path, project: Path
-) -> None:
+def test_update_private_variables(runcutty: RunCutty, repository: Path) -> None:
     """It does not bind private variables from the project configuration."""
+    updatefile(
+        repository / "{{ cookiecutter.project }}" / ".cookiecutter.json",
+        """
+        {{ cookiecutter | jsonify }}
+        """,
+    )
+
+    project = Path("example")
+
+    runcutty("create", str(repository))
+
     # Add another Jinja extension to `_extensions`.
     context = json.loads((project / ".cookiecutter.json").read_text())
     extensions: list[str] = context["_extensions"]

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -37,7 +37,7 @@ def updateprojectvariable(repository: Path, name: str, value: Any) -> None:
 
 def projectvariable(project: Path, name: str) -> Any:
     """Return the bound value of a project variable."""
-    path = project / ".cookiecutter.json"
+    path = project / "cutty.json"
     data = json.loads(path.read_text())
     return data[name]
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -264,16 +264,3 @@ def test_update_private_variables(
 
     context = json.loads((project / ".cookiecutter.json").read_text())
     assert extensions == context["_extensions"]
-
-
-def test_update_no_dot_cookiecutter_json(runcutty: RunCutty, repository: Path) -> None:
-    """It does not require .cookiecutter.json in the project."""
-    removefile(repository / "{{ cookiecutter.project }}" / ".cookiecutter.json")
-
-    project = Path("example")
-
-    runcutty("create", str(repository))
-
-    updatefile(repository / "{{ cookiecutter.project }}" / "LICENSE", "")
-
-    runcutty("update", f"--cwd={project}")


### PR DESCRIPTION
- :white_check_mark: [functional] Add test that `cutty cookiecutter` does not create cutty.json
- :recycle: [functional] Inline function `projectvariable` in `test_update_private_variables`
- :white_check_mark: [functional] Read project variables from cutty.json in tests
- :fire: [functional] Remove test for .cookiecutter.json creation
- :recycle: [functional] Simplify `test_create_in_place` using `{project,template}_files`
- :white_check_mark: [functional] Break up and generalize `test_create_cookiecutter`
- :fire: [functional] Remove test for updating without .cookiecutter.json
- :white_check_mark: [functional] Remove .cookiecutter.json from template fixture
