### PR TITLE
:recycle: [services] Move functions reading project configurations to the `cutty.templates` package

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -13,17 +13,9 @@ from cutty.filestorage.adapters.observers.git import commit
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
+from cutty.templates.adapters.cookiecutter.projectconfig import getprojecttemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
-
-
-def getprojecttemplate(projectdir: Path) -> str:
-    """Return the location of the project template."""
-    context = readprojectconfigfile(projectdir)
-    result = context["_template"]
-    if not isinstance(result, str):
-        raise TypeError(f"{projectdir}: _template must be 'str', got {result!r}")
-    return result
 
 
 def getprojectbindings(projectdir: Path) -> Sequence[Binding]:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -1,10 +1,8 @@
 """Update a project with changes from its Cookiecutter template."""
 import hashlib
-import json
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 from typing import Optional
 from typing import Sequence
 
@@ -15,28 +13,22 @@ from cutty.filestorage.adapters.observers.git import commit
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
+from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
 
 def getprojecttemplate(projectdir: Path) -> str:
     """Return the location of the project template."""
-    context = getprojectcontext(projectdir)
+    context = readprojectconfigfile(projectdir)
     result = context["_template"]
     if not isinstance(result, str):
         raise TypeError(f"{projectdir}: _template must be 'str', got {result!r}")
     return result
 
 
-def getprojectcontext(projectdir: Path) -> dict[str, Any]:
-    """Return the Cookiecutter context of the project."""
-    text = (projectdir / "cutty.json").read_text()
-    data = json.loads(text)
-    return {key: value for key, value in data.items() if isinstance(key, str)}
-
-
 def getprojectbindings(projectdir: Path) -> Sequence[Binding]:
     """Return the variable bindings of the project."""
-    context = getprojectcontext(projectdir)
+    context = readprojectconfigfile(projectdir)
     return [Binding(key, value) for key, value in context.items()]
 
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -13,15 +13,9 @@ from cutty.filestorage.adapters.observers.git import commit
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
+from cutty.templates.adapters.cookiecutter.projectconfig import getprojectbindings
 from cutty.templates.adapters.cookiecutter.projectconfig import getprojecttemplate
-from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
-
-
-def getprojectbindings(projectdir: Path) -> Sequence[Binding]:
-    """Return the variable bindings of the project."""
-    context = readprojectconfigfile(projectdir)
-    return [Binding(key, value) for key, value in context.items()]
 
 
 def checkoutemptytree(repositorypath: Path) -> None:

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -1,6 +1,8 @@
 """Configuration for projects generated from Cookiecutter templates."""
 import json
+import pathlib
 from collections.abc import Iterable
