### PR TITLE
:recycle: [templates] Reduce dependency on storage layout in project configuration tests

### DIFF
--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -6,7 +6,7 @@ from typing import Any
 import pygit2
 import pytest
 
-from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
+from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from tests.functional.conftest import RunCutty
 from tests.util.files import chdir
 from tests.util.git import removefile
@@ -38,9 +38,8 @@ def updateprojectvariable(template: Path, name: str, value: Any) -> None:
 
 def projectvariable(project: Path, name: str) -> Any:
     """Return the bound value of a project variable."""
-    path = project / PROJECT_CONFIG_FILE
-    data = json.loads(path.read_text())
-    return data[name]
+    config = readprojectconfigfile(project)
+    return next(binding.value for binding in config.bindings if binding.name == name)
 
 
 def test_trivial(runcutty: RunCutty, template: Path, project: Path) -> None:

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -4,6 +4,7 @@ import pathlib
 
 import pytest
 
+from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
@@ -35,6 +36,12 @@ def test_createprojectconfigfile_template() -> None:
     file = createprojectconfigfile(project, config)
 
     assert "_template" in json.loads(file.blob.decode())
+
+
+@pytest.fixture
+def storage(tmp_path: pathlib.Path) -> DiskFileStorage:
+    """Fixture for disk file storage."""
+    return DiskFileStorage(tmp_path / "storage")
 
 
 def test_readprojectconfigfile(tmp_path: pathlib.Path) -> None:

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -51,8 +51,11 @@ def test_readprojectconfigfile(tmp_path: pathlib.Path) -> None:
 def test_readprojectconfigfile_template(tmp_path: pathlib.Path) -> None:
     """It returns the `_template` key from cutty.json."""
     template = "https://example.com/repository.git"
