### PR TITLE
:sparkles: [services] Add `cutty update --continue`

### DIFF
--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -40,12 +40,20 @@ from cutty.templates.domain.bindings import Binding
         "cookiecutter.json file."
     ),
 )
+@click.option(
+    "continue_",
+    "--continue",
+    is_flag=True,
+    default=False,
+    help="Resume updating after conflict resolution.",
+)
 def update(
     extra_context: dict[str, str],
     no_input: bool,
     cwd: Optional[pathlib.Path],
     checkout: Optional[str],
     directory: Optional[pathlib.Path],
+    continue_: bool = False,
 ) -> None:
     """Update a project with changes from its template."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -5,6 +5,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
+from cutty.services.update import continueupdate
 from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
 
@@ -56,6 +57,10 @@ def update(
     continue_: bool = False,
 ) -> None:
     """Update a project with changes from its template."""
+    if continue_:
+        continueupdate(projectdir=cwd)
+        return
+
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
     service_update(
         extrabindings=extrabindings,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -123,3 +123,12 @@ def update(
     cherrypick(projectdir, UPDATE_BRANCH_REF)
 
     updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
+
+
+def continueupdate(*, projectdir: Optional[Path] = None) -> None:
+    """Continue an update after conflict resolution."""
+    if projectdir is None:
+        projectdir = Path.cwd()
+
+    commit(pygit2.Repository(projectdir), message=UPDATE_MESSAGE)
+    updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -4,9 +4,15 @@ from pathlib import Path
 import pygit2
 import pytest
 
+from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
+from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.update import cherrypick
+from cutty.services.update import continueupdate
 from cutty.services.update import createworktree
+from tests.util.files import chdir
 from tests.util.git import commit
+from tests.util.git import resolveconflicts
+from tests.util.git import Side
 
 
 def test_createworktree(tmp_path: Path) -> None:
@@ -101,3 +107,38 @@ def test_cherrypick_conflict_deletion(tmp_path: Path) -> None:
 
     with pytest.raises(Exception, match="README"):
         cherrypick(repositorypath, otherbranch.name)
+
+
+def test_continueupdate(tmp_path: Path) -> None:
+    """It commits the changes and updates the latest branch."""
+    repositorypath = tmp_path / "repository"
+    repository = pygit2.init_repository(repositorypath)
+    commit(repositorypath, message="Initial")
+
+    mainbranch = repository.references[repository.references["HEAD"].target]
+    repository.branches.create(LATEST_BRANCH, repository.head.peel())
+    updatebranch = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+
+    (repositorypath / "README").write_text("This is the version on the main branch.")
+    commit(repositorypath, message="Add README")
+
+    repository.checkout(updatebranch)
+    (repositorypath / "README").write_text("This is the version on the update branch.")
+    commit(repositorypath, message="Add README")
+
+    repository.checkout(mainbranch)
+
+    with pytest.raises(Exception, match="README"):
+        cherrypick(repositorypath, updatebranch.name)
+
+    resolveconflicts(repositorypath, repositorypath / "README", Side.THEIRS)
+
+    with chdir(repositorypath):
+        continueupdate()
+
+    blob = repository.head.peel().tree / "README"
+    assert blob.data == b"This is the version on the update branch."
+    assert (
+        repository.branches[LATEST_BRANCH].peel()
+        == repository.branches[UPDATE_BRANCH].peel()
+    )


### PR DESCRIPTION
- :white_check_mark: [util] Add function `resolveconflicts` to git utilities
- :white_check_mark: [functional] Add test for `cutty update --continue`
- :sparkles: [entrypoints] Add option `--continue` to `cutty update`
- :white_check_mark: [services] Add test for `continueupdate` function
- :sparkles: [services] Add function `continueupdate`
- :sparkles: [entrypoints] Implement `cutty update --continue`