+from typing import Any
 
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filesystems.domain.purepath import PurePath
@@ -18,3 +20,10 @@ def createprojectconfigfile(
     blob = json.dumps(data).encode()
 
     return RegularFile(path, blob)
+
+
+def readprojectconfigfile(project: pathlib.Path) -> dict[str, Any]:
+    """Return the Cookiecutter context of the project."""
+    text = (project / "cutty.json").read_text()
+    data = json.loads(text)
+    return {key: value for key, value in data.items() if isinstance(key, str)}

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -27,3 +27,12 @@ def readprojectconfigfile(project: pathlib.Path) -> dict[str, Any]:
     text = (project / "cutty.json").read_text()
     data = json.loads(text)
     return {key: value for key, value in data.items() if isinstance(key, str)}
+
+
+def getprojecttemplate(project: pathlib.Path) -> str:
+    """Return the location of the project template."""
+    context = readprojectconfigfile(project)
+    result = context["_template"]
+    if not isinstance(result, str):
+        raise TypeError(f"{project}: _template must be 'str', got {result!r}")
+    return result

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -3,6 +3,7 @@ import json
 import pathlib
 from collections.abc import Iterable
 from typing import Any
+from typing import Sequence
 
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filesystems.domain.purepath import PurePath
@@ -36,3 +37,9 @@ def getprojecttemplate(project: pathlib.Path) -> str:
     if not isinstance(result, str):
         raise TypeError(f"{project}: _template must be 'str', got {result!r}")
     return result
+
+
+def getprojectbindings(project: pathlib.Path) -> Sequence[Binding]:
+    """Return the variable bindings of the project."""
+    context = readprojectconfigfile(project)
+    return [Binding(key, value) for key, value in context.items()]

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -1,5 +1,4 @@
 """Unit tests for cutty.services.update."""
-import json
 from pathlib import Path
 
 import pygit2
@@ -7,27 +6,7 @@ import pytest
 
 from cutty.services.update import cherrypick
 from cutty.services.update import createworktree
-from cutty.services.update import getprojecttemplate
 from tests.util.git import commit
-
-
-def test_getprojecttemplate(tmp_path: Path) -> None:
-    """It returns the `_template` key from cutty.json."""
-    template = "https://example.com/repository.git"
-    text = json.dumps({"_template": template})
-    (tmp_path / "cutty.json").write_text(text)
-
-    assert template == getprojecttemplate(tmp_path)
-
-
-def test_getprojecttemplate_typeerror(tmp_path: Path) -> None:
-    """It checks that `_template` key is a string."""
-    template = None
-    text = json.dumps({"_template": template})
-    (tmp_path / "cutty.json").write_text(text)
-
-    with pytest.raises(TypeError):
-        getprojecttemplate(tmp_path)
 
 
 def test_createworktree(tmp_path: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -7,7 +7,6 @@ import pytest
 
 from cutty.services.update import cherrypick
 from cutty.services.update import createworktree
-from cutty.services.update import getprojectcontext
 from cutty.services.update import getprojecttemplate
 from tests.util.git import commit
 
@@ -29,15 +28,6 @@ def test_getprojecttemplate_typeerror(tmp_path: Path) -> None:
 
     with pytest.raises(TypeError):
         getprojecttemplate(tmp_path)
-
-
-def test_getprojectcontext(tmp_path: Path) -> None:
-    """It returns the persisted Cookiecutter context."""
-    context = {"project": "example"}
-    text = json.dumps(context)
-    (tmp_path / "cutty.json").write_text(text)
-
-    assert context == getprojectcontext(tmp_path)
 
 
 def test_createworktree(tmp_path: Path) -> None:

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -2,8 +2,11 @@
 import json
 import pathlib
 
+import pytest
+
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
+from cutty.templates.adapters.cookiecutter.projectconfig import getprojecttemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
@@ -38,3 +41,22 @@ def test_readprojectconfigfile(tmp_path: pathlib.Path) -> None:
     (tmp_path / "cutty.json").write_text(text)
 
     assert context == readprojectconfigfile(tmp_path)
+
+
+def test_getprojecttemplate(tmp_path: pathlib.Path) -> None:
+    """It returns the `_template` key from cutty.json."""
+    template = "https://example.com/repository.git"
+    text = json.dumps({"_template": template})
+    (tmp_path / "cutty.json").write_text(text)
+
+    assert template == getprojecttemplate(tmp_path)
+
+
+def test_getprojecttemplate_typeerror(tmp_path: pathlib.Path) -> None:
+    """It checks that `_template` key is a string."""
+    template = None
+    text = json.dumps({"_template": template})
+    (tmp_path / "cutty.json").write_text(text)
+
+    with pytest.raises(TypeError):
+        getprojecttemplate(tmp_path)

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -1,8 +1,10 @@
 """Unit tests for cutty.templates.adapters.cookiecutter.projectconfig."""
 import json
+import pathlib
 
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
+from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
 
@@ -27,3 +29,12 @@ def test_createprojectconfigfile_template() -> None:
     file = createprojectconfigfile(project, bindings, template)
 
     assert "_template" in json.loads(file.blob.decode())
+
+
+def test_readprojectconfigfile(tmp_path: pathlib.Path) -> None:
+    """It returns the persisted Cookiecutter context."""
+    context = {"project": "example"}
+    text = json.dumps(context)
+    (tmp_path / "cutty.json").write_text(text)
+
+    assert context == readprojectconfigfile(tmp_path)


### PR DESCRIPTION
- :recycle: [services] Move function `getprojectcontext` to `templates` as `readprojectconfigfile`
- :recycle: [services] Move function `getprojecttemplate` to `templates`
- :recycle: [services] Move function `getprojectbindings` to `templates`