-    text = json.dumps({"_template": template})
-    (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
+    bindings = [Binding("project", "example")]
+    config = ProjectConfig(template, bindings)
+    file = createprojectconfigfile(PurePath(), config)
+
+    (tmp_path.joinpath(*file.path.parts)).write_text(file.blob.decode())
 
     config = readprojectconfigfile(tmp_path)
 

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -13,6 +13,15 @@ from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfi
 from cutty.templates.domain.bindings import Binding
 
 
+@pytest.fixture
+def projectconfig() -> ProjectConfig:
+    """Fixture for a project configuration."""
+    template = "https://example.com/repository.git"
+    bindings = [Binding("project", "example"), Binding("license", "MIT")]
+
+    return ProjectConfig(template, bindings)
+
+
 def test_createprojectconfigfile_bindings() -> None:
     """It creates a JSON file with the bindings."""
     template = "https://example.com/repository.git"

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -57,20 +57,6 @@ def test_readprojectconfigfile(
     assert projectconfig == readprojectconfigfile(storage.root)
 
 
-def test_readprojectconfigfile_template(
-    storage: DiskFileStorage, projectconfig: ProjectConfig
-) -> None:
-    """It returns the `_template` key from cutty.json."""
-    file = createprojectconfigfile(PurePath(), projectconfig)
-
-    with storage:
-        storage.add(file)
-
-    projectconfig2 = readprojectconfigfile(storage.root)
-
-    assert projectconfig.template == projectconfig2.template
-
-
 def test_readprojectconfigfile_template_typeerror(tmp_path: pathlib.Path) -> None:
     """It checks that `_template` key is a string."""
     template = None

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -44,27 +44,30 @@ def storage(tmp_path: pathlib.Path) -> DiskFileStorage:
     return DiskFileStorage(tmp_path / "storage")
 
 
-def test_readprojectconfigfile(tmp_path: pathlib.Path) -> None:
+def test_readprojectconfigfile(storage: DiskFileStorage) -> None:
     """It returns the persisted Cookiecutter context."""
     template = "https://example.com/repository.git"
     bindings = [Binding("project", "example")]
     config = ProjectConfig(template, bindings)
     file = createprojectconfigfile(PurePath(), config)
-    tmp_path.joinpath(*file.path.parts).write_bytes(file.blob)
 
-    assert config == readprojectconfigfile(tmp_path)
+    with storage:
+        storage.add(file)
+
+    assert config == readprojectconfigfile(storage.root)
 
 
-def test_readprojectconfigfile_template(tmp_path: pathlib.Path) -> None:
+def test_readprojectconfigfile_template(storage: DiskFileStorage) -> None:
     """It returns the `_template` key from cutty.json."""
     template = "https://example.com/repository.git"
     bindings = [Binding("project", "example")]
     config = ProjectConfig(template, bindings)
     file = createprojectconfigfile(PurePath(), config)
 
-    (tmp_path.joinpath(*file.path.parts)).write_text(file.blob.decode())
+    with storage:
+        storage.add(file)
 
-    config = readprojectconfigfile(tmp_path)
+    config = readprojectconfigfile(storage.root)
 
     assert template == config.template
 

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -31,7 +31,7 @@ def storage(tmp_path: pathlib.Path) -> DiskFileStorage:
 def test_readprojectconfigfile(
     storage: DiskFileStorage, projectconfig: ProjectConfig
 ) -> None:
-    """It returns the persisted Cookiecutter context."""
+    """It returns the persisted project configuration."""
     file = createprojectconfigfile(PurePath(), projectconfig)
 
     with storage:

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -28,9 +28,7 @@ def storage(tmp_path: pathlib.Path) -> DiskFileStorage:
     return DiskFileStorage(tmp_path / "storage")
 
 
-def test_readprojectconfigfile(
-    storage: DiskFileStorage, projectconfig: ProjectConfig
-) -> None:
+def test_roundtrip(storage: DiskFileStorage, projectconfig: ProjectConfig) -> None:
     """It returns the persisted project configuration."""
     file = createprojectconfigfile(PurePath(), projectconfig)
 

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -22,23 +22,6 @@ def projectconfig() -> ProjectConfig:
     return ProjectConfig(template, bindings)
 
 
-def test_createprojectconfigfile_bindings(projectconfig: ProjectConfig) -> None:
-    """It creates a JSON file with the bindings."""
-    project = PurePath("example")
-    file = createprojectconfigfile(project, projectconfig)
-
-    data = json.loads(file.blob.decode())
-    assert all(binding.name in data for binding in projectconfig.bindings)
-
-
-def test_createprojectconfigfile_template(projectconfig: ProjectConfig) -> None:
-    """It creates a JSON file containing the template location."""
-    project = PurePath("example")
-    file = createprojectconfigfile(project, projectconfig)
-
-    assert "_template" in json.loads(file.blob.decode())
-
-
 @pytest.fixture
 def storage(tmp_path: pathlib.Path) -> DiskFileStorage:
     """Fixture for disk file storage."""

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -22,27 +22,19 @@ def projectconfig() -> ProjectConfig:
     return ProjectConfig(template, bindings)
 
 
-def test_createprojectconfigfile_bindings() -> None:
+def test_createprojectconfigfile_bindings(projectconfig: ProjectConfig) -> None:
     """It creates a JSON file with the bindings."""
-    template = "https://example.com/repository.git"
     project = PurePath("example")
-    bindings = [Binding("project", "example"), Binding("license", "MIT")]
-
-    config = ProjectConfig(template, bindings)
-    file = createprojectconfigfile(project, config)
+    file = createprojectconfigfile(project, projectconfig)
 
     data = json.loads(file.blob.decode())
-    assert all(binding.name in data for binding in bindings)
+    assert all(binding.name in data for binding in projectconfig.bindings)
 
 
-def test_createprojectconfigfile_template() -> None:
+def test_createprojectconfigfile_template(projectconfig: ProjectConfig) -> None:
     """It creates a JSON file containing the template location."""
-    template = "https://example.com/repository.git"
     project = PurePath("example")
-    bindings = [Binding("Project", "example")]
-
-    config = ProjectConfig(template, bindings)
-    file = createprojectconfigfile(project, config)
+    file = createprojectconfigfile(project, projectconfig)
 
     assert "_template" in json.loads(file.blob.decode())
 
@@ -53,32 +45,30 @@ def storage(tmp_path: pathlib.Path) -> DiskFileStorage:
     return DiskFileStorage(tmp_path / "storage")
 
 
-def test_readprojectconfigfile(storage: DiskFileStorage) -> None:
+def test_readprojectconfigfile(
+    storage: DiskFileStorage, projectconfig: ProjectConfig
+) -> None:
     """It returns the persisted Cookiecutter context."""
-    template = "https://example.com/repository.git"
-    bindings = [Binding("project", "example")]
-    config = ProjectConfig(template, bindings)
-    file = createprojectconfigfile(PurePath(), config)
+    file = createprojectconfigfile(PurePath(), projectconfig)
 
     with storage:
         storage.add(file)
 
-    assert config == readprojectconfigfile(storage.root)
+    assert projectconfig == readprojectconfigfile(storage.root)
 
 
-def test_readprojectconfigfile_template(storage: DiskFileStorage) -> None:
+def test_readprojectconfigfile_template(
+    storage: DiskFileStorage, projectconfig: ProjectConfig
+) -> None:
     """It returns the `_template` key from cutty.json."""
-    template = "https://example.com/repository.git"
-    bindings = [Binding("project", "example")]
-    config = ProjectConfig(template, bindings)
-    file = createprojectconfigfile(PurePath(), config)
+    file = createprojectconfigfile(PurePath(), projectconfig)
 
     with storage:
         storage.add(file)
 
-    config = readprojectconfigfile(storage.root)
+    projectconfig2 = readprojectconfigfile(storage.root)
 
-    assert template == config.template
+    assert projectconfig.template == projectconfig2.template
 
 
 def test_readprojectconfigfile_template_typeerror(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
- :recycle: [templates] Use `createprojectconfigfile` in `readprojectconfigfile` tests
- :recycle: [templates] Add fixture `storage`
- :recycle: [templates] Use file storage instead of I/O in `readprojectconfigfile` tests
- :recycle: [templates] Add `projectconfig` fixture
- :recycle: [templates] Replace inline code with `projectconfig` fixture
- :fire: [templates] Remove redundant test for `readprojectconfigfile`
- :fire: [templates] Remove redundant tests for `createprojectconfigfile`
- :bulb: [templates] Improve docstring for `readprojectconfigfile` test
- :recycle: [templates] Rename test for `readprojectconfigfile`
