### PR TITLE
:sparkles: [entrypoints] Add `cutty update --checkout=<revision>`

### DIFF
--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -26,6 +26,12 @@ from cutty.templates.domain.bindings import Binding
     help="Directory of the generated project.",
 )
 @click.option(
+    "-c",
+    "--checkout",
+    metavar="REV",
+    help="Branch, tag, or commit hash of the template repository.",
+)
+@click.option(
     "--directory",
     metavar="DIR",
     type=click.Path(path_type=pathlib.Path),
@@ -38,6 +44,7 @@ def update(
     extra_context: dict[str, str],
     no_input: bool,
     cwd: Optional[pathlib.Path],
+    checkout: Optional[str],
     directory: Optional[pathlib.Path],
 ) -> None:
     """Update a project with changes from its template."""

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -53,5 +53,6 @@ def update(
         extrabindings=extrabindings,
         no_input=no_input,
         projectdir=cwd,
+        checkout=checkout,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -76,6 +76,7 @@ def update(
     projectdir: Optional[Path] = None,
     extrabindings: Sequence[Binding] = (),
     no_input: bool = False,
+    checkout: Optional[str] = None,
     directory: Optional[PurePosixPath] = None,
 ) -> None:
     """Update a project with changes from its Cookiecutter template."""
@@ -95,6 +96,7 @@ def update(
             outputdirisproject=True,
             extrabindings=extrabindings,
             no_input=no_input,
+            checkout=checkout,
             directory=directory,
         )
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -292,3 +292,16 @@ def test_directory_update(runcutty: RunCutty, template: Path, project: Path) -> 
 
     config = readprojectconfigfile(project)
     assert directory == str(config.directory)
+
+
+def test_checkout(runcutty: RunCutty, template: Path, project: Path) -> None:
+    """It uses the specified revision of the template."""
+    updatefile(template / "{{ cookiecutter.project }}" / "LICENSE", "first version")
+
+    revision = pygit2.Repository(template).head.target
+
+    updatefile(template / "{{ cookiecutter.project }}" / "LICENSE", "second version")
+
+    runcutty("update", f"--cwd={project}", f"--checkout={revision}")
+
+    assert (project / "LICENSE").read_text() == "first version"


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty update --checkout`
- :sparkles: [entrypoints] Add option `--checkout`
- :sparkles: [services] Expose `checkout` parameter in `update` service
