### PR TITLE
:recycle: [entrypoints] Register CLI commands in a more explicit way

### DIFF
--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -7,3 +7,4 @@ from ._main import main as main  # noqa: F401
 
 main.command()(create.create)
 main.command()(update.update)
+main.command()(cookiecutter.cookiecutter)

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -4,3 +4,5 @@ from . import create  # noqa: F401
 from . import update  # noqa: F401
 from . import cookiecutter  # noqa: F401
 from ._main import main as main  # noqa: F401
+
+main.command()(create.create)

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -6,3 +6,4 @@ from . import cookiecutter  # noqa: F401
 from ._main import main as main  # noqa: F401
 
 main.command()(create.create)
+main.command()(update.update)

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -1,9 +1,9 @@
 """Command-line interface."""
 # noreorder
-from . import create  # noqa: F401
-from . import update  # noqa: F401
-from . import cookiecutter  # noqa: F401
-from ._main import main as main  # noqa: F401
+from . import create
+from . import update
+from . import cookiecutter
+from ._main import main as main
 
 main.command()(create.create)
 main.command()(update.update)

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -5,9 +5,11 @@ from cutty.entrypoints.cli.create import create
 from cutty.entrypoints.cli.update import update
 
 
-main.command()(create)
-main.command()(update)
-main.command()(cookiecutter)
+registercommand = main.command()
+
+registercommand(create)
+registercommand(update)
+registercommand(cookiecutter)
 
 
 __all__ = ["main"]

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -1,5 +1,5 @@
 """Command-line interface."""
-from cutty.entrypoints.cli._main import main as main
+from cutty.entrypoints.cli._main import main
 from cutty.entrypoints.cli.cookiecutter import cookiecutter
 from cutty.entrypoints.cli.create import create
 from cutty.entrypoints.cli.update import update
@@ -8,3 +8,6 @@ from cutty.entrypoints.cli.update import update
 main.command()(create)
 main.command()(update)
 main.command()(cookiecutter)
+
+
+__all__ = ["main"]

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -1,10 +1,10 @@
 """Command-line interface."""
-# noreorder
-from . import create
-from . import update
-from . import cookiecutter
-from ._main import main as main
+from cutty.entrypoints.cli._main import main as main
+from cutty.entrypoints.cli.cookiecutter import cookiecutter
+from cutty.entrypoints.cli.create import create
+from cutty.entrypoints.cli.update import update
 
-main.command()(create.create)
-main.command()(update.update)
-main.command()(cookiecutter.cookiecutter)
+
+main.command()(create)
+main.command()(update)
+main.command()(cookiecutter)

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -5,13 +5,11 @@ from typing import Optional
 
 import click
 
-from cutty.entrypoints.cli._main import main as _main
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.create import create as service_create
 from cutty.templates.domain.bindings import Binding
 
 
-@_main.command()
 @click.argument("template")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 import click
 
-from cutty.entrypoints.cli._main import main as _main
 from cutty.services.create import create as service_create
 from cutty.templates.domain.bindings import Binding
 
@@ -29,7 +28,6 @@ def extra_context_callback(
     return dict(_generate())
 
 
-@_main.command()
 @click.argument("template")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -4,13 +4,11 @@ from typing import Optional
 
 import click
 
-from cutty.entrypoints.cli._main import main as _main
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
 
 
-@_main.command()
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
     "--no-input",


### PR DESCRIPTION
- :recycle: [entrypoints] Move `create` registration to `__init__` module
- :recycle: [entrypoints] Move `update` registration to `__init__` module
- :recycle: [entrypoints] Move `cookiecutter` registration to `__init__` module
- :rotating_light: [entrypoints] Remove unused `noqa: F401`
- :recycle: [entrypoints] Reorder and standardize imports in `__init__` module
- :recycle: [entrypoints] Use `__all__` instead of `import...as`
- :recycle: [entrypoints] Extract variable `registercommand`
