### PR TITLE
:sparkles: [services] Add `cutty update --abort`

### DIFF
--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -5,6 +5,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
+from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import skipupdate
 from cutty.services.update import update as service_update
@@ -55,6 +56,12 @@ from cutty.templates.domain.bindings import Binding
     default=False,
     help="Skip the current update.",
 )
+@click.option(
+    "--abort",
+    is_flag=True,
+    default=False,
+    help="Abort the current update.",
+)
 def update(
     extra_context: dict[str, str],
     no_input: bool,
@@ -63,6 +70,7 @@ def update(
     directory: Optional[pathlib.Path],
     continue_: bool,
     skip: bool,
+    abort: bool,
 ) -> None:
     """Update a project with changes from its template."""
     if continue_:
@@ -71,6 +79,10 @@ def update(
 
     if skip:
         skipupdate(projectdir=cwd)
+        return
+
+    if abort:
+        abortupdate(projectdir=cwd)
         return
 
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -162,3 +162,12 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
 
     resetmerge(projectdir, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
     updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
+
+
+def abortupdate(*, projectdir: Optional[Path] = None) -> None:
+    """Abort an update with conflicts."""
+    if projectdir is None:
+        projectdir = Path.cwd()
+
+    resetmerge(projectdir, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+    updatebranch(projectdir, UPDATE_BRANCH, target=LATEST_BRANCH)

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -309,6 +309,7 @@ def test_checkout(runcutty: RunCutty, template: Path, project: Path) -> None:
     assert (project / "LICENSE").read_text() == "first version"
 
 
+@pytest.mark.xfail(reason="TODO")
 def test_abort(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does not skip changes when a previous update was aborted."""
     updatefile(project / "LICENSE", "this is the version in the project")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -309,7 +309,7 @@ def test_checkout(runcutty: RunCutty, template: Path, project: Path) -> None:
     assert (project / "LICENSE").read_text() == "first version"
 
 
-def test_conflict_abort(runcutty: RunCutty, template: Path, project: Path) -> None:
+def test_abort(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does not skip changes when a previous update was aborted."""
     updatefile(project / "LICENSE", "this is the version in the project")
     updatefile(
@@ -320,9 +320,8 @@ def test_conflict_abort(runcutty: RunCutty, template: Path, project: Path) -> No
     with pytest.raises(Exception, match="conflict"):
         runcutty("update", f"--cwd={project}")
 
-    # Abort the cherry-pick, unceremoniously.
-    repository = pygit2.Repository(project)
-    repository.reset(repository.head.target, pygit2.GIT_RESET_HARD)
+    # Abort the update.
+    runcutty("update", f"--cwd={project}", "--abort")
 
     # Update the template with an unproblematic change.
     updatefile(template / "{{ cookiecutter.project }}" / "INSTALL")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -309,7 +309,6 @@ def test_checkout(runcutty: RunCutty, template: Path, project: Path) -> None:
     assert (project / "LICENSE").read_text() == "first version"
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_abort(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does not skip changes when a previous update was aborted."""
     updatefile(project / "LICENSE", "this is the version in the project")


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for `cutty update --abort`
- :white_check_mark: Add XFAIL marker
- :white_check_mark: [services] Add tests for `resetmerge` replacing `skipupdate` tests
- :white_check_mark: [services] Add test that `abortupdate` rewinds `cutty/update`
- :sparkles: [services] Add `abortupdate` function
- :rewind: Revert "Add XFAIL marker"
- :sparkles: [entrypoints] Add `cutty update --abort`
