### PR TITLE
:children_crossing: [templates] Improve storage layout of cutty.json to be more extensible

### DIFF
--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -23,8 +23,9 @@ class ProjectConfig:
 def createprojectconfigfile(project: PurePath, config: ProjectConfig) -> RegularFile:
     """Create a JSON file with the settings and bindings for a project."""
     path = project / PROJECT_CONFIG_FILE
-    data = {binding.name: binding.value for binding in config.bindings} | {
-        "_template": config.template
+    data = {
+        "template": {"location": config.template},
+        "bindings": {binding.name: binding.value for binding in config.bindings},
     }
     blob = json.dumps(data).encode()
 
@@ -36,11 +37,11 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     text = (project / PROJECT_CONFIG_FILE).read_text()
     data = json.loads(text)
     context = {key: value for key, value in data.items()}
-    template = context.pop("_template")
+    template = context["template"]["location"]
 
     if not isinstance(template, str):
         raise TypeError(f"{project}: _template must be 'str', got {template!r}")
 
-    bindings = [Binding(key, value) for key, value in context.items()]
+    bindings = [Binding(key, value) for key, value in context["bindings"].items()]
 
     return ProjectConfig(template, bindings)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -40,7 +40,7 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     template = context["template"]["location"]
 
     if not isinstance(template, str):
-        raise TypeError(f"{project}: _template must be 'str', got {template!r}")
+        raise TypeError(f"{project}: template location must be 'str', got {template!r}")
 
     bindings = [Binding(key, value) for key, value in context["bindings"].items()]
 

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -37,6 +37,10 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     path = project / PROJECT_CONFIG_FILE
     text = path.read_text()
     data = json.loads(text)
+
+    if not isinstance(data, dict):
+        raise TypeError(f"{path}: project configuration must be 'dict', got {data!r}")
+
     context = {key: value for key, value in data.items()}
     template = context["template"]["location"]
 

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -41,12 +41,11 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     if not isinstance(data, dict):
         raise TypeError(f"{path}: project configuration must be 'dict', got {data!r}")
 
-    context = {key: value for key, value in data.items()}
-    template = context["template"]["location"]
+    template = data["template"]["location"]
 
     if not isinstance(template, str):
         raise TypeError(f"{path}: template location must be 'str', got {template!r}")
 
-    bindings = [Binding(key, value) for key, value in context["bindings"].items()]
+    bindings = [Binding(key, value) for key, value in data["bindings"].items()]
 
     return ProjectConfig(template, bindings)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -34,13 +34,14 @@ def createprojectconfigfile(project: PurePath, config: ProjectConfig) -> Regular
 
 def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration."""
-    text = (project / PROJECT_CONFIG_FILE).read_text()
+    path = project / PROJECT_CONFIG_FILE
+    text = path.read_text()
     data = json.loads(text)
     context = {key: value for key, value in data.items()}
     template = context["template"]["location"]
 
     if not isinstance(template, str):
-        raise TypeError(f"{project}: template location must be 'str', got {template!r}")
+        raise TypeError(f"{path}: template location must be 'str', got {template!r}")
 
     bindings = [Binding(key, value) for key, value in context["bindings"].items()]
 

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -1,4 +1,5 @@
 """Unit tests for cutty.templates.adapters.cookiecutter.projectconfig."""
+import dataclasses
 import json
 import pathlib
 
@@ -35,6 +36,20 @@ def test_roundtrip(storage: DiskFileStorage, projectconfig: ProjectConfig) -> No
         storage.add(file)
 
     assert projectconfig == readprojectconfigfile(storage.root)
+
+
+def test_readprojectconfigfile_typeerror(
+    storage: DiskFileStorage, projectconfig: ProjectConfig
+) -> None:
+    """It checks that the template location is a string."""
+    file = createprojectconfigfile(PurePath(), projectconfig)
+    file = dataclasses.replace(file, blob=json.dumps("teapot").encode())
+
+    with storage:
+        storage.add(file)
+
+    with pytest.raises(TypeError):
+        readprojectconfigfile(storage.root)
 
 
 def test_readprojectconfigfile_template_typeerror(

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -40,8 +40,7 @@ def test_roundtrip(storage: DiskFileStorage, projectconfig: ProjectConfig) -> No
 
 def test_readprojectconfigfile_template_typeerror(tmp_path: pathlib.Path) -> None:
     """It checks that `_template` key is a string."""
-    template = None
-    text = json.dumps({"_template": template})
+    text = json.dumps({"template": {"location": None}, "bindings": []})
     (tmp_path / PROJECT_CONFIG_FILE).write_text(text)
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
- :white_check_mark: [templates] Adapt `readprojectconfigfile` test to change in storage layout
- :sparkles: [templates] Change the storage layout of cutty.json
- :recycle: [templates] Reduce dependency of `readprojectconfigfile` test on storage layout
- :children_crossing: [templates] Avoid storage layout details in error message
- :children_crossing: [templates] Include full path in error message
- :white_check_mark: [templates] Add test for cutty.json without dict
- :children_crossing: [templates] Improve error message when cutty.json does not contain dict
- :recycle: [templates] Remove redundant copy of project config data
