### PR TITLE
:bug: [services] Fix untracked files after `cutty update --abort` and `--skip`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -152,7 +152,10 @@ def resetmerge(repositorypath: Path, parent: str, cherry: str) -> None:
         file.path for delta in diff.deltas for file in (delta.old_file, delta.new_file)
     ]
 
-    repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=paths)
+    repository.checkout(
+        strategy=pygit2.GIT_CHECKOUT_FORCE | pygit2.GIT_CHECKOUT_REMOVE_UNTRACKED,
+        paths=paths,
+    )
 
 
 def skipupdate(*, projectdir: Optional[Path] = None) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -17,6 +17,7 @@ from tests.util.git import commit
 from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
+from tests.util.git import updatefiles
 
 
 def test_createworktree(tmp_path: Path) -> None:
@@ -203,8 +204,7 @@ def test_resetmerge_restores_files_without_conflict(repositorypath: Path) -> Non
     license = repositorypath / "LICENSE"
 
     repository.checkout(update)
-    updatefile(license)
-    updatefile(readme, "This is the version on the update branch.")
+    updatefiles({license: "", readme: "This is the version on the update branch."})
 
     repository.checkout(main)
     updatefile(readme, "This is the version on the main branch.")

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -45,6 +45,22 @@ def updatefile(path: Path, text: str = "") -> None:
     commit(repository, message=f"{verb} {path.name}")
 
 
+def updatefiles(paths: dict[Path, str]) -> None:
+    """Add or update repository files."""
+    verb = "Add"
+
+    for path, text in paths.items():
+        repository = discoverrepository(path)
+
+        if path.exists():
+            verb = "Update"
+
+        path.write_text(dedent(text).lstrip())
+
+    pathlist = " and ".join(path.name for path in paths)
+    commit(repository, message=f"{verb} {pathlist}")
+
+
 def removefile(path: Path) -> None:
     """Remove a repository file."""
     repository = discoverrepository(path)


### PR DESCRIPTION
- :recycle: [tests] Add `updatefiles` to git utilities
- :white_check_mark: [services] Fix test for `resetmerge` with non-conflicting files
- :bug: [services] Fix untracked files after `cutty update --abort` and `--skip`
