### PR TITLE
:sparkles: [entrypoints] Add `cutty update --directory=<directory>`

### DIFF
--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -25,11 +25,26 @@ from cutty.templates.domain.bindings import Binding
     ),
     help="Directory of the generated project.",
 )
+@click.option(
+    "--directory",
+    metavar="DIR",
+    type=click.Path(path_type=pathlib.Path),
+    help=(
+        "Directory within the template repository that contains the "
+        "cookiecutter.json file."
+    ),
+)
 def update(
     extra_context: dict[str, str],
     no_input: bool,
     cwd: Optional[pathlib.Path],
+    directory: Optional[pathlib.Path],
 ) -> None:
     """Update a project with changes from its template."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-    service_update(extrabindings=extrabindings, no_input=no_input, projectdir=cwd)
+    service_update(
+        extrabindings=extrabindings,
+        no_input=no_input,
+        projectdir=cwd,
+        directory=pathlib.PurePosixPath(directory) if directory is not None else None,
+    )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -3,6 +3,7 @@ import hashlib
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Optional
 from typing import Sequence
 
@@ -75,6 +76,7 @@ def update(
     projectdir: Optional[Path] = None,
     extrabindings: Sequence[Binding] = (),
     no_input: bool = False,
+    directory: Optional[PurePosixPath] = None,
 ) -> None:
     """Update a project with changes from its Cookiecutter template."""
     if projectdir is None:
@@ -83,6 +85,9 @@ def update(
     projectconfig = readprojectconfigfile(projectdir)
     extrabindings = list(projectconfig.bindings) + list(extrabindings)
 
+    if directory is None:
+        directory = projectconfig.directory
+
     with createworktree(projectdir, LATEST_BRANCH, checkout=False) as worktree:
         create(
             projectconfig.template,
@@ -90,7 +95,7 @@ def update(
             outputdirisproject=True,
             extrabindings=extrabindings,
             no_input=no_input,
-            directory=projectconfig.directory,
+            directory=directory,
         )
 
     cherrypick(projectdir, LATEST_BRANCH_REF)

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -281,3 +281,14 @@ def test_directory_projectconfig(runcutty: RunCutty, template: Path) -> None:
     runcutty("update", f"--cwd={project}")
 
     assert (project / "LICENSE").is_file()
+
+
+def test_directory_update(runcutty: RunCutty, template: Path, project: Path) -> None:
+    """It uses the template directory specified when updating."""
+    directory = "a"
+    move_repository_files_to_subdirectory(template, directory)
+
+    runcutty("update", f"--cwd={project}", f"--directory={directory}")
+
+    config = readprojectconfigfile(project)
+    assert directory == str(config.directory)

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -270,8 +270,8 @@ def test_private_variables(runcutty: RunCutty, template: Path) -> None:
     assert extensions == privatevariable(project, "_extensions")
 
 
-def test_directory(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
-    """It uses the template in the subdirectory specified on creation."""
+def test_directory_projectconfig(runcutty: RunCutty, template: Path) -> None:
+    """It uses the template directory specified in the project configuration."""
     project = Path("example")
     directory = "a"
     move_repository_files_to_subdirectory(template, directory)


### PR DESCRIPTION
- :recycle: [functional] Rename existing test for updating with template directory
- :white_check_mark: [functional] Add test for `cutty update --directory=<directory>`
- :sparkles: [services] Add optional `directory` parameter to `update` service
- :sparkles: [entrypoints] Add `cutty update --directory=<directory>`
