### PR TITLE
:sparkles: [services] Add `cutty update --skip`

### DIFF
--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -6,6 +6,7 @@ import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.update import continueupdate
+from cutty.services.update import skipupdate
 from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
 
@@ -48,17 +49,28 @@ from cutty.templates.domain.bindings import Binding
     default=False,
     help="Resume updating after conflict resolution.",
 )
+@click.option(
+    "--skip",
+    is_flag=True,
+    default=False,
+    help="Skip the current update.",
+)
 def update(
     extra_context: dict[str, str],
     no_input: bool,
     cwd: Optional[pathlib.Path],
     checkout: Optional[str],
     directory: Optional[pathlib.Path],
-    continue_: bool = False,
+    continue_: bool,
+    skip: bool,
 ) -> None:
     """Update a project with changes from its template."""
     if continue_:
         continueupdate(projectdir=cwd)
+        return
+
+    if skip:
+        skipupdate(projectdir=cwd)
         return
 
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -132,3 +132,11 @@ def continueupdate(*, projectdir: Optional[Path] = None) -> None:
 
     commit(pygit2.Repository(projectdir), message=UPDATE_MESSAGE)
     updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
+
+
+def skipupdate(*, projectdir: Optional[Path] = None) -> None:
+    """Skip an update with conflicts."""
+    if projectdir is None:
+        projectdir = Path.cwd()
+
+    updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -139,4 +139,7 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
+    repository = pygit2.Repository(projectdir)
+    repository.index.read_tree(repository.head.peel().tree)
+    repository.index.write()
     updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -142,4 +142,6 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
     repository = pygit2.Repository(projectdir)
     repository.index.read_tree(repository.head.peel().tree)
     repository.index.write()
+    repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE)
+
     updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -348,3 +348,25 @@ def test_continue(runcutty: RunCutty, template: Path, project: Path) -> None:
     runcutty("update", f"--cwd={project}", "--continue")
 
     assert (project / "LICENSE").read_text() == "this is the version in the template"
+
+
+def test_skip(runcutty: RunCutty, template: Path, project: Path) -> None:
+    """It skips the update."""
+    updatefile(project / "LICENSE", "this is the version in the project")
+    updatefile(
+        template / "{{ cookiecutter.project }}" / "LICENSE",
+        "this is the version in the template",
+    )
+
+    with pytest.raises(Exception, match="conflict"):
+        runcutty("update", f"--cwd={project}")
+
+    runcutty("update", f"--cwd={project}", "--skip")
+
+    # Update the template with an unproblematic change.
+    updatefile(template / "{{ cookiecutter.project }}" / "INSTALL")
+
+    runcutty("update", f"--cwd={project}")
+
+    assert (project / "LICENSE").read_text() == "this is the version in the project"
+    assert (project / "INSTALL").is_file()

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -350,7 +350,6 @@ def test_continue(runcutty: RunCutty, template: Path, project: Path) -> None:
     assert (project / "LICENSE").read_text() == "this is the version in the template"
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_skip(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It skips the update."""
     updatefile(project / "LICENSE", "this is the version in the project")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -350,6 +350,7 @@ def test_continue(runcutty: RunCutty, template: Path, project: Path) -> None:
     assert (project / "LICENSE").read_text() == "this is the version in the template"
 
 
+@pytest.mark.xfail(reason="TODO")
 def test_skip(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It skips the update."""
     updatefile(project / "LICENSE", "this is the version in the project")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -173,6 +173,22 @@ def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> 
         cherrypick(repositorypath, update.name)
 
 
+def test_skipupdate_resets_index(repositorypath: Path) -> None:
+    """It resets the index to HEAD, removing conflicts."""
+    createconflict(
+        repositorypath,
+        repositorypath / "README",
+        "This is the version on the update branch.",
+        "This is the version on the main branch.",
+    )
+
+    with chdir(repositorypath):
+        skipupdate()
+
+    repository = pygit2.Repository(repositorypath)
+    assert repository.index.write_tree() == repository.head.peel().tree.id
+
+
 def test_skipupdate_fastforwards_latest(repositorypath: Path) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
     createconflict(

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -142,3 +142,11 @@ def test_continueupdate(tmp_path: Path) -> None:
         repository.branches[LATEST_BRANCH].peel()
         == repository.branches[UPDATE_BRANCH].peel()
     )
+
+
+@pytest.fixture
+def repositorypath(tmp_path: Path) -> Path:
+    """Fixture for a repository."""
+    repositorypath = tmp_path / "repository"
+    pygit2.init_repository(repositorypath)
+    return repositorypath

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -173,6 +173,22 @@ def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> 
         cherrypick(repositorypath, update.name)
 
 
+def test_skipupdate_restores_files_with_conflicts(repositorypath: Path) -> None:
+    """It restores the conflicting files in the working tree to our version."""
+    path = repositorypath / "README"
+    createconflict(
+        repositorypath,
+        path,
+        "This is the version on the update branch.",
+        "This is the version on the main branch.",
+    )
+
+    with chdir(repositorypath):
+        skipupdate()
+
+    assert path.read_text() == "This is the version on the main branch."
+
+
 def test_skipupdate_resets_index(repositorypath: Path) -> None:
     """It resets the index to HEAD, removing conflicts."""
     createconflict(


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty update --skip`
- :white_check_mark: [functional] Add XFAIL marker
- :recycle: [services] Add `repositorypath` fixture
- :recycle: [services] Extract function `createconflict` from tests
- :white_check_mark: [services] Add test that `skipupdate` fast-forwards `cutty/latest`
- :sparkles: [services] Add `skipupdate` function and fast-forward `cutty/latest`
- :white_check_mark: [services] Add test that `skipupdate` resets the index
- :sparkles: [services] Reset index in `skipupdate`
- :white_check_mark: [services] Add test that `skipupdate` restores the working tree
- :sparkles: [services] Restore working tree in `skipupdate`
- :white_check_mark: [services] Add test that `skipupdate` restores files without conflict
- :rewind: [functional] Revert "Add XFAIL marker"
- :sparkles: [entrypoints] Add `cutty update --skip`
