### PR TITLE
:recycle: [templates] Rename functions to find project files and hooks in Cookiecutter templates

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -10,8 +10,8 @@ from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
+from cutty.templates.adapters.cookiecutter.config import findcookiecutterhooks
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterpaths
-from cutty.templates.adapters.cookiecutter.config import findhooks
 from cutty.templates.adapters.cookiecutter.config import loadcookiecutterconfig
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
 from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
@@ -66,7 +66,9 @@ def create(
     else:
         projectdir = outputdir / projectfiles[0].path.parts[strip]
 
-    hookfiles = lazysequence(renderfiles(findhooks(templatedir), render, bindings))
+    hookfiles = lazysequence(
+        renderfiles(findcookiecutterhooks(templatedir), render, bindings)
+    )
     projectconfigfile = (
         createprojectconfigfile(
             PurePath(*projectdir.relative_to(outputdir).parts), bindings, template

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -10,8 +10,8 @@ from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
+from cutty.templates.adapters.cookiecutter.config import findcookiecutterpaths
 from cutty.templates.adapters.cookiecutter.config import findhooks
-from cutty.templates.adapters.cookiecutter.config import findpaths
 from cutty.templates.adapters.cookiecutter.config import loadcookiecutterconfig
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
 from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
@@ -53,7 +53,7 @@ def create(
     )
 
     projectfiles = lazysequence(
-        renderfiles(findpaths(templatedir, config), render, bindings)
+        renderfiles(findcookiecutterpaths(templatedir, config), render, bindings)
     )
     if not projectfiles:  # pragma: no cover
         return

--- a/src/cutty/templates/adapters/cookiecutter/config.py
+++ b/src/cutty/templates/adapters/cookiecutter/config.py
@@ -77,7 +77,7 @@ def findcookiecutterpaths(path: Path, config: Config) -> Iterator[Path]:
     yield template_dir
 
 
-def findhooks(path: Path) -> Iterator[Path]:
+def findcookiecutterhooks(path: Path) -> Iterator[Path]:
     """Load hooks in a Cookiecutter template."""
     hooks = {"pre_gen_project", "post_gen_project"}
     hookdir = path / "hooks"

--- a/src/cutty/templates/adapters/cookiecutter/config.py
+++ b/src/cutty/templates/adapters/cookiecutter/config.py
@@ -66,7 +66,7 @@ def loadcookiecutterconfig(template: str, path: Path) -> Config:
     return Config(settings, variables)
 
 
-def findpaths(path: Path, config: Config) -> Iterator[Path]:
+def findcookiecutterpaths(path: Path, config: Config) -> Iterator[Path]:
     """Load project files in a Cookiecutter template."""
     for template_dir in path.iterdir():
         if all(token in template_dir.name for token in ("{{", "cookiecutter", "}}")):

--- a/tests/unit/templates/domain/test_config.py
+++ b/tests/unit/templates/domain/test_config.py
@@ -1,8 +1,8 @@
 """Unit tests for cutty.templates.domain.config."""
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
+from cutty.templates.adapters.cookiecutter.config import findcookiecutterhooks
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterpaths
-from cutty.templates.adapters.cookiecutter.config import findhooks
 from cutty.templates.domain.config import Config
 from cutty.templates.domain.variables import Variable
 
@@ -39,16 +39,16 @@ def test_findcookiecutterpaths_other_directories() -> None:
     assert next(paths, None) is None
 
 
-def test_findhooks_none() -> None:
+def test_findcookiecutterhooks_none() -> None:
     """It does not yield if there is no hook directory."""
     filesystem = DictFilesystem({"{{ cookiecutter.project }}": {}})
     path = Path(filesystem=filesystem)
-    paths = findhooks(path)
+    paths = findcookiecutterhooks(path)
 
     assert next(paths, None) is None
 
 
-def test_findhooks_paths() -> None:
+def test_findcookiecutterhooks_paths() -> None:
     """It returns paths to hooks."""
     filesystem = DictFilesystem(
         {
@@ -57,13 +57,13 @@ def test_findhooks_paths() -> None:
         }
     )
     path = Path(filesystem=filesystem)
-    paths = findhooks(path)
+    paths = findcookiecutterhooks(path)
 
     assert next(paths) == path / "hooks" / "pre_gen_project.py"
     assert next(paths, None) is None
 
 
-def test_findhooks_bogus_hooks() -> None:
+def test_findcookiecutterhooks_bogus_hooks() -> None:
     """It ignores hooks with a backup extension."""
     filesystem = DictFilesystem(
         {
@@ -72,6 +72,6 @@ def test_findhooks_bogus_hooks() -> None:
         }
     )
     path = Path(filesystem=filesystem)
-    paths = findhooks(path)
+    paths = findcookiecutterhooks(path)
 
     assert next(paths, None) is None

--- a/tests/unit/templates/domain/test_config.py
+++ b/tests/unit/templates/domain/test_config.py
@@ -1,8 +1,8 @@
 """Unit tests for cutty.templates.domain.config."""
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
+from cutty.templates.adapters.cookiecutter.config import findcookiecutterpaths
 from cutty.templates.adapters.cookiecutter.config import findhooks
-from cutty.templates.adapters.cookiecutter.config import findpaths
 from cutty.templates.domain.config import Config
 from cutty.templates.domain.variables import Variable
 
@@ -12,18 +12,18 @@ def test_config(variable: Variable) -> None:
     Config(settings={"a-setting": "value"}, variables=(variable,))
 
 
-def test_findpaths_template_directory() -> None:
+def test_findcookiecutterpaths_template_directory() -> None:
     """It returns the template directory."""
     config = Config({}, ())
     filesystem = DictFilesystem({"{{ cookiecutter.project }}": {}})
     path = Path(filesystem=filesystem)
-    paths = findpaths(path, config)
+    paths = findcookiecutterpaths(path, config)
 
     assert next(paths) == path / "{{ cookiecutter.project }}"
     assert next(paths, None) is None
 
 
-def test_findpaths_other_directories() -> None:
+def test_findcookiecutterpaths_other_directories() -> None:
     """It ignores other directories."""
     config = Config({}, ())
     filesystem = DictFilesystem(
@@ -33,7 +33,7 @@ def test_findpaths_other_directories() -> None:
         }
     )
     path = Path(filesystem=filesystem)
-    paths = findpaths(path, config)
+    paths = findcookiecutterpaths(path, config)
 
     assert next(paths) == path / "{{ cookiecutter.project }}"
     assert next(paths, None) is None


### PR DESCRIPTION
- :recycle: [templates] Rename function `findpaths` to `findcookiecutterpaths`
- :recycle: [templates] Rename function `findhooks` to `findcookiecutterhooks`
