### PR TITLE
:recycle: [templates] Create class `cookiecutter.ProjectConfig`

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -14,6 +14,7 @@ from cutty.templates.adapters.cookiecutter.config import findcookiecutterhooks
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterpaths
 from cutty.templates.adapters.cookiecutter.config import loadcookiecutterconfig
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
+from cutty.templates.adapters.cookiecutter.projectconfig import ProjectConfig
 from cutty.templates.adapters.cookiecutter.render import createcookiecutterrenderer
 from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.renderfiles import renderfiles
@@ -71,7 +72,8 @@ def create(
     )
     projectconfigfile = (
         createprojectconfigfile(
-            PurePath(*projectdir.relative_to(outputdir).parts), bindings, template
+            PurePath(*projectdir.relative_to(outputdir).parts),
+            ProjectConfig(template, bindings),
         )
         if createconfigfile
         else None

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -13,7 +13,7 @@ from cutty.filestorage.adapters.observers.git import commit
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
-from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile2
+from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
 
@@ -79,7 +79,7 @@ def update(
     if projectdir is None:
         projectdir = Path.cwd()
 
-    projectconfig = readprojectconfigfile2(projectdir)
+    projectconfig = readprojectconfigfile(projectdir)
     extrabindings = list(projectconfig.bindings) + list(extrabindings)
 
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -13,8 +13,7 @@ from cutty.filestorage.adapters.observers.git import commit
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
-from cutty.templates.adapters.cookiecutter.projectconfig import getprojectbindings
-from cutty.templates.adapters.cookiecutter.projectconfig import getprojecttemplate
+from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile2
 from cutty.templates.domain.bindings import Binding
 
 
@@ -80,13 +79,12 @@ def update(
     if projectdir is None:
         projectdir = Path.cwd()
 
-    template = getprojecttemplate(projectdir)
-    bindings = getprojectbindings(projectdir)
-    extrabindings = list(bindings) + list(extrabindings)
+    projectconfig = readprojectconfigfile2(projectdir)
+    extrabindings = list(projectconfig.bindings) + list(extrabindings)
 
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:
         create(
-            template,
+            projectconfig.template,
             outputdir=worktree,
             outputdirisproject=True,
             extrabindings=extrabindings,

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -41,11 +41,7 @@ def readprojectconfigfile(project: pathlib.Path) -> dict[str, Any]:
 
 def getprojecttemplate(project: pathlib.Path) -> str:
     """Return the location of the project template."""
-    context = readprojectconfigfile(project)
-    result = context["_template"]
-    if not isinstance(result, str):
-        raise TypeError(f"{project}: _template must be 'str', got {result!r}")
-    return result
+    return readprojectconfigfile2(project).template
 
 
 def getprojectbindings(project: pathlib.Path) -> Sequence[Binding]:

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -35,7 +35,7 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration."""
     text = (project / PROJECT_CONFIG_FILE).read_text()
     data = json.loads(text)
-    context = {key: value for key, value in data.items() if isinstance(key, str)}
+    context = {key: value for key, value in data.items()}
     template = context.pop("_template")
 
     if not isinstance(template, str):

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -56,6 +56,9 @@ def getprojectbindings(project: pathlib.Path) -> Sequence[Binding]:
 
 def readprojectconfigfile2(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration."""
-    template = getprojecttemplate(project)
+    context = readprojectconfigfile(project)
+    template = context["_template"]
+    if not isinstance(template, str):
+        raise TypeError(f"{project}: _template must be 'str', got {template!r}")
     bindings = getprojectbindings(project)
     return ProjectConfig(template, bindings)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -39,11 +39,6 @@ def readprojectconfigfile(project: pathlib.Path) -> dict[str, Any]:
     return {key: value for key, value in data.items() if isinstance(key, str)}
 
 
-def getprojecttemplate(project: pathlib.Path) -> str:
-    """Return the location of the project template."""
-    return readprojectconfigfile2(project).template
-
-
 def getprojectbindings(project: pathlib.Path) -> Sequence[Binding]:
     """Return the variable bindings of the project."""
     context = readprojectconfigfile(project)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -2,6 +2,7 @@
 import json
 import pathlib
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any
 from typing import Sequence
 
@@ -11,6 +12,14 @@ from cutty.templates.domain.bindings import Binding
 
 
 PROJECT_CONFIG_FILE = "cutty.json"
+
+
+@dataclass
+class ProjectConfig:
+    """Project configuration."""
+
+    template: str
+    bindings: Sequence[Binding]
 
 
 def createprojectconfigfile(

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -2,7 +2,6 @@
 import json
 import pathlib
 from dataclasses import dataclass
-from typing import Any
 from typing import Sequence
 
 from cutty.filestorage.domain.files import RegularFile
@@ -32,16 +31,11 @@ def createprojectconfigfile(project: PurePath, config: ProjectConfig) -> Regular
     return RegularFile(path, blob)
 
 
-def readprojectconfigfile(project: pathlib.Path) -> dict[str, Any]:
-    """Return the Cookiecutter context of the project."""
-    text = (project / PROJECT_CONFIG_FILE).read_text()
-    data = json.loads(text)
-    return {key: value for key, value in data.items() if isinstance(key, str)}
-
-
 def readprojectconfigfile2(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration."""
-    context = readprojectconfigfile(project)
+    text = (project / PROJECT_CONFIG_FILE).read_text()
+    data = json.loads(text)
+    context = {key: value for key, value in data.items() if isinstance(key, str)}
     template = context.pop("_template")
 
     if not isinstance(template, str):

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -42,7 +42,7 @@ def readprojectconfigfile(project: pathlib.Path) -> dict[str, Any]:
 def readprojectconfigfile2(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration."""
     context = readprojectconfigfile(project)
-    template = context["_template"]
+    template = context.pop("_template")
 
     if not isinstance(template, str):
         raise TypeError(f"{project}: _template must be 'str', got {template!r}")

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -39,17 +39,15 @@ def readprojectconfigfile(project: pathlib.Path) -> dict[str, Any]:
     return {key: value for key, value in data.items() if isinstance(key, str)}
 
 
-def getprojectbindings(project: pathlib.Path) -> Sequence[Binding]:
-    """Return the variable bindings of the project."""
-    context = readprojectconfigfile(project)
-    return [Binding(key, value) for key, value in context.items()]
-
-
 def readprojectconfigfile2(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration."""
     context = readprojectconfigfile(project)
     template = context["_template"]
+
     if not isinstance(template, str):
         raise TypeError(f"{project}: _template must be 'str', got {template!r}")
-    bindings = getprojectbindings(project)
+
+    context = readprojectconfigfile(project)
+    bindings = [Binding(key, value) for key, value in context.items()]
+
     return ProjectConfig(template, bindings)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -1,7 +1,6 @@
 """Configuration for projects generated from Cookiecutter templates."""
 import json
 import pathlib
-from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 from typing import Sequence
@@ -22,13 +21,11 @@ class ProjectConfig:
     bindings: Sequence[Binding]
 
 
-def createprojectconfigfile(
-    project: PurePath, bindings: Iterable[Binding], template: str
-) -> RegularFile:
+def createprojectconfigfile(project: PurePath, config: ProjectConfig) -> RegularFile:
     """Create a JSON file with the settings and bindings for a project."""
     path = project / PROJECT_CONFIG_FILE
-    data = {binding.name: binding.value for binding in bindings} | {
-        "_template": template
+    data = {binding.name: binding.value for binding in config.bindings} | {
+        "_template": config.template
     }
     blob = json.dumps(data).encode()
 

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -47,7 +47,6 @@ def readprojectconfigfile2(project: pathlib.Path) -> ProjectConfig:
     if not isinstance(template, str):
         raise TypeError(f"{project}: _template must be 'str', got {template!r}")
 
-    context = readprojectconfigfile(project)
     bindings = [Binding(key, value) for key, value in context.items()]
 
     return ProjectConfig(template, bindings)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -31,7 +31,7 @@ def createprojectconfigfile(project: PurePath, config: ProjectConfig) -> Regular
     return RegularFile(path, blob)
 
 
-def readprojectconfigfile2(project: pathlib.Path) -> ProjectConfig:
+def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration."""
     text = (project / PROJECT_CONFIG_FILE).read_text()
     data = json.loads(text)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -52,3 +52,10 @@ def getprojectbindings(project: pathlib.Path) -> Sequence[Binding]:
     """Return the variable bindings of the project."""
     context = readprojectconfigfile(project)
     return [Binding(key, value) for key, value in context.items()]
+
+
+def readprojectconfigfile2(project: pathlib.Path) -> ProjectConfig:
+    """Load the project configuration."""
+    template = getprojecttemplate(project)
+    bindings = getprojectbindings(project)
+    return ProjectConfig(template, bindings)

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -64,4 +64,4 @@ def test_readprojectconfigfile_template_typeerror(tmp_path: pathlib.Path) -> Non
     (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
 
     with pytest.raises(TypeError):
-        readprojectconfigfile(tmp_path).template
+        readprojectconfigfile(tmp_path)

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -40,7 +40,8 @@ def test_createprojectconfigfile_template() -> None:
 
 def test_readprojectconfigfile(tmp_path: pathlib.Path) -> None:
     """It returns the persisted Cookiecutter context."""
-    context = {"project": "example"}
+    template = "https://example.com/repository.git"
+    context = {"_template": template, "project": "example"}
     text = json.dumps(context)
     (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
 

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -6,10 +6,10 @@ import pytest
 
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
-from cutty.templates.adapters.cookiecutter.projectconfig import getprojecttemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.templates.adapters.cookiecutter.projectconfig import ProjectConfig
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
+from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile2
 from cutty.templates.domain.bindings import Binding
 
 
@@ -54,7 +54,7 @@ def test_getprojecttemplate(tmp_path: pathlib.Path) -> None:
     text = json.dumps({"_template": template})
     (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
 
-    assert template == getprojecttemplate(tmp_path)
+    assert template == readprojectconfigfile2(tmp_path).template
 
 
 def test_getprojecttemplate_typeerror(tmp_path: pathlib.Path) -> None:
@@ -64,4 +64,4 @@ def test_getprojecttemplate_typeerror(tmp_path: pathlib.Path) -> None:
     (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
 
     with pytest.raises(TypeError):
-        getprojecttemplate(tmp_path)
+        readprojectconfigfile2(tmp_path).template

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -8,7 +8,7 @@ from cutty.filesystems.domain.purepath import PurePath
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.templates.adapters.cookiecutter.projectconfig import ProjectConfig
-from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile2
+from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
 
@@ -45,7 +45,7 @@ def test_readprojectconfigfile(tmp_path: pathlib.Path) -> None:
     file = createprojectconfigfile(PurePath(), config)
     tmp_path.joinpath(*file.path.parts).write_bytes(file.blob)
 
-    assert config == readprojectconfigfile2(tmp_path)
+    assert config == readprojectconfigfile(tmp_path)
 
 
 def test_getprojecttemplate(tmp_path: pathlib.Path) -> None:
@@ -54,7 +54,7 @@ def test_getprojecttemplate(tmp_path: pathlib.Path) -> None:
     text = json.dumps({"_template": template})
     (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
 
-    assert template == readprojectconfigfile2(tmp_path).template
+    assert template == readprojectconfigfile(tmp_path).template
 
 
 def test_getprojecttemplate_typeerror(tmp_path: pathlib.Path) -> None:
@@ -64,4 +64,4 @@ def test_getprojecttemplate_typeerror(tmp_path: pathlib.Path) -> None:
     (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
 
     with pytest.raises(TypeError):
-        readprojectconfigfile2(tmp_path).template
+        readprojectconfigfile(tmp_path).template

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -8,7 +8,6 @@ from cutty.filesystems.domain.purepath import PurePath
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.templates.adapters.cookiecutter.projectconfig import ProjectConfig
-from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile2
 from cutty.templates.domain.bindings import Binding
 
@@ -41,11 +40,12 @@ def test_createprojectconfigfile_template() -> None:
 def test_readprojectconfigfile(tmp_path: pathlib.Path) -> None:
     """It returns the persisted Cookiecutter context."""
     template = "https://example.com/repository.git"
-    context = {"_template": template, "project": "example"}
-    text = json.dumps(context)
-    (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
+    bindings = [Binding("project", "example")]
+    config = ProjectConfig(template, bindings)
+    file = createprojectconfigfile(PurePath(), config)
+    tmp_path.joinpath(*file.path.parts).write_bytes(file.blob)
 
-    assert context == readprojectconfigfile(tmp_path)
+    assert config == readprojectconfigfile2(tmp_path)
 
 
 def test_getprojecttemplate(tmp_path: pathlib.Path) -> None:

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -48,7 +48,7 @@ def test_readprojectconfigfile(tmp_path: pathlib.Path) -> None:
     assert config == readprojectconfigfile(tmp_path)
 
 
-def test_getprojecttemplate(tmp_path: pathlib.Path) -> None:
+def test_readprojectconfigfile_template(tmp_path: pathlib.Path) -> None:
     """It returns the `_template` key from cutty.json."""
     template = "https://example.com/repository.git"
     text = json.dumps({"_template": template})
@@ -57,7 +57,7 @@ def test_getprojecttemplate(tmp_path: pathlib.Path) -> None:
     assert template == readprojectconfigfile(tmp_path).template
 
 
-def test_getprojecttemplate_typeerror(tmp_path: pathlib.Path) -> None:
+def test_readprojectconfigfile_template_typeerror(tmp_path: pathlib.Path) -> None:
     """It checks that `_template` key is a string."""
     template = None
     text = json.dumps({"_template": template})

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -8,6 +8,7 @@ from cutty.filesystems.domain.purepath import PurePath
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
 from cutty.templates.adapters.cookiecutter.projectconfig import getprojecttemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
+from cutty.templates.adapters.cookiecutter.projectconfig import ProjectConfig
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
@@ -18,7 +19,8 @@ def test_createprojectconfigfile_bindings() -> None:
     project = PurePath("example")
     bindings = [Binding("project", "example"), Binding("license", "MIT")]
 
-    file = createprojectconfigfile(project, bindings, template)
+    config = ProjectConfig(template, bindings)
+    file = createprojectconfigfile(project, config)
 
     data = json.loads(file.blob.decode())
     assert all(binding.name in data for binding in bindings)
@@ -30,7 +32,8 @@ def test_createprojectconfigfile_template() -> None:
     project = PurePath("example")
     bindings = [Binding("Project", "example")]
 
-    file = createprojectconfigfile(project, bindings, template)
+    config = ProjectConfig(template, bindings)
+    file = createprojectconfigfile(project, config)
 
     assert "_template" in json.loads(file.blob.decode())
 

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -54,7 +54,9 @@ def test_readprojectconfigfile_template(tmp_path: pathlib.Path) -> None:
     text = json.dumps({"_template": template})
     (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
 
-    assert template == readprojectconfigfile(tmp_path).template
+    config = readprojectconfigfile(tmp_path)
+
+    assert template == config.template
 
 
 def test_readprojectconfigfile_template_typeerror(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
- :recycle: [templates] Add class `cookiecutter.ProjectConfig`
- :recycle: [templates] Change function `createprojectconfigfile` to accept `ProjectConfig`
- :recycle: [templates] Add `readprojectconfigfile2` returning `ProjectConfig`
- :recycle: [services] Replace inline code with function call to `readprojectconfigfile2`
- :white_check_mark: [templates] Add missing `_template` entry in project config test
- :recycle: [templates] Inline function `getprojecttemplate` into `readprojectconfigfile2`
- :recycle: [templates] Replace `getprojecttemplate` body with call to `readprojectconfigfile2`
- :recycle: [templates] Inline function `getprojecttemplate`
- :recycle: [templates] Inline function `getprojectbindings`
- :recycle: [templates] Avoid duplicate file read in `readprojectconfigfile2`
- :recycle: [templates] Avoid bogus `_template` binding in `readprojectconfigfile2`
- :white_check_mark: [templates] Modify `createprojectconfigfile` test to use `ProjectConfig`
- :recycle: [templates] Inline function `readprojectconfigfile`
- :recycle: [templates] Rename function `createprojectconfigfile{2 => }`
