### PR TITLE
:recycle: [functional] Rename functions and extract functions in functional tests

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -82,7 +82,7 @@ def template_directory(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def repository(template_directory: Path) -> Path:
+def template(template_directory: Path) -> Path:
     """Fixture for a template repository."""
     pygit2.init_repository(template_directory)
     commit(template_directory, message="Initial")

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -65,10 +65,7 @@ def test_checkout(runcutty: RunCutty, template: Path) -> None:
     """It uses the specified revision of the template."""
     initial = pygit2.Repository(template).head.target
 
-    updatefile(
-        template / "{{ cookiecutter.project }}" / "LICENSE",
-        "",
-    )
+    updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
 
     runcutty("cookiecutter", f"--checkout={initial}", str(template))
 

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -19,93 +19,93 @@ def test_create_help(runcutty: RunCutty) -> None:
     runcutty("cookiecutter", "--help")
 
 
-def test_default(runcutty: RunCutty, repository: Path) -> None:
+def test_default(runcutty: RunCutty, template: Path) -> None:
     """It generates a project."""
-    runcutty("cookiecutter", str(repository))
+    runcutty("cookiecutter", str(template))
 
-    assert template_files(repository) == project_files("example") - {EXTRA}
+    assert template_files(template) == project_files("example") - {EXTRA}
 
 
-def test_input(runcutty: RunCutty, repository: Path) -> None:
+def test_input(runcutty: RunCutty, template: Path) -> None:
     """It generates a project."""
-    runcutty("cookiecutter", str(repository), input="foobar\n\n\n")
+    runcutty("cookiecutter", str(template), input="foobar\n\n\n")
 
     assert Path("foobar", "README.md").read_text() == "# foobar\n"
 
 
-def test_no_repository(runcutty: RunCutty, repository: Path) -> None:
+def test_no_repository(runcutty: RunCutty, template: Path) -> None:
     """It does not create a git repository for the project."""
-    runcutty("cookiecutter", str(repository))
+    runcutty("cookiecutter", str(template))
 
     assert not Path("example", ".git").is_dir()
 
 
-def test_no_cutty_json(runcutty: RunCutty, repository: Path) -> None:
+def test_no_cutty_json(runcutty: RunCutty, template: Path) -> None:
     """It does not create a cutty.json file."""
-    runcutty("cookiecutter", str(repository))
+    runcutty("cookiecutter", str(template))
 
     assert not Path("example", PROJECT_CONFIG_FILE).is_file()
 
 
-def test_no_input(runcutty: RunCutty, repository: Path) -> None:
+def test_no_input(runcutty: RunCutty, template: Path) -> None:
     """It does not prompt for variables."""
-    runcutty("cookiecutter", "--no-input", str(repository))
+    runcutty("cookiecutter", "--no-input", str(template))
 
-    assert template_files(repository) == project_files("example") - {EXTRA}
+    assert template_files(template) == project_files("example") - {EXTRA}
 
 
-def test_extra_context(runcutty: RunCutty, repository: Path) -> None:
+def test_extra_context(runcutty: RunCutty, template: Path) -> None:
     """It allows setting variables on the command-line."""
-    runcutty("cookiecutter", str(repository), "project=awesome")
+    runcutty("cookiecutter", str(template), "project=awesome")
 
-    assert template_files(repository) == project_files("awesome") - {EXTRA}
+    assert template_files(template) == project_files("awesome") - {EXTRA}
 
 
-def test_checkout(runcutty: RunCutty, repository: Path) -> None:
+def test_checkout(runcutty: RunCutty, template: Path) -> None:
     """It uses the specified revision of the template."""
-    initial = pygit2.Repository(repository).head.target
+    initial = pygit2.Repository(template).head.target
 
     updatefile(
-        repository / "{{ cookiecutter.project }}" / "LICENSE",
+        template / "{{ cookiecutter.project }}" / "LICENSE",
         "",
     )
 
-    runcutty("cookiecutter", f"--checkout={initial}", str(repository))
+    runcutty("cookiecutter", f"--checkout={initial}", str(template))
 
     assert not Path("example", "LICENSE").exists()
 
 
-def test_output_dir(runcutty: RunCutty, repository: Path, tmp_path: Path) -> None:
+def test_output_dir(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
     """It generates the project under the specified directory."""
     outputdir = tmp_path / "outputdir"
 
-    runcutty("cookiecutter", f"--output-dir={outputdir}", str(repository))
+    runcutty("cookiecutter", f"--output-dir={outputdir}", str(template))
 
-    assert template_files(repository) == project_files(outputdir / "example") - {EXTRA}
+    assert template_files(template) == project_files(outputdir / "example") - {EXTRA}
 
 
-def test_directory(runcutty: RunCutty, repository: Path, tmp_path: Path) -> None:
+def test_directory(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
     """It uses the template in the given subdirectory."""
     directory = "a"
-    move_repository_files_to_subdirectory(repository, directory)
+    move_repository_files_to_subdirectory(template, directory)
 
-    runcutty("cookiecutter", f"--directory={directory}", str(repository))
+    runcutty("cookiecutter", f"--directory={directory}", str(template))
 
-    assert template_files(repository / "a") == project_files("example") - {EXTRA}
+    assert template_files(template / "a") == project_files("example") - {EXTRA}
 
 
-def test_overwrite(runcutty: RunCutty, repository: Path) -> None:
+def test_overwrite(runcutty: RunCutty, template: Path) -> None:
     """It overwrites existing files."""
     readme = Path("example", "README.md")
     readme.parent.mkdir()
     readme.touch()
 
-    runcutty("cookiecutter", "--overwrite-if-exists", str(repository))
+    runcutty("cookiecutter", "--overwrite-if-exists", str(template))
 
     assert readme.read_text() == "# example\n"
 
 
-def test_skip(runcutty: RunCutty, repository: Path) -> None:
+def test_skip(runcutty: RunCutty, template: Path) -> None:
     """It skips existing files."""
     readme = Path("example", "README.md")
     readme.parent.mkdir()
@@ -115,7 +115,7 @@ def test_skip(runcutty: RunCutty, repository: Path) -> None:
         "cookiecutter",
         "--overwrite-if-exists",
         "--skip-if-file-exists",
-        str(repository),
+        str(template),
     )
 
     assert readme.read_text() == ""

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -55,7 +55,7 @@ def test_cutty_json_already_exists(runcutty: RunCutty, repository: Path) -> None
         runcutty("create", str(repository))
 
 
-def test_create_inplace(runcutty: RunCutty, repository: Path) -> None:
+def test_inplace(runcutty: RunCutty, repository: Path) -> None:
     """It generates the project files in the current directory."""
     runcutty("create", "--no-input", "--in-place", str(repository))
 

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -49,7 +49,7 @@ def test_cutty_json(runcutty: RunCutty, template: Path) -> None:
 
 def test_cutty_json_already_exists(runcutty: RunCutty, template: Path) -> None:
     """It raises an exception."""
-    updatefile(template / "{{ cookiecutter.project }}" / PROJECT_CONFIG_FILE, "")
+    updatefile(template / "{{ cookiecutter.project }}" / PROJECT_CONFIG_FILE)
 
     with pytest.raises(FileExistsError):
         runcutty("create", str(template))

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -19,54 +19,54 @@ def test_help(runcutty: RunCutty) -> None:
     runcutty("create", "--help")
 
 
-def test_input(runcutty: RunCutty, repository: Path) -> None:
+def test_input(runcutty: RunCutty, template: Path) -> None:
     """It binds project variables from user input."""
-    runcutty("create", str(repository), input="foobar\n\n\n")
+    runcutty("create", str(template), input="foobar\n\n\n")
 
     assert Path("foobar", "README.md").read_text() == "# foobar\n"
 
 
-def test_hook(runcutty: RunCutty, repository: Path) -> None:
+def test_hook(runcutty: RunCutty, template: Path) -> None:
     """It runs hooks."""
-    runcutty("create", str(repository))
+    runcutty("create", str(template))
 
     assert Path("example", "post_gen_project").is_file()
 
 
-def test_files(runcutty: RunCutty, repository: Path) -> None:
+def test_files(runcutty: RunCutty, template: Path) -> None:
     """It renders the project files."""
-    runcutty("create", str(repository))
+    runcutty("create", str(template))
 
-    assert template_files(repository) == project_files("example") - EXTRA
+    assert template_files(template) == project_files("example") - EXTRA
 
 
-def test_cutty_json(runcutty: RunCutty, repository: Path) -> None:
+def test_cutty_json(runcutty: RunCutty, template: Path) -> None:
     """It creates a cutty.json file."""
-    runcutty("create", str(repository))
+    runcutty("create", str(template))
 
     assert Path("example", PROJECT_CONFIG_FILE).is_file()
 
 
-def test_cutty_json_already_exists(runcutty: RunCutty, repository: Path) -> None:
+def test_cutty_json_already_exists(runcutty: RunCutty, template: Path) -> None:
     """It raises an exception."""
-    updatefile(repository / "{{ cookiecutter.project }}" / PROJECT_CONFIG_FILE, "")
+    updatefile(template / "{{ cookiecutter.project }}" / PROJECT_CONFIG_FILE, "")
 
     with pytest.raises(FileExistsError):
-        runcutty("create", str(repository))
+        runcutty("create", str(template))
 
 
-def test_inplace(runcutty: RunCutty, repository: Path) -> None:
+def test_inplace(runcutty: RunCutty, template: Path) -> None:
     """It generates the project files in the current directory."""
-    runcutty("create", "--no-input", "--in-place", str(repository))
+    runcutty("create", "--no-input", "--in-place", str(template))
 
-    assert template_files(repository) == project_files(".") - EXTRA
+    assert template_files(template) == project_files(".") - EXTRA
 
 
-def test_directory(runcutty: RunCutty, repository: Path, tmp_path: Path) -> None:
+def test_directory(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
     """It uses the template in the given subdirectory."""
     directory = "a"
-    move_repository_files_to_subdirectory(repository, directory)
+    move_repository_files_to_subdirectory(template, directory)
 
-    runcutty("create", f"--directory={directory}", str(repository))
+    runcutty("create", f"--directory={directory}", str(template))
 
-    assert template_files(repository / "a") == project_files("example") - EXTRA
+    assert template_files(template / "a") == project_files("example") - EXTRA

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -248,6 +248,12 @@ def test_dictvariable(runcutty: RunCutty, repository: Path) -> None:
 
 def test_private_variables(runcutty: RunCutty, repository: Path) -> None:
     """It does not bind private variables from the project configuration."""
+
+    def privatevariable(project: Path, variable: str) -> Any:
+        """Return any variable from the Cookiecutter context of a generated project."""
+        context = json.loads((project / ".cookiecutter.json").read_text())
+        return context[variable]
+
     updatefile(
         repository / "{{ cookiecutter.project }}" / ".cookiecutter.json",
         """
@@ -260,12 +266,10 @@ def test_private_variables(runcutty: RunCutty, repository: Path) -> None:
     runcutty("create", str(repository))
 
     # Add another Jinja extension to `_extensions`.
-    context = json.loads((project / ".cookiecutter.json").read_text())
-    extensions: list[str] = context["_extensions"]
+    extensions: list[str] = privatevariable(project, "_extensions")
     extensions.append("jinja2.ext.i18n")
     updateprojectvariable(repository, "_extensions", extensions)
 
     runcutty("update", f"--cwd={project}")
 
-    context = json.loads((project / ".cookiecutter.json").read_text())
-    assert extensions == context["_extensions"]
+    assert extensions == privatevariable(project, "_extensions")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -69,10 +69,7 @@ def test_merge(runcutty: RunCutty, template: Path, project: Path) -> None:
         """,
     )
 
-    updatefile(
-        template / "{{ cookiecutter.project }}" / "LICENSE",
-        "",
-    )
+    updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
 
     with chdir(project):
         runcutty("update")
@@ -107,7 +104,7 @@ def test_conflict(runcutty: RunCutty, template: Path, project: Path) -> None:
 def test_remove(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It applies file deletions from the template."""
     removefile(template / "{{ cookiecutter.project }}" / "README.md")
-    updatefile(template / "{{ cookiecutter.project }}" / ".keep", "")
+    updatefile(template / "{{ cookiecutter.project }}" / ".keep")
 
     with chdir(project):
         runcutty("update")
@@ -233,10 +230,7 @@ def test_dictvariable(runcutty: RunCutty, template: Path) -> None:
     runcutty("create", str(template), input=userinput)
 
     # Add LICENSE so update has something to do.
-    updatefile(
-        template / "{{ cookiecutter.project }}" / "LICENSE",
-        "",
-    )
+    updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
 
     # Update the project.
     project = Path("example")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -43,7 +43,7 @@ def projectvariable(project: Path, name: str) -> Any:
     return data[name]
 
 
-def test_update_trivial(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_trivial(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It applies changes from the template."""
     updatefile(
         repository / "{{ cookiecutter.project }}" / "README.md",
@@ -59,7 +59,7 @@ def test_update_trivial(runcutty: RunCutty, repository: Path, project: Path) -> 
     assert (project / "README.md").read_text() == "# awesome\nAn awesome project.\n"
 
 
-def test_update_merge(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_merge(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It merges changes from the template."""
     updatefile(
         project / "README.md",
@@ -81,7 +81,7 @@ def test_update_merge(runcutty: RunCutty, repository: Path, project: Path) -> No
     assert (project / "LICENSE").is_file()
 
 
-def test_update_conflict(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_conflict(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It exits with a non-zero status on merge conflicts."""
     updatefile(
         project / "README.md",
@@ -104,7 +104,7 @@ def test_update_conflict(runcutty: RunCutty, repository: Path, project: Path) ->
             runcutty("update")
 
 
-def test_update_remove(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_remove(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It applies file deletions from the template."""
     removefile(repository / "{{ cookiecutter.project }}" / "README.md")
     updatefile(repository / "{{ cookiecutter.project }}" / ".keep", "")
@@ -115,7 +115,7 @@ def test_update_remove(runcutty: RunCutty, repository: Path, project: Path) -> N
     assert not (project / "README.md").is_file()
 
 
-def test_update_noop(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_noop(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It does nothing if the generated project did not change."""
     oldhead = pygit2.Repository(project).head.target
 
@@ -125,9 +125,7 @@ def test_update_noop(runcutty: RunCutty, repository: Path, project: Path) -> Non
     assert oldhead == pygit2.Repository(project).head.target
 
 
-def test_update_new_variables(
-    runcutty: RunCutty, repository: Path, project: Path
-) -> None:
+def test_new_variables(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It prompts for variables added after the last project generation."""
     updateprojectvariable(repository, "status", ["alpha", "beta", "stable"])
 
@@ -137,7 +135,7 @@ def test_update_new_variables(
     assert "stable" == projectvariable(project, "status")
 
 
-def test_update_extra_context_old_variable(
+def test_extra_context_old_variable(
     runcutty: RunCutty, repository: Path, project: Path
 ) -> None:
     """It allows setting variables on the command-line."""
@@ -147,7 +145,7 @@ def test_update_extra_context_old_variable(
     assert "excellent" == projectvariable(project, "project")
 
 
-def test_update_extra_context_new_variable(
+def test_extra_context_new_variable(
     runcutty: RunCutty, repository: Path, project: Path
 ) -> None:
     """It allows setting variables on the command-line."""
@@ -159,7 +157,7 @@ def test_update_extra_context_new_variable(
     assert "stable" == projectvariable(project, "status")
 
 
-def test_update_no_input(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_no_input(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It does not prompt for variables added after the last project generation."""
     updateprojectvariable(repository, "status", ["alpha", "beta", "stable"])
 
@@ -169,9 +167,7 @@ def test_update_no_input(runcutty: RunCutty, repository: Path, project: Path) ->
     assert "alpha" == projectvariable(project, "status")
 
 
-def test_update_rename_projectdir(
-    runcutty: RunCutty, repository: Path, project: Path
-) -> None:
+def test_rename_projectdir(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It generates the project in the project directory irrespective of its name."""
     project2 = Path("awesome2")
     project.rename(project2)
@@ -190,7 +186,7 @@ def test_update_rename_projectdir(
     assert (project2 / "README.md").read_text() == "# awesome\nAn awesome project.\n"
 
 
-def test_update_cwd(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_cwd(runcutty: RunCutty, repository: Path, project: Path) -> None:
     """It updates the project in the specified directory."""
     updatefile(
         repository / "{{ cookiecutter.project }}" / "README.md",
@@ -205,7 +201,7 @@ def test_update_cwd(runcutty: RunCutty, repository: Path, project: Path) -> None
     assert (project / "README.md").read_text() == "# awesome\nAn awesome project.\n"
 
 
-def test_update_dictvariable(runcutty: RunCutty, repository: Path) -> None:
+def test_dictvariable(runcutty: RunCutty, repository: Path) -> None:
     """It loads dict variables from the project configuration."""
     # Add a dict variable with image types to the template.
     images = {
@@ -250,7 +246,7 @@ def test_update_dictvariable(runcutty: RunCutty, repository: Path) -> None:
     assert pngimages == projectvariable(project, "images")
 
 
-def test_update_private_variables(runcutty: RunCutty, repository: Path) -> None:
+def test_private_variables(runcutty: RunCutty, repository: Path) -> None:
     """It does not bind private variables from the project configuration."""
     updatefile(
         repository / "{{ cookiecutter.project }}" / ".cookiecutter.json",

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -249,17 +249,18 @@ def test_dictvariable(runcutty: RunCutty, repository: Path) -> None:
 def test_private_variables(runcutty: RunCutty, repository: Path) -> None:
     """It does not bind private variables from the project configuration."""
 
+    def adddotcookiecutterjson(repository: Path) -> None:
+        """Add .cookiecutter.json file to the template."""
+        path = repository / "{{ cookiecutter.project }}" / ".cookiecutter.json"
+        text = "{{ cookiecutter | jsonify }}"
+        updatefile(path, text)
+
     def privatevariable(project: Path, variable: str) -> Any:
         """Return any variable from the Cookiecutter context of a generated project."""
         context = json.loads((project / ".cookiecutter.json").read_text())
         return context[variable]
 
-    updatefile(
-        repository / "{{ cookiecutter.project }}" / ".cookiecutter.json",
-        """
-        {{ cookiecutter | jsonify }}
-        """,
-    )
+    adddotcookiecutterjson(repository)
 
     project = Path("example")
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -19,18 +19,18 @@ def test_help(runcutty: RunCutty) -> None:
 
 
 @pytest.fixture
-def project(runcutty: RunCutty, repository: Path) -> Path:
+def project(runcutty: RunCutty, template: Path) -> Path:
     """Fixture for a generated project."""
     project = Path("awesome")
 
-    runcutty("create", "--no-input", str(repository), f"project={project.name}")
+    runcutty("create", "--no-input", str(template), f"project={project.name}")
 
     return project
 
 
-def updateprojectvariable(repository: Path, name: str, value: Any) -> None:
+def updateprojectvariable(template: Path, name: str, value: Any) -> None:
     """Add or update a project variable in the template."""
-    path = repository / "cookiecutter.json"
+    path = template / "cookiecutter.json"
     data = json.loads(path.read_text())
     data[name] = value
     updatefile(path, json.dumps(data))
@@ -43,10 +43,10 @@ def projectvariable(project: Path, name: str) -> Any:
     return data[name]
 
 
-def test_trivial(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_trivial(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It applies changes from the template."""
     updatefile(
-        repository / "{{ cookiecutter.project }}" / "README.md",
+        template / "{{ cookiecutter.project }}" / "README.md",
         """
         # {{ cookiecutter.project }}
         An awesome project.
@@ -59,7 +59,7 @@ def test_trivial(runcutty: RunCutty, repository: Path, project: Path) -> None:
     assert (project / "README.md").read_text() == "# awesome\nAn awesome project.\n"
 
 
-def test_merge(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_merge(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It merges changes from the template."""
     updatefile(
         project / "README.md",
@@ -70,7 +70,7 @@ def test_merge(runcutty: RunCutty, repository: Path, project: Path) -> None:
     )
 
     updatefile(
-        repository / "{{ cookiecutter.project }}" / "LICENSE",
+        template / "{{ cookiecutter.project }}" / "LICENSE",
         "",
     )
 
@@ -81,7 +81,7 @@ def test_merge(runcutty: RunCutty, repository: Path, project: Path) -> None:
     assert (project / "LICENSE").is_file()
 
 
-def test_conflict(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_conflict(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It exits with a non-zero status on merge conflicts."""
     updatefile(
         project / "README.md",
@@ -92,7 +92,7 @@ def test_conflict(runcutty: RunCutty, repository: Path, project: Path) -> None:
     )
 
     updatefile(
-        repository / "{{ cookiecutter.project }}" / "README.md",
+        template / "{{ cookiecutter.project }}" / "README.md",
         """
         # {{ cookiecutter.project }}
         An excellent project.
@@ -104,10 +104,10 @@ def test_conflict(runcutty: RunCutty, repository: Path, project: Path) -> None:
             runcutty("update")
 
 
-def test_remove(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_remove(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It applies file deletions from the template."""
-    removefile(repository / "{{ cookiecutter.project }}" / "README.md")
-    updatefile(repository / "{{ cookiecutter.project }}" / ".keep", "")
+    removefile(template / "{{ cookiecutter.project }}" / "README.md")
+    updatefile(template / "{{ cookiecutter.project }}" / ".keep", "")
 
     with chdir(project):
         runcutty("update")
@@ -115,7 +115,7 @@ def test_remove(runcutty: RunCutty, repository: Path, project: Path) -> None:
     assert not (project / "README.md").is_file()
 
 
-def test_noop(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_noop(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does nothing if the generated project did not change."""
     oldhead = pygit2.Repository(project).head.target
 
@@ -125,9 +125,9 @@ def test_noop(runcutty: RunCutty, repository: Path, project: Path) -> None:
     assert oldhead == pygit2.Repository(project).head.target
 
 
-def test_new_variables(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_new_variables(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It prompts for variables added after the last project generation."""
-    updateprojectvariable(repository, "status", ["alpha", "beta", "stable"])
+    updateprojectvariable(template, "status", ["alpha", "beta", "stable"])
 
     with chdir(project):
         runcutty("update", input="3\n")
@@ -136,7 +136,7 @@ def test_new_variables(runcutty: RunCutty, repository: Path, project: Path) -> N
 
 
 def test_extra_context_old_variable(
-    runcutty: RunCutty, repository: Path, project: Path
+    runcutty: RunCutty, template: Path, project: Path
 ) -> None:
     """It allows setting variables on the command-line."""
     with chdir(project):
@@ -146,10 +146,10 @@ def test_extra_context_old_variable(
 
 
 def test_extra_context_new_variable(
-    runcutty: RunCutty, repository: Path, project: Path
+    runcutty: RunCutty, template: Path, project: Path
 ) -> None:
     """It allows setting variables on the command-line."""
-    updateprojectvariable(repository, "status", ["alpha", "beta", "stable"])
+    updateprojectvariable(template, "status", ["alpha", "beta", "stable"])
 
     with chdir(project):
         runcutty("update", "status=stable")
@@ -157,9 +157,9 @@ def test_extra_context_new_variable(
     assert "stable" == projectvariable(project, "status")
 
 
-def test_no_input(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_no_input(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does not prompt for variables added after the last project generation."""
-    updateprojectvariable(repository, "status", ["alpha", "beta", "stable"])
+    updateprojectvariable(template, "status", ["alpha", "beta", "stable"])
 
     with chdir(project):
         runcutty("update", "--no-input", input="3\n")
@@ -167,13 +167,13 @@ def test_no_input(runcutty: RunCutty, repository: Path, project: Path) -> None:
     assert "alpha" == projectvariable(project, "status")
 
 
-def test_rename_projectdir(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_rename_projectdir(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It generates the project in the project directory irrespective of its name."""
     project2 = Path("awesome2")
     project.rename(project2)
 
     updatefile(
-        repository / "{{ cookiecutter.project }}" / "README.md",
+        template / "{{ cookiecutter.project }}" / "README.md",
         """
         # {{ cookiecutter.project }}
         An awesome project.
@@ -186,10 +186,10 @@ def test_rename_projectdir(runcutty: RunCutty, repository: Path, project: Path) 
     assert (project2 / "README.md").read_text() == "# awesome\nAn awesome project.\n"
 
 
-def test_cwd(runcutty: RunCutty, repository: Path, project: Path) -> None:
+def test_cwd(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It updates the project in the specified directory."""
     updatefile(
-        repository / "{{ cookiecutter.project }}" / "README.md",
+        template / "{{ cookiecutter.project }}" / "README.md",
         """
         # {{ cookiecutter.project }}
         An awesome project.
@@ -201,7 +201,7 @@ def test_cwd(runcutty: RunCutty, repository: Path, project: Path) -> None:
     assert (project / "README.md").read_text() == "# awesome\nAn awesome project.\n"
 
 
-def test_dictvariable(runcutty: RunCutty, repository: Path) -> None:
+def test_dictvariable(runcutty: RunCutty, template: Path) -> None:
     """It loads dict variables from the project configuration."""
     # Add a dict variable with image types to the template.
     images = {
@@ -217,7 +217,7 @@ def test_dictvariable(runcutty: RunCutty, repository: Path) -> None:
         },
     }
 
-    updateprojectvariable(repository, "images", images)
+    updateprojectvariable(template, "images", images)
 
     # Create a project using only PNG images.
     pngimages = {key: value for key, value in images.items() if key == "png"}
@@ -230,11 +230,11 @@ def test_dictvariable(runcutty: RunCutty, repository: Path) -> None:
         ]
     )
 
-    runcutty("create", str(repository), input=userinput)
+    runcutty("create", str(template), input=userinput)
 
     # Add LICENSE so update has something to do.
     updatefile(
-        repository / "{{ cookiecutter.project }}" / "LICENSE",
+        template / "{{ cookiecutter.project }}" / "LICENSE",
         "",
     )
 
@@ -246,12 +246,12 @@ def test_dictvariable(runcutty: RunCutty, repository: Path) -> None:
     assert pngimages == projectvariable(project, "images")
 
 
-def test_private_variables(runcutty: RunCutty, repository: Path) -> None:
+def test_private_variables(runcutty: RunCutty, template: Path) -> None:
     """It does not bind private variables from the project configuration."""
 
-    def adddotcookiecutterjson(repository: Path) -> None:
+    def adddotcookiecutterjson(template: Path) -> None:
         """Add .cookiecutter.json file to the template."""
-        path = repository / "{{ cookiecutter.project }}" / ".cookiecutter.json"
+        path = template / "{{ cookiecutter.project }}" / ".cookiecutter.json"
         text = "{{ cookiecutter | jsonify }}"
         updatefile(path, text)
 
@@ -260,16 +260,16 @@ def test_private_variables(runcutty: RunCutty, repository: Path) -> None:
         context = json.loads((project / ".cookiecutter.json").read_text())
         return context[variable]
 
-    adddotcookiecutterjson(repository)
+    adddotcookiecutterjson(template)
 
     project = Path("example")
 
-    runcutty("create", str(repository))
+    runcutty("create", str(template))
 
     # Add another Jinja extension to `_extensions`.
     extensions: list[str] = privatevariable(project, "_extensions")
     extensions.append("jinja2.ext.i18n")
-    updateprojectvariable(repository, "_extensions", extensions)
+    updateprojectvariable(template, "_extensions", extensions)
 
     runcutty("update", f"--cwd={project}")
 

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -33,7 +33,7 @@ def discoverrepository(path: Path) -> Path:
     return Path(pygit2.discover_repository(path))
 
 
-def updatefile(path: Path, text: str) -> None:
+def updatefile(path: Path, text: str = "") -> None:
     """Add or update a repository file."""
     repository = discoverrepository(path)
 


### PR DESCRIPTION
- :recycle: [functional] Remove redundant name prefixes from test functions
- :recycle: [functional] Extract nested function `privatevariable` in update test
- :recycle: [functional] Extract nested function `adddotcookiecutterjson` in update test
- :recycle: [functional] Rename `repository` fixture to `template`
