### PR TITLE
:sparkles: [services] Store template subdirectory in project configuration

### DIFF
--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -73,7 +73,7 @@ def create(
     projectconfigfile = (
         createprojectconfigfile(
             PurePath(*projectdir.relative_to(outputdir).parts),
-            ProjectConfig(template, bindings),
+            ProjectConfig(template, bindings, directory=directory),
         )
         if createconfigfile
         else None

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -90,6 +90,7 @@ def update(
             outputdirisproject=True,
             extrabindings=extrabindings,
             no_input=no_input,
+            directory=projectconfig.directory,
         )
 
     cherrypick(projectdir, LATEST_BRANCH_REF)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -24,9 +24,10 @@ class ProjectConfig:
 
 def createprojectconfigfile(project: PurePath, config: ProjectConfig) -> RegularFile:
     """Create a JSON file with the settings and bindings for a project."""
+    directory = str(config.directory) if config.directory is not None else None
     path = project / PROJECT_CONFIG_FILE
     data = {
-        "template": {"location": config.template},
+        "template": {"location": config.template, "directory": directory},
         "bindings": {binding.name: binding.value for binding in config.bindings},
     }
     blob = json.dumps(data).encode()
@@ -48,6 +49,11 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     if not isinstance(template, str):
         raise TypeError(f"{path}: template location must be 'str', got {template!r}")
 
+    directory = data["template"]["directory"]
     bindings = [Binding(key, value) for key, value in data["bindings"].items()]
 
-    return ProjectConfig(template, bindings)
+    return ProjectConfig(
+        template,
+        bindings,
+        directory=pathlib.PurePosixPath(directory) if directory is not None else None,
+    )

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -2,6 +2,7 @@
 import json
 import pathlib
 from dataclasses import dataclass
+from typing import Optional
 from typing import Sequence
 
 from cutty.filestorage.domain.files import RegularFile
@@ -18,6 +19,7 @@ class ProjectConfig:
 
     template: str
     bindings: Sequence[Binding]
+    directory: Optional[pathlib.PurePosixPath] = None
 
 
 def createprojectconfigfile(project: PurePath, config: ProjectConfig) -> RegularFile:

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -50,6 +50,12 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
         raise TypeError(f"{path}: template location must be 'str', got {template!r}")
 
     directory = data["template"]["directory"]
+
+    if not (directory is None or isinstance(directory, str)):
+        raise TypeError(
+            f"{path}: template directory must be 'str' or 'None', got {template!r}"
+        )
+
     bindings = [Binding(key, value) for key, value in data["bindings"].items()]
 
     return ProjectConfig(

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -270,6 +270,7 @@ def test_private_variables(runcutty: RunCutty, template: Path) -> None:
     assert extensions == privatevariable(project, "_extensions")
 
 
+@pytest.mark.xfail(reason="TODO")
 def test_directory(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
     """It uses the template in the subdirectory specified on creation."""
     project = Path("example")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -270,7 +270,6 @@ def test_private_variables(runcutty: RunCutty, template: Path) -> None:
     assert extensions == privatevariable(project, "_extensions")
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_directory(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
     """It uses the template in the subdirectory specified on creation."""
     project = Path("example")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -9,6 +9,7 @@ import pytest
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from tests.functional.conftest import RunCutty
 from tests.util.files import chdir
+from tests.util.git import move_repository_files_to_subdirectory
 from tests.util.git import removefile
 from tests.util.git import updatefile
 
@@ -267,3 +268,16 @@ def test_private_variables(runcutty: RunCutty, template: Path) -> None:
     runcutty("update", f"--cwd={project}")
 
     assert extensions == privatevariable(project, "_extensions")
+
+
+def test_directory(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
+    """It uses the template in the subdirectory specified on creation."""
+    project = Path("example")
+    directory = "a"
+    move_repository_files_to_subdirectory(template, directory)
+
+    runcutty("create", f"--directory={directory}", str(template))
+    updatefile(template / "a" / "{{ cookiecutter.project }}" / "LICENSE")
+    runcutty("update", f"--cwd={project}")
+
+    assert (project / "LICENSE").is_file()

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -19,7 +19,7 @@ def projectconfig() -> ProjectConfig:
     template = "https://example.com/repository.git"
     bindings = [Binding("project", "example"), Binding("license", "MIT")]
 
-    return ProjectConfig(template, bindings)
+    return ProjectConfig(template, bindings, directory=pathlib.PurePosixPath("a"))
 
 
 @pytest.fixture

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -68,3 +68,21 @@ def test_readprojectconfigfile_template_typeerror(
 
     with pytest.raises(TypeError):
         readprojectconfigfile(storage.root)
+
+
+def test_readprojectconfigfile_directory_typeerror(
+    storage: DiskFileStorage, projectconfig: ProjectConfig
+) -> None:
+    """It checks that the template directory is a string or None."""
+    file = createprojectconfigfile(PurePath(), projectconfig)
+
+    # Replace the template location with 42 in the JSON record.
+    data = json.loads(file.blob.decode())
+    data["template"]["directory"] = 42
+    file = dataclasses.replace(file, blob=json.dumps(data).encode())
+
+    with storage:
+        storage.add(file)
+
+    with pytest.raises(TypeError):
+        readprojectconfigfile(storage.root)


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty update` with template subdirectory
- :white_check_mark: [functional] Apply XFAIL marker
- :white_check_mark: [templates] Change `projectconfig` fixture to include `directory`
- :sparkles: [templates] Add optional `directory` attribute to `ProjectConfig`
- :sparkles: [templates] Store and load template directory from cutty.json
- :white_check_mark: [templates] Add test for invalid template directory in cutty.json
- :sparkles: [templates] Improve error message when template directory has the wrong type
- :rewind: [functional] Revert "Apply XFAIL marker"
- :sparkles: [services] Store template directory in cutty.json on creation
- :sparkles: [services] Use `directory` from project configuration when updating
