### PR TITLE
:sparkles: [services] Do not skip changes after `cutty update` was aborted

### DIFF
--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -65,10 +65,10 @@ class GitRepositoryObserver(FileStorageObserver):
         except pygit2.GitError:
             repository = pygit2.init_repository(self.project)
 
-        if LATEST_BRANCH in repository.branches:
-            # HEAD must point to latest branch if it exists.
+        if UPDATE_BRANCH in repository.branches:
+            # HEAD must point to update branch if it exists.
             head = repository.references["HEAD"].target
-            if head != LATEST_BRANCH_REF:
+            if head != UPDATE_BRANCH_REF:
                 raise RuntimeError(f"unexpected HEAD: {head}")
 
         message = (

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -9,7 +9,7 @@ import pygit2
 from cutty.filestorage.domain.observers import FileStorageObserver
 
 
-LATEST_BRANCH = "cutty/latest"
+LATEST_BRANCH = UPDATE_BRANCH = "cutty/latest"
 LATEST_BRANCH_REF = f"refs/heads/{LATEST_BRANCH}"
 CREATE_MESSAGE = "Initial import"
 UPDATE_MESSAGE = "Update project template"

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -11,6 +11,7 @@ from cutty.filestorage.domain.observers import FileStorageObserver
 
 LATEST_BRANCH = UPDATE_BRANCH = "cutty/latest"
 LATEST_BRANCH_REF = f"refs/heads/{LATEST_BRANCH}"
+UPDATE_BRANCH_REF = f"refs/heads/{UPDATE_BRANCH}"
 CREATE_MESSAGE = "Initial import"
 UPDATE_MESSAGE = "Update project template"
 

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -9,8 +9,9 @@ import pygit2
 from cutty.filestorage.domain.observers import FileStorageObserver
 
 
-LATEST_BRANCH = UPDATE_BRANCH = "cutty/latest"
+LATEST_BRANCH = "cutty/latest"
 LATEST_BRANCH_REF = f"refs/heads/{LATEST_BRANCH}"
+UPDATE_BRANCH = "cutty/update"
 UPDATE_BRANCH_REF = f"refs/heads/{UPDATE_BRANCH}"
 CREATE_MESSAGE = "Initial import"
 UPDATE_MESSAGE = "Update project template"

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -82,6 +82,13 @@ def createbranch(
     repository.branches.create(branch, commit, force=force)
 
 
+def updatebranch(repositorypath: Path, branch: str, *, target: str) -> None:
+    """Update a branch to the given target, another branch."""
+    repository = pygit2.Repository(repositorypath)
+    commit = repository.branches[target].peel()
+    repository.branches[branch].set_target(commit.id)
+
+
 def update(
     *,
     projectdir: Optional[Path] = None,
@@ -115,7 +122,4 @@ def update(
 
     cherrypick(projectdir, UPDATE_BRANCH_REF)
 
-    repository = pygit2.Repository(projectdir)
-    repository.branches[LATEST_BRANCH].set_target(
-        repository.branches[UPDATE_BRANCH].peel().id
-    )
+    updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -43,6 +43,7 @@ def createworktree(
 
         if not checkout:
             # Emulate `--no-checkout` by checking out an empty tree after the fact.
+            # https://github.com/libgit2/libgit2/issues/5949
             checkoutemptytree(path)
 
         yield path

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -307,7 +307,6 @@ def test_checkout(runcutty: RunCutty, template: Path, project: Path) -> None:
     assert (project / "LICENSE").read_text() == "first version"
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_conflict_abort(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does not skip changes when a previous update was aborted."""
     updatefile(project / "LICENSE", "this is the version in the project")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -305,3 +305,26 @@ def test_checkout(runcutty: RunCutty, template: Path, project: Path) -> None:
     runcutty("update", f"--cwd={project}", f"--checkout={revision}")
 
     assert (project / "LICENSE").read_text() == "first version"
+
+
+def test_conflict_abort(runcutty: RunCutty, template: Path, project: Path) -> None:
+    """It does not skip changes when a previous update was aborted."""
+    updatefile(project / "LICENSE", "this is the version in the project")
+    updatefile(
+        template / "{{ cookiecutter.project }}" / "LICENSE",
+        "this is the version in the template",
+    )
+
+    with pytest.raises(Exception, match="conflict"):
+        runcutty("update", f"--cwd={project}")
+
+    # Abort the cherry-pick, unceremoniously.
+    repository = pygit2.Repository(project)
+    repository.reset(repository.head.target, pygit2.GIT_RESET_HARD)
+
+    # Update the template with an unproblematic change.
+    updatefile(template / "{{ cookiecutter.project }}" / "INSTALL")
+
+    # Repeat the update, it should fail again.
+    with pytest.raises(Exception, match="conflict"):
+        runcutty("update", f"--cwd={project}")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -307,6 +307,7 @@ def test_checkout(runcutty: RunCutty, template: Path, project: Path) -> None:
     assert (project / "LICENSE").read_text() == "first version"
 
 
+@pytest.mark.xfail(reason="TODO")
 def test_conflict_abort(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does not skip changes when a previous update was aborted."""
     updatefile(project / "LICENSE", "this is the version in the project")

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -9,6 +9,8 @@ from cutty.filestorage.adapters.observers.git import commit as _commit
 from cutty.filestorage.adapters.observers.git import GitRepositoryObserver
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH_REF
+from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
+from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH_REF
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
@@ -147,11 +149,11 @@ def test_branch_not_checked_out(
 def test_existing_branch(
     storage: FileStorage, file: RegularFile, project: pathlib.Path
 ) -> None:
-    """It updates the `latest` branch if it exists."""
+    """It updates the `update` branch if it exists."""
     repository = pygit2.init_repository(project)
     commit(repository)
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
-    repository.set_head(LATEST_BRANCH_REF)
+    repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
         storage.add(file)
@@ -162,10 +164,10 @@ def test_existing_branch(
 def test_existing_branch_not_head(
     storage: FileStorage, file: RegularFile, project: pathlib.Path
 ) -> None:
-    """It raises an exception if `latest` exists but HEAD points elsewhere."""
+    """It raises an exception if `update` exists but HEAD points elsewhere."""
     repository = pygit2.init_repository(project)
     commit(repository)
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
+    repository.branches.create(UPDATE_BRANCH, repository.head.peel())
 
     with pytest.raises(Exception):
         with storage:
@@ -181,7 +183,8 @@ def test_existing_branch_commit_message(
     repository = pygit2.init_repository(project)
     commit(repository)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
-    repository.set_head(LATEST_BRANCH_REF)
+    repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
         storage.add(file)
@@ -197,8 +200,8 @@ def test_existing_branch_no_changes(
     repository = pygit2.init_repository(project)
     commit(repository)
 
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
-    repository.set_head(LATEST_BRANCH_REF)
+    repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    repository.set_head(UPDATE_BRANCH_REF)
     oldhead = repository.head.target
 
     with storage:


### PR DESCRIPTION
- :bulb: [services] Add comment with libgit2 issue for `git worktree add --no-checkout`
- :white_check_mark: [functional] Add test for retrying an update after abort
- :white_check_mark: [functional] Apply XFAIL marker
- :recycle: [filestorage] Add constant `UPDATE_BRANCH` as alias for `LATEST_BRANCH`
- :recycle: [filestorage] Add constant `UPDATE_BRANCH_REF`
- :recycle: [filestorage] Use `UPDATE_BRANCH `for updates
- :recycle: [filestorage] Change tests to use `UPDATE_BRANCH` for updates
- :sparkles: [services] Update `cutty/latest` only if cherrypick succeeded
- :sparkles: [filestorage] Set `UPDATE_BRANCH` to `cutty/update` instead of aliasing `LATEST_BRANCH`
- :rewind: [functional] Revert "Apply XFAIL marker"
- :recycle: [services] Extract function `createbranch`
- :recycle: [services] Extract function `updatebranch`
