### PR TITLE
:recycle: [services] Refactor update tests

### DIFF
--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -87,14 +87,14 @@ def test_cherrypick_adds_file(
     """It cherry-picks the commit onto the current branch."""
     commit(repositorypath)
 
-    main = repository.references["HEAD"].target
+    mainref = repository.references["HEAD"].target
     branch = repository.branches.create("branch", repository.head.peel())
     path = repositorypath / "README"
 
     repository.checkout(branch)
     updatefile(path)
 
-    repository.checkout(main)
+    repository.checkout(mainref)
     assert not path.is_file()
 
     cherrypick(repositorypath, "refs/heads/branch")
@@ -107,14 +107,14 @@ def test_cherrypick_conflict_edit(
     """It raises an exception when both sides modified the file."""
     commit(repositorypath)
 
-    main = repository.references["HEAD"].target
+    mainref = repository.references["HEAD"].target
     branch = repository.branches.create("branch", repository.head.peel())
     path = repositorypath / "README"
 
     repository.checkout(branch)
     updatefile(path, "a")
 
-    repository.checkout(main)
+    repository.checkout(mainref)
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
@@ -128,13 +128,13 @@ def test_cherrypick_conflict_deletion(
     path = repositorypath / "README"
     updatefile(path, "a")
 
-    main = repository.references["HEAD"].target
+    mainref = repository.references["HEAD"].target
     branch = repository.branches.create("branch", repository.head.peel())
 
     repository.checkout(branch)
     updatefile(path, "b")
 
-    repository.checkout(main)
+    repository.checkout(mainref)
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -110,12 +110,11 @@ def test_cherrypick_conflict(
     branch = repository.branches.create("branch", repository.head.peel())
     path = repositorypath / "README"
 
-    updatefile(path, "This is the version on the main branch.")
-
     repository.checkout(branch)
     updatefile(path, "This is the version on the other branch.")
 
     repository.checkout(main)
+    updatefile(path, "This is the version on the main branch.")
 
     with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, branch.name)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -153,7 +153,7 @@ def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> 
 
     main = repository.head
     update = createbranch(repository, UPDATE_BRANCH)
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
+    createbranch(repository, LATEST_BRANCH)
 
     repository.checkout(update)
     updatefile(path, text1)
@@ -215,7 +215,7 @@ def test_resetmerge_restores_files_without_conflict(
 
     main = repository.head
     update = createbranch(repository, UPDATE_BRANCH)
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
+    createbranch(repository, LATEST_BRANCH)
 
     path1 = repositorypath / "README"
     path2 = repositorypath / "LICENSE"
@@ -242,7 +242,7 @@ def test_resetmerge_keeps_unrelated_additions(
 
     main = repository.head
     update = createbranch(repository, UPDATE_BRANCH)
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
+    createbranch(repository, LATEST_BRANCH)
 
     path1 = repositorypath / "README"
     path2 = repositorypath / "LICENSE"
@@ -271,7 +271,7 @@ def test_resetmerge_keeps_unrelated_changes(
 
     main = repository.head
     update = createbranch(repository, UPDATE_BRANCH)
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
+    createbranch(repository, LATEST_BRANCH)
 
     path1 = repositorypath / "README"
     path2 = repositorypath / "LICENSE"
@@ -301,7 +301,7 @@ def test_resetmerge_keeps_unrelated_deletions(
 
     main = repository.head
     update = createbranch(repository, UPDATE_BRANCH)
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
+    createbranch(repository, LATEST_BRANCH)
 
     path1 = repositorypath / "README"
     path2 = repositorypath / "LICENSE"

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -28,6 +28,12 @@ def repositorypath(tmp_path: Path) -> Path:
     return repositorypath
 
 
+@pytest.fixture
+def repository(repositorypath: Path) -> pygit2.Repository:
+    """Fixture for a repository."""
+    return pygit2.Repository(repositorypath)
+
+
 def test_createworktree(tmp_path: Path) -> None:
     """It returns a path to the worktree."""
     repositorypath = tmp_path / "repository"

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -128,7 +128,7 @@ def test_cherrypick_conflict_deletion(
     updatefile(path, "This is the initial version.")
 
     main = repository.references["HEAD"].target
-    branch = repository.branches.create("mybranch", repository.head.peel())
+    branch = repository.branches.create("branch", repository.head.peel())
 
     path.unlink()
     commit(repositorypath, message="Remove README")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -73,8 +73,7 @@ def test_createworktree_no_checkout(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It creates a worktree without checking out the files."""
-    (repositorypath / "README").touch()
-    commit(repositorypath, message="Initial")
+    updatefile(repositorypath / "README")
     repository.branches.create("mybranch", repository.head.peel())
 
     with createworktree(repositorypath, "mybranch", checkout=False) as worktree:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -36,8 +36,7 @@ def repository(repositorypath: Path) -> pygit2.Repository:
 
 def test_createworktree(repository: pygit2.Repository, repositorypath: Path) -> None:
     """It returns a path to the worktree."""
-    (repositorypath / "README").touch()
-    commit(repositorypath, message="Initial")
+    updatefile(repositorypath / "README")
     repository.branches.create("mybranch", repository.head.peel())
 
     with createworktree(repositorypath, "mybranch") as worktree:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -106,20 +106,20 @@ def test_cherrypick_conflict(
     """It raises an exception on merge conflicts."""
     commit(repositorypath)
 
-    mainbranch = repository.references[repository.references["HEAD"].target]
-    otherbranch = repository.branches.create("mybranch", repository.head.peel())
+    main = repository.references[repository.references["HEAD"].target]
+    branch = repository.branches.create("mybranch", repository.head.peel())
 
     (repositorypath / "README").write_text("This is the version on the main branch.")
     commit(repositorypath, message="Add README")
 
-    repository.checkout(otherbranch)
+    repository.checkout(branch)
     (repositorypath / "README").write_text("This is the version on the other branch.")
     commit(repositorypath, message="Add README")
 
-    repository.checkout(mainbranch)
+    repository.checkout(main)
 
     with pytest.raises(Exception, match="README"):
-        cherrypick(repositorypath, otherbranch.name)
+        cherrypick(repositorypath, branch.name)
 
 
 def test_cherrypick_conflict_deletion(tmp_path: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -38,7 +38,7 @@ def test_createworktree_creates_worktree(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It creates a worktree."""
-    updatefile(repositorypath / "README")
+    commit(repositorypath)
     repository.branches.create("mybranch", repository.head.peel())
 
     with createworktree(repositorypath, "mybranch") as worktree:
@@ -49,7 +49,7 @@ def test_createworktree_removes_worktree_on_exit(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It removes the worktree on exit."""
-    updatefile(repositorypath / "README")
+    commit(repositorypath)
     repository.branches.create("mybranch", repository.head.peel())
 
     with createworktree(repositorypath, "mybranch") as worktree:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -101,7 +101,7 @@ def test_cherrypick_adds_file(
     assert path.is_file()
 
 
-def test_cherrypick_conflict(
+def test_cherrypick_conflict_edit(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It raises an exception on merge conflicts."""

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -146,7 +146,7 @@ def test_cherrypick_conflict_deletion(
         cherrypick(repositorypath, branch.name)
 
 
-def createconflict(repositorypath: Path, path: Path, theirs: str, ours: str) -> None:
+def createconflict(repositorypath: Path, path: Path, *, theirs: str, ours: str) -> None:
     """Create an update conflict."""
     repository = pygit2.Repository(repositorypath)
     commit(repositorypath)
@@ -171,7 +171,7 @@ def test_continueupdate_commits_changes(
     """It commits the changes."""
     path = repositorypath / "README"
 
-    createconflict(repositorypath, path, "a", "b")
+    createconflict(repositorypath, path, theirs="a", ours="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -187,7 +187,7 @@ def test_continueupdate_fastforwards_latest(
     """It updates the latest branch to the tip of the update branch."""
     path = repositorypath / "README"
 
-    createconflict(repositorypath, path, "a", "b")
+    createconflict(repositorypath, path, theirs="a", ours="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -201,7 +201,7 @@ def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:
     """It restores the conflicting files in the working tree to our version."""
     path = repositorypath / "README"
 
-    createconflict(repositorypath, path, "a", "b")
+    createconflict(repositorypath, path, theirs="a", ours="b")
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
     assert path.read_text() == "b"
@@ -327,7 +327,7 @@ def test_resetmerge_resets_index(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    createconflict(repositorypath, repositorypath / "README", "a", "b")
+    createconflict(repositorypath, repositorypath / "README", theirs="a", ours="b")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
@@ -338,7 +338,7 @@ def test_skipupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
-    createconflict(repositorypath, repositorypath / "README", "a", "b")
+    createconflict(repositorypath, repositorypath / "README", theirs="a", ours="b")
 
     updatehead = repository.branches[UPDATE_BRANCH].peel()
 
@@ -352,7 +352,7 @@ def test_abortupdate_rewinds_update_branch(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
-    createconflict(repositorypath, repositorypath / "README", "a", "b")
+    createconflict(repositorypath, repositorypath / "README", theirs="a", ours="b")
 
     branches = repository.branches
     latesthead = branches[LATEST_BRANCH].peel()

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -1,4 +1,6 @@
 """Unit tests for cutty.services.update."""
+import string
+from collections.abc import Iterator
 from pathlib import Path
 
 import pygit2
@@ -28,6 +30,12 @@ def repositorypath(tmp_path: Path) -> Path:
     pygit2.init_repository(repositorypath)
     commit(repositorypath)
     return repositorypath
+
+
+@pytest.fixture
+def repositorypaths(repositorypath: Path) -> Iterator[Path]:
+    """Return an arbitrary path in the repository."""
+    return (repositorypath / letter for letter in string.ascii_letters)
 
 
 @pytest.fixture
@@ -209,13 +217,11 @@ def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:
 
 
 def test_resetmerge_restores_files_without_conflict(
-    repository: pygit2.Repository, repositorypath: Path
+    repository: pygit2.Repository, repositorypath: Path, repositorypaths: Iterator[Path]
 ) -> None:
     """It restores non-conflicting files in the working tree to our version."""
     main, update, _ = cuttybranches(repository)
-
-    path1 = repositorypath / "a"
-    path2 = repositorypath / "b"
+    path1, path2 = next(repositorypaths), next(repositorypaths)
 
     repository.checkout(update)
     updatefiles({path1: "a", path2: ""})
@@ -232,13 +238,11 @@ def test_resetmerge_restores_files_without_conflict(
 
 
 def test_resetmerge_keeps_unrelated_additions(
-    repository: pygit2.Repository, repositorypath: Path
+    repository: pygit2.Repository, repositorypath: Path, repositorypaths: Iterator[Path]
 ) -> None:
     """It keeps additions of files that did not change in the update."""
     main, update, _ = cuttybranches(repository)
-
-    path1 = repositorypath / "a"
-    path2 = repositorypath / "b"
+    path1, path2 = next(repositorypaths), next(repositorypaths)
 
     repository.checkout(update)
     updatefile(path1, "a")
@@ -257,13 +261,11 @@ def test_resetmerge_keeps_unrelated_additions(
 
 
 def test_resetmerge_keeps_unrelated_changes(
-    repository: pygit2.Repository, repositorypath: Path
+    repository: pygit2.Repository, repositorypath: Path, repositorypaths: Iterator[Path]
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
     main, update, _ = cuttybranches(repository)
-
-    path1 = repositorypath / "a"
-    path2 = repositorypath / "b"
+    path1, path2 = next(repositorypaths), next(repositorypaths)
 
     repository.checkout(update)
     updatefile(path1, "a")
@@ -283,13 +285,11 @@ def test_resetmerge_keeps_unrelated_changes(
 
 
 def test_resetmerge_keeps_unrelated_deletions(
-    repository: pygit2.Repository, repositorypath: Path
+    repository: pygit2.Repository, repositorypath: Path, repositorypaths: Iterator[Path]
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
     main, update, _ = cuttybranches(repository)
-
-    path1 = repositorypath / "a"
-    path2 = repositorypath / "b"
+    path1, path2 = next(repositorypaths), next(repositorypaths)
 
     repository.checkout(update)
     updatefile(path1, "a")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -172,7 +172,7 @@ def test_continueupdate_commits_changes(
     with chdir(repositorypath):
         continueupdate()
 
-    blob = repository.head.peel().tree / "README"
+    blob = repository.head.peel().tree / path.name
     assert blob.data == b"a"
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -85,7 +85,7 @@ def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None
     commit(repositorypath)
 
     currentbranch = repository.references["HEAD"].target
-    otherbranch = "mybranch"
+    otherbranch = "branch"
 
     (repositorypath / "README").touch()
     repository.branches.create(otherbranch, repository.head.peel())

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -84,13 +84,13 @@ def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None
     """It cherry-picks the commit onto the current branch."""
     commit(repositorypath)
 
-    currentbranch = repository.references["HEAD"].target
-
+    main = repository.references[repository.references["HEAD"].target]
     branch = repository.branches.create("branch", repository.head.peel())
+
     repository.checkout(branch)
     updatefile(repositorypath / "README")
 
-    repository.checkout(currentbranch)
+    repository.checkout(main)
     assert not (repositorypath / "README").is_file()
 
     cherrypick(repositorypath, "refs/heads/branch")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -343,11 +343,13 @@ def test_skipupdate_fastforwards_latest(
     assert repository.branches[LATEST_BRANCH].peel() == updatehead
 
 
-def test_abortupdate_rewinds_update_branch(repositorypath: Path) -> None:
+def test_abortupdate_rewinds_update_branch(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It resets the update branch to the tip of the latest branch."""
     createconflict(repositorypath, repositorypath / "README", "a", "b")
 
-    branches = pygit2.Repository(repositorypath).branches
+    branches = repository.branches
     latesthead = branches[LATEST_BRANCH].peel()
 
     with chdir(repositorypath):

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -150,8 +150,7 @@ def test_continueupdate(repository: pygit2.Repository, repositorypath: Path) -> 
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     path = repositorypath / "README"
 
-    path.write_text("This is the version on the main branch.")
-    commit(repositorypath, message="Add README")
+    updatefile(path, "This is the version on the main branch.")
 
     repository.checkout(update)
     path.write_text("This is the version on the update branch.")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -142,7 +142,7 @@ def test_cherrypick_conflict_deletion(
 
 
 def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> None:
-    """Fixture for an update conflict."""
+    """Create an update conflict."""
     repository = pygit2.Repository(repositorypath)
     commit(repositorypath)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -35,12 +35,17 @@ def repository(repositorypath: Path) -> pygit2.Repository:
     return pygit2.Repository(repositorypath)
 
 
+def createbranch(repository: pygit2.Repository, name: str) -> pygit2.Branch:
+    """Create a branch at HEAD."""
+    return repository.branches.create(name, repository.head.peel())
+
+
 def test_createworktree_creates_worktree(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It creates a worktree."""
     commit(repositorypath)
-    repository.branches.create("branch", repository.head.peel())
+    createbranch(repository, "branch")
 
     with createworktree(repositorypath, "branch") as worktree:
         assert (worktree / ".git").is_file()
@@ -51,7 +56,7 @@ def test_createworktree_removes_worktree_on_exit(
 ) -> None:
     """It removes the worktree on exit."""
     commit(repositorypath)
-    repository.branches.create("branch", repository.head.peel())
+    createbranch(repository, "branch")
 
     with createworktree(repositorypath, "branch") as worktree:
         pass
@@ -64,7 +69,7 @@ def test_createworktree_does_checkout(
 ) -> None:
     """It checks out a working tree."""
     updatefile(repositorypath / "README")
-    repository.branches.create("branch", repository.head.peel())
+    createbranch(repository, "branch")
 
     with createworktree(repositorypath, "branch") as worktree:
         assert (worktree / "README").is_file()
@@ -75,7 +80,7 @@ def test_createworktree_no_checkout(
 ) -> None:
     """It creates a worktree without checking out the files."""
     updatefile(repositorypath / "README")
-    repository.branches.create("branch", repository.head.peel())
+    createbranch(repository, "branch")
 
     with createworktree(repositorypath, "branch", checkout=False) as worktree:
         assert not (worktree / "README").is_file()
@@ -88,7 +93,7 @@ def test_cherrypick_adds_file(
     commit(repositorypath)
 
     mainref = repository.references["HEAD"].target
-    branch = repository.branches.create("branch", repository.head.peel())
+    branch = createbranch(repository, "branch")
     path = repositorypath / "README"
 
     repository.checkout(branch)
@@ -108,7 +113,7 @@ def test_cherrypick_conflict_edit(
     commit(repositorypath)
 
     mainref = repository.references["HEAD"].target
-    branch = repository.branches.create("branch", repository.head.peel())
+    branch = createbranch(repository, "branch")
     path = repositorypath / "README"
 
     repository.checkout(branch)
@@ -129,7 +134,7 @@ def test_cherrypick_conflict_deletion(
     updatefile(path, "a")
 
     mainref = repository.references["HEAD"].target
-    branch = repository.branches.create("branch", repository.head.peel())
+    branch = createbranch(repository, "branch")
 
     repository.checkout(branch)
     updatefile(path, "b")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -333,12 +333,7 @@ def test_skipupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
-    createconflict(
-        repositorypath,
-        repositorypath / "README",
-        "This is the version on the update branch.",
-        "This is the version on the main branch.",
-    )
+    createconflict(repositorypath, repositorypath / "README", "a", "b")
 
     updatehead = repository.branches[UPDATE_BRANCH].peel()
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -152,7 +152,7 @@ def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> 
     commit(repositorypath)
 
     main = repository.head
-    update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    update = createbranch(repository, UPDATE_BRANCH)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
     repository.checkout(update)
@@ -214,7 +214,7 @@ def test_resetmerge_restores_files_without_conflict(
     commit(repositorypath, message="Initial")
 
     main = repository.head
-    update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    update = createbranch(repository, UPDATE_BRANCH)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
     path1 = repositorypath / "README"
@@ -241,7 +241,7 @@ def test_resetmerge_keeps_unrelated_additions(
     commit(repositorypath)
 
     main = repository.head
-    update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    update = createbranch(repository, UPDATE_BRANCH)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
     path1 = repositorypath / "README"
@@ -270,7 +270,7 @@ def test_resetmerge_keeps_unrelated_changes(
     commit(repositorypath, message="Initial")
 
     main = repository.head
-    update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    update = createbranch(repository, UPDATE_BRANCH)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
     path1 = repositorypath / "README"
@@ -300,7 +300,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     commit(repositorypath)
 
     main = repository.head
-    update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    update = createbranch(repository, UPDATE_BRANCH)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
     path1 = repositorypath / "README"

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -120,10 +120,10 @@ def test_cherrypick_conflict(
         cherrypick(repositorypath, branch.name)
 
 
-def test_cherrypick_conflict_deletion(tmp_path: Path) -> None:
+def test_cherrypick_conflict_deletion(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It does not crash when the merge conflict involves file deletions."""
-    repositorypath = tmp_path / "repository"
-    repository = pygit2.init_repository(repositorypath)
     (repositorypath / "README").write_text("This is the initial version.")
     commit(repositorypath, message="Initial")
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -34,16 +34,39 @@ def repository(repositorypath: Path) -> pygit2.Repository:
     return pygit2.Repository(repositorypath)
 
 
-def test_createworktree(repository: pygit2.Repository, repositorypath: Path) -> None:
-    """It returns a path to the worktree."""
+def test_createworktree_creates_worktree(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
+    """It creates a worktree."""
     updatefile(repositorypath / "README")
     repository.branches.create("mybranch", repository.head.peel())
 
     with createworktree(repositorypath, "mybranch") as worktree:
         assert (worktree / ".git").is_file()
-        assert (worktree / "README").is_file()
+
+
+def test_createworktree_removes_worktree_on_exit(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
+    """It removes the worktree on exit."""
+    updatefile(repositorypath / "README")
+    repository.branches.create("mybranch", repository.head.peel())
+
+    with createworktree(repositorypath, "mybranch") as worktree:
+        pass
 
     assert not worktree.is_dir()
+
+
+def test_createworktree_does_checkout(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
+    """It checks out a working tree."""
+    updatefile(repositorypath / "README")
+    repository.branches.create("mybranch", repository.head.peel())
+
+    with createworktree(repositorypath, "mybranch") as worktree:
+        assert (worktree / "README").is_file()
 
 
 def test_createworktree_no_checkout(tmp_path: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -14,6 +14,7 @@ from cutty.services.update import resetmerge
 from cutty.services.update import skipupdate
 from tests.util.files import chdir
 from tests.util.git import commit
+from tests.util.git import removefile
 from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
@@ -130,8 +131,7 @@ def test_cherrypick_conflict_deletion(
     main = repository.references["HEAD"].target
     branch = repository.branches.create("branch", repository.head.peel())
 
-    path.unlink()
-    commit(repositorypath, message="Remove README")
+    removefile(path)
 
     repository.checkout(branch)
     path.write_text("This is the version on the other branch.")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -87,7 +87,7 @@ def test_cherrypick_adds_file(
     """It cherry-picks the commit onto the current branch."""
     commit(repositorypath)
 
-    main = repository.references[repository.references["HEAD"].target]
+    main = repository.references["HEAD"].target
     branch = repository.branches.create("branch", repository.head.peel())
     path = repositorypath / "README"
 
@@ -107,7 +107,7 @@ def test_cherrypick_conflict(
     """It raises an exception on merge conflicts."""
     commit(repositorypath)
 
-    main = repository.references[repository.references["HEAD"].target]
+    main = repository.references["HEAD"].target
     branch = repository.branches.create("branch", repository.head.peel())
     path = repositorypath / "README"
 
@@ -136,7 +136,7 @@ def test_cherrypick_conflict_deletion(
     repository.checkout(branch)
     updatefile(path, "This is the version on the other branch.")
 
-    repository.checkout(repository.references[main])
+    repository.checkout(main)
 
     with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, branch.name)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -126,7 +126,7 @@ def test_cherrypick_conflict_deletion(
 ) -> None:
     """It does not crash when the merge conflict involves file deletions."""
     path = repositorypath / "README"
-    updatefile(path, "This is the initial version.")
+    updatefile(path, "a")
 
     main = repository.references["HEAD"].target
     branch = repository.branches.create("branch", repository.head.peel())
@@ -134,7 +134,7 @@ def test_cherrypick_conflict_deletion(
     removefile(path)
 
     repository.checkout(branch)
-    updatefile(path, "This is the version on the other branch.")
+    updatefile(path, "b")
 
     repository.checkout(main)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -145,21 +145,21 @@ def test_continueupdate(repository: pygit2.Repository, repositorypath: Path) -> 
     """It commits the changes and updates the latest branch."""
     commit(repositorypath)
 
-    mainbranch = repository.references[repository.references["HEAD"].target]
+    main = repository.references[repository.references["HEAD"].target]
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
-    updatebranch = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
 
     (repositorypath / "README").write_text("This is the version on the main branch.")
     commit(repositorypath, message="Add README")
 
-    repository.checkout(updatebranch)
+    repository.checkout(update)
     (repositorypath / "README").write_text("This is the version on the update branch.")
     commit(repositorypath, message="Add README")
 
-    repository.checkout(mainbranch)
+    repository.checkout(main)
 
     with pytest.raises(Exception, match="README"):
-        cherrypick(repositorypath, updatebranch.name)
+        cherrypick(repositorypath, update.name)
 
     resolveconflicts(repositorypath, repositorypath / "README", Side.THEIRS)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -302,11 +302,11 @@ def test_resetmerge_keeps_unrelated_deletions(
     path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
-    updatefile(path1, "This is the version on the update branch.")
+    updatefile(path1, "a")
 
     repository.checkout(main)
     updatefile(path2)
-    updatefile(path1, "This is the version on the main branch.")
+    updatefile(path1, "b")
 
     path2.unlink()
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -150,12 +150,11 @@ def test_continueupdate(repository: pygit2.Repository, repositorypath: Path) -> 
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     path = repositorypath / "README"
 
-    updatefile(path, "This is the version on the main branch.")
-
     repository.checkout(update)
     updatefile(path, "This is the version on the update branch.")
 
     repository.checkout(main)
+    updatefile(path, "This is the version on the main branch.")
 
     with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, update.name)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -215,7 +215,7 @@ def test_resetmerge_restores_files_without_conflict(
     main, update, _ = cuttybranches(repository)
 
     path1 = repositorypath / "a"
-    path2 = repositorypath / "LICENSE"
+    path2 = repositorypath / "b"
 
     repository.checkout(update)
     updatefiles({path1: "a", path2: ""})
@@ -238,7 +238,7 @@ def test_resetmerge_keeps_unrelated_additions(
     main, update, _ = cuttybranches(repository)
 
     path1 = repositorypath / "a"
-    path2 = repositorypath / "LICENSE"
+    path2 = repositorypath / "b"
 
     repository.checkout(update)
     updatefile(path1, "a")
@@ -263,7 +263,7 @@ def test_resetmerge_keeps_unrelated_changes(
     main, update, _ = cuttybranches(repository)
 
     path1 = repositorypath / "a"
-    path2 = repositorypath / "LICENSE"
+    path2 = repositorypath / "b"
 
     repository.checkout(update)
     updatefile(path1, "a")
@@ -289,7 +289,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     main, update, _ = cuttybranches(repository)
 
     path1 = repositorypath / "a"
-    path2 = repositorypath / "LICENSE"
+    path2 = repositorypath / "b"
 
     repository.checkout(update)
     updatefile(path1, "a")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -117,7 +117,7 @@ def test_cherrypick_conflict(
 
     repository.checkout(main)
 
-    with pytest.raises(Exception, match="README"):
+    with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, branch.name)
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -112,10 +112,10 @@ def test_cherrypick_conflict(
     path = repositorypath / "README"
 
     repository.checkout(branch)
-    updatefile(path, "This is the version on the other branch.")
+    updatefile(path, "a")
 
     repository.checkout(main)
-    updatefile(path, "This is the version on the main branch.")
+    updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, branch.name)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -292,7 +292,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
-    commit(repositorypath, message="Initial")
+    commit(repositorypath)
 
     main = repository.references[repository.references["HEAD"].target]
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -146,7 +146,7 @@ def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> 
     repository = pygit2.Repository(repositorypath)
     commit(repositorypath)
 
-    main = repository.references[repository.references["HEAD"].target]
+    main = repository.head
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
@@ -208,7 +208,7 @@ def test_resetmerge_restores_files_without_conflict(
     """It restores non-conflicting files in the working tree to our version."""
     commit(repositorypath, message="Initial")
 
-    main = repository.references[repository.references["HEAD"].target]
+    main = repository.head
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
@@ -235,7 +235,7 @@ def test_resetmerge_keeps_unrelated_additions(
     """It keeps additions of files that did not change in the update."""
     commit(repositorypath)
 
-    main = repository.references[repository.references["HEAD"].target]
+    main = repository.head
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
@@ -264,7 +264,7 @@ def test_resetmerge_keeps_unrelated_changes(
     """It keeps modifications to files that did not change in the update."""
     commit(repositorypath, message="Initial")
 
-    main = repository.references[repository.references["HEAD"].target]
+    main = repository.head
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
@@ -294,7 +294,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     """It keeps deletions of files that did not change in the update."""
     commit(repositorypath)
 
-    main = repository.references[repository.references["HEAD"].target]
+    main = repository.head
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -20,6 +20,14 @@ from tests.util.git import updatefile
 from tests.util.git import updatefiles
 
 
+@pytest.fixture
+def repositorypath(tmp_path: Path) -> Path:
+    """Fixture for a repository."""
+    repositorypath = tmp_path / "repository"
+    pygit2.init_repository(repositorypath)
+    return repositorypath
+
+
 def test_createworktree(tmp_path: Path) -> None:
     """It returns a path to the worktree."""
     repositorypath = tmp_path / "repository"
@@ -147,14 +155,6 @@ def test_continueupdate(tmp_path: Path) -> None:
         repository.branches[LATEST_BRANCH].peel()
         == repository.branches[UPDATE_BRANCH].peel()
     )
-
-
-@pytest.fixture
-def repositorypath(tmp_path: Path) -> Path:
-    """Fixture for a repository."""
-    repositorypath = tmp_path / "repository"
-    pygit2.init_repository(repositorypath)
-    return repositorypath
 
 
 def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -110,12 +110,10 @@ def test_cherrypick_conflict(
     branch = repository.branches.create("mybranch", repository.head.peel())
     path = repositorypath / "README"
 
-    path.write_text("This is the version on the main branch.")
-    commit(repositorypath, message="Add README")
+    updatefile(path, "This is the version on the main branch.")
 
     repository.checkout(branch)
-    path.write_text("This is the version on the other branch.")
-    commit(repositorypath, message="Add README")
+    updatefile(path, "This is the version on the other branch.")
 
     repository.checkout(main)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -86,15 +86,16 @@ def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None
 
     main = repository.references[repository.references["HEAD"].target]
     branch = repository.branches.create("branch", repository.head.peel())
+    path = repositorypath / "README"
 
     repository.checkout(branch)
-    updatefile(repositorypath / "README")
+    updatefile(path)
 
     repository.checkout(main)
-    assert not (repositorypath / "README").is_file()
+    assert not path.is_file()
 
     cherrypick(repositorypath, "refs/heads/branch")
-    assert (repositorypath / "README").is_file()
+    assert path.is_file()
 
 
 def test_cherrypick_conflict(tmp_path: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -202,9 +202,10 @@ def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:
     assert path.read_text() == "b"
 
 
-def test_resetmerge_restores_files_without_conflict(repositorypath: Path) -> None:
+def test_resetmerge_restores_files_without_conflict(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It restores non-conflicting files in the working tree to our version."""
-    repository = pygit2.Repository(repositorypath)
     commit(repositorypath, message="Initial")
 
     main = repository.references[repository.references["HEAD"].target]

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -107,7 +107,7 @@ def test_cherrypick_conflict(
     commit(repositorypath)
 
     main = repository.references[repository.references["HEAD"].target]
-    branch = repository.branches.create("mybranch", repository.head.peel())
+    branch = repository.branches.create("branch", repository.head.peel())
     path = repositorypath / "README"
 
     updatefile(path, "This is the version on the main branch.")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -164,22 +164,9 @@ def test_continueupdate_commits_changes(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It commits the changes."""
-    commit(repositorypath)
-
-    main = repository.references[repository.references["HEAD"].target]
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
-    update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     path = repositorypath / "README"
 
-    repository.checkout(update)
-    updatefile(path, "a")
-
-    repository.checkout(main)
-    updatefile(path, "b")
-
-    with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, update.name)
-
+    createconflict(repositorypath, path, "a", "b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -193,22 +180,9 @@ def test_continueupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It updates the latest branch to the tip of the update branch."""
-    commit(repositorypath)
-
-    main = repository.references[repository.references["HEAD"].target]
-    repository.branches.create(LATEST_BRANCH, repository.head.peel())
-    update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     path = repositorypath / "README"
 
-    repository.checkout(update)
-    updatefile(path, "a")
-
-    repository.checkout(main)
-    updatefile(path, "b")
-
-    with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, update.name)
-
+    createconflict(repositorypath, path, "a", "b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -124,22 +124,23 @@ def test_cherrypick_conflict_deletion(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It does not crash when the merge conflict involves file deletions."""
-    (repositorypath / "README").write_text("This is the initial version.")
+    path = repositorypath / "README"
+    path.write_text("This is the initial version.")
     commit(repositorypath, message="Initial")
 
     mainbranch = repository.references["HEAD"].target
     otherbranch = repository.branches.create("mybranch", repository.head.peel())
 
-    (repositorypath / "README").unlink()
+    path.unlink()
     commit(repositorypath, message="Remove README")
 
     repository.checkout(otherbranch)
-    (repositorypath / "README").write_text("This is the version on the other branch.")
+    path.write_text("This is the version on the other branch.")
     commit(repositorypath, message="Update README")
 
     repository.checkout(repository.references[mainbranch])
 
-    with pytest.raises(Exception, match="README"):
+    with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, otherbranch.name)
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -86,8 +86,8 @@ def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None
 
     currentbranch = repository.references["HEAD"].target
 
-    repository.branches.create("branch", repository.head.peel())
-    repository.set_head("refs/heads/branch")
+    branch = repository.branches.create("branch", repository.head.peel())
+    repository.checkout(branch)
     updatefile(repositorypath / "README")
 
     repository.checkout(currentbranch)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -295,8 +295,8 @@ def test_resetmerge_keeps_unrelated_deletions(
     updatefile(path1, "a")
 
     repository.checkout(main)
-    updatefile(path2)
     updatefile(path1, "b")
+    updatefile(path2)
 
     path2.unlink()
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -275,8 +275,8 @@ def test_resetmerge_keeps_unrelated_changes(
     updatefile(path1, "a")
 
     repository.checkout(main)
-    updatefile(path2)
     updatefile(path1, "b")
+    updatefile(path2)
 
     path2.write_text("c")
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -345,12 +345,7 @@ def test_skipupdate_fastforwards_latest(
 
 def test_abortupdate_rewinds_update_branch(repositorypath: Path) -> None:
     """It resets the update branch to the tip of the latest branch."""
-    createconflict(
-        repositorypath,
-        repositorypath / "README",
-        "This is the version on the update branch.",
-        "This is the version on the main branch.",
-    )
+    createconflict(repositorypath, repositorypath / "README", "a", "b")
 
     branches = pygit2.Repository(repositorypath).branches
     latesthead = branches[LATEST_BRANCH].peel()

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -288,9 +288,10 @@ def test_resetmerge_keeps_unrelated_changes(
     assert path2.read_text() == "c"
 
 
-def test_resetmerge_keeps_unrelated_deletions(repositorypath: Path) -> None:
+def test_resetmerge_keeps_unrelated_deletions(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It keeps deletions of files that did not change in the update."""
-    repository = pygit2.Repository(repositorypath)
     commit(repositorypath, message="Initial")
 
     main = repository.references[repository.references["HEAD"].target]

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -188,10 +188,8 @@ def test_continueupdate_fastforwards_latest(
     with chdir(repositorypath):
         continueupdate()
 
-    assert (
-        repository.branches[LATEST_BRANCH].peel()
-        == repository.branches[UPDATE_BRANCH].peel()
-    )
+    branches = repository.branches
+    assert branches[LATEST_BRANCH].peel() == branches[UPDATE_BRANCH].peel()
 
 
 def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -211,7 +211,7 @@ def test_resetmerge_restores_files_without_conflict(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It restores non-conflicting files in the working tree to our version."""
-    commit(repositorypath, message="Initial")
+    commit(repositorypath)
 
     main = repository.head
     update = createbranch(repository, UPDATE_BRANCH)
@@ -267,7 +267,7 @@ def test_resetmerge_keeps_unrelated_changes(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
-    commit(repositorypath, message="Initial")
+    commit(repositorypath)
 
     main = repository.head
     update = createbranch(repository, UPDATE_BRANCH)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -171,14 +171,14 @@ def test_continueupdate_commits_changes(
     """It commits the changes."""
     path = repositorypath / "README"
 
-    createconflict(repositorypath, path, ours="b", theirs="a")
+    createconflict(repositorypath, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
         continueupdate()
 
     blob = repository.head.peel().tree / path.name
-    assert blob.data == b"a"
+    assert blob.data == b"b"
 
 
 def test_continueupdate_fastforwards_latest(
@@ -187,7 +187,7 @@ def test_continueupdate_fastforwards_latest(
     """It updates the latest branch to the tip of the update branch."""
     path = repositorypath / "README"
 
-    createconflict(repositorypath, path, ours="b", theirs="a")
+    createconflict(repositorypath, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -201,10 +201,10 @@ def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:
     """It restores the conflicting files in the working tree to our version."""
     path = repositorypath / "README"
 
-    createconflict(repositorypath, path, ours="b", theirs="a")
+    createconflict(repositorypath, path, ours="a", theirs="b")
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
-    assert path.read_text() == "b"
+    assert path.read_text() == "a"
 
 
 def test_resetmerge_restores_files_without_conflict(
@@ -327,7 +327,7 @@ def test_resetmerge_resets_index(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    createconflict(repositorypath, repositorypath / "README", ours="b", theirs="a")
+    createconflict(repositorypath, repositorypath / "README", ours="a", theirs="b")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
@@ -338,7 +338,7 @@ def test_skipupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
-    createconflict(repositorypath, repositorypath / "README", ours="b", theirs="a")
+    createconflict(repositorypath, repositorypath / "README", ours="a", theirs="b")
 
     updatehead = repository.branches[UPDATE_BRANCH].peel()
 
@@ -352,7 +352,7 @@ def test_abortupdate_rewinds_update_branch(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
-    createconflict(repositorypath, repositorypath / "README", ours="b", theirs="a")
+    createconflict(repositorypath, repositorypath / "README", ours="a", theirs="b")
 
     branches = repository.branches
     latesthead = branches[LATEST_BRANCH].peel()

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -85,17 +85,16 @@ def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None
     commit(repositorypath)
 
     currentbranch = repository.references["HEAD"].target
-    otherbranch = "branch"
 
     (repositorypath / "README").touch()
-    repository.branches.create(otherbranch, repository.head.peel())
-    repository.set_head(f"refs/heads/{otherbranch}")
+    repository.branches.create("branch", repository.head.peel())
+    repository.set_head("refs/heads/branch")
     commit(repositorypath, message="Add README")
 
     repository.checkout(currentbranch)
     assert not (repositorypath / "README").is_file()
 
-    cherrypick(repositorypath, f"refs/heads/{otherbranch}")
+    cherrypick(repositorypath, "refs/heads/branch")
     assert (repositorypath / "README").is_file()
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -322,12 +322,7 @@ def test_resetmerge_resets_index(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    createconflict(
-        repositorypath,
-        repositorypath / "README",
-        "This is the version on the update branch.",
-        "This is the version on the main branch.",
-    )
+    createconflict(repositorypath, repositorypath / "README", "a", "b")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -104,7 +104,7 @@ def test_cherrypick_adds_file(
 def test_cherrypick_conflict_edit(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
-    """It raises an exception on merge conflicts."""
+    """It raises an exception when both sides modified the file."""
     commit(repositorypath)
 
     main = repository.references["HEAD"].target
@@ -124,7 +124,7 @@ def test_cherrypick_conflict_edit(
 def test_cherrypick_conflict_deletion(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
-    """It does not crash when the merge conflict involves file deletions."""
+    """It raises an exception when one side modified and the other deleted the file."""
     path = repositorypath / "README"
     updatefile(path, "a")
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -243,10 +243,10 @@ def test_resetmerge_keeps_unrelated_additions(
     path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
-    updatefile(path1, "This is the version on the update branch.")
+    updatefile(path1, "a")
 
     repository.checkout(main)
-    updatefile(path1, "This is the version on the main branch.")
+    updatefile(path1, "b")
 
     path2.touch()
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -34,11 +34,9 @@ def repository(repositorypath: Path) -> pygit2.Repository:
     return pygit2.Repository(repositorypath)
 
 
-def test_createworktree(tmp_path: Path) -> None:
+def test_createworktree(repository: pygit2.Repository, repositorypath: Path) -> None:
     """It returns a path to the worktree."""
-    repositorypath = tmp_path / "repository"
-    repository = pygit2.init_repository(repositorypath)
-    (tmp_path / "repository" / "README").touch()
+    (repositorypath / "README").touch()
     commit(repositorypath, message="Initial")
     repository.branches.create("mybranch", repository.head.peel())
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -298,24 +298,24 @@ def test_resetmerge_keeps_unrelated_deletions(
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
-    readme = repositorypath / "README"
-    license = repositorypath / "LICENSE"
+    path1 = repositorypath / "README"
+    path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
-    updatefile(readme, "This is the version on the update branch.")
+    updatefile(path1, "This is the version on the update branch.")
 
     repository.checkout(main)
-    updatefile(license)
-    updatefile(readme, "This is the version on the main branch.")
+    updatefile(path2)
+    updatefile(path1, "This is the version on the main branch.")
 
-    license.unlink()
+    path2.unlink()
 
-    with pytest.raises(Exception, match=readme.name):
+    with pytest.raises(Exception, match=path1.name):
         cherrypick(repositorypath, update.name)
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
-    assert not license.exists()
+    assert not path2.exists()
 
 
 def test_resetmerge_resets_index(repositorypath: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -86,9 +86,9 @@ def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None
 
     currentbranch = repository.references["HEAD"].target
 
-    (repositorypath / "README").touch()
     repository.branches.create("branch", repository.head.peel())
     repository.set_head("refs/heads/branch")
+    (repositorypath / "README").touch()
     commit(repositorypath, message="Add README")
 
     repository.checkout(currentbranch)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -141,10 +141,8 @@ def test_cherrypick_conflict_deletion(
         cherrypick(repositorypath, branch.name)
 
 
-def test_continueupdate(tmp_path: Path) -> None:
+def test_continueupdate(repository: pygit2.Repository, repositorypath: Path) -> None:
     """It commits the changes and updates the latest branch."""
-    repositorypath = tmp_path / "repository"
-    repository = pygit2.init_repository(repositorypath)
     commit(repositorypath, message="Initial")
 
     mainbranch = repository.references[repository.references["HEAD"].target]

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -153,8 +153,7 @@ def test_continueupdate(repository: pygit2.Repository, repositorypath: Path) -> 
     updatefile(path, "This is the version on the main branch.")
 
     repository.checkout(update)
-    path.write_text("This is the version on the update branch.")
-    commit(repositorypath, message="Add README")
+    updatefile(path, "This is the version on the update branch.")
 
     repository.checkout(main)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -239,23 +239,23 @@ def test_resetmerge_keeps_unrelated_additions(
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
-    readme = repositorypath / "README"
-    license = repositorypath / "LICENSE"
+    path1 = repositorypath / "README"
+    path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
-    updatefile(readme, "This is the version on the update branch.")
+    updatefile(path1, "This is the version on the update branch.")
 
     repository.checkout(main)
-    updatefile(readme, "This is the version on the main branch.")
+    updatefile(path1, "This is the version on the main branch.")
 
-    license.touch()
+    path2.touch()
 
-    with pytest.raises(Exception, match=readme.name):
+    with pytest.raises(Exception, match=path1.name):
         cherrypick(repositorypath, update.name)
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
-    assert license.exists()
+    assert path2.exists()
 
 
 def test_resetmerge_keeps_unrelated_changes(repositorypath: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -151,10 +151,10 @@ def test_continueupdate(repository: pygit2.Repository, repositorypath: Path) -> 
     path = repositorypath / "README"
 
     repository.checkout(update)
-    updatefile(path, "This is the version on the update branch.")
+    updatefile(path, "a")
 
     repository.checkout(main)
-    updatefile(path, "This is the version on the main branch.")
+    updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, update.name)
@@ -165,7 +165,7 @@ def test_continueupdate(repository: pygit2.Repository, repositorypath: Path) -> 
         continueupdate()
 
     blob = repository.head.peel().tree / "README"
-    assert blob.data == b"This is the version on the update branch."
+    assert blob.data == b"a"
     assert (
         repository.branches[LATEST_BRANCH].peel()
         == repository.branches[UPDATE_BRANCH].peel()

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -215,10 +215,10 @@ def test_resetmerge_restores_files_with_conflicts(
     assert path.read_text() == "a"
 
 
-def test_resetmerge_restores_files_without_conflict(
+def test_resetmerge_removes_added_files(
     repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
 ) -> None:
-    """It restores non-conflicting files in the working tree to our version."""
+    """It removes files added by the cherry-picked commit."""
     main, update, _ = cuttybranches(repository)
     path1, path2 = next(paths), next(paths)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -100,10 +100,10 @@ def test_cherrypick_adds_file(
     assert path.is_file()
 
 
-def test_cherrypick_conflict(tmp_path: Path) -> None:
+def test_cherrypick_conflict(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It raises an exception on merge conflicts."""
-    repositorypath = tmp_path / "repository"
-    repository = pygit2.init_repository(repositorypath)
     commit(repositorypath, message="Initial")
 
     mainbranch = repository.references[repository.references["HEAD"].target]

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -40,7 +40,7 @@ def path(repositorypath: Path) -> Path:
 
 @pytest.fixture
 def repositorypaths(repositorypath: Path) -> Iterator[Path]:
-    """Return an arbitrary path in the repository."""
+    """Return arbitrary paths in the repository."""
     return (repositorypath / letter for letter in string.ascii_letters)
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -146,7 +146,7 @@ def test_cherrypick_conflict_deletion(
         cherrypick(repositorypath, branch.name)
 
 
-def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> None:
+def createconflict(repositorypath: Path, path: Path, theirs: str, ours: str) -> None:
     """Create an update conflict."""
     repository = pygit2.Repository(repositorypath)
     commit(repositorypath)
@@ -156,10 +156,10 @@ def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> 
     createbranch(repository, LATEST_BRANCH)
 
     repository.checkout(update)
-    updatefile(path, text1)
+    updatefile(path, theirs)
 
     repository.checkout(main)
-    updatefile(path, text2)
+    updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, update.name)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -69,11 +69,11 @@ def test_createworktree_does_checkout(
         assert (worktree / "README").is_file()
 
 
-def test_createworktree_no_checkout(tmp_path: Path) -> None:
+def test_createworktree_no_checkout(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It creates a worktree without checking out the files."""
-    repositorypath = tmp_path / "repository"
-    repository = pygit2.init_repository(repositorypath)
-    (tmp_path / "repository" / "README").touch()
+    (repositorypath / "README").touch()
     commit(repositorypath, message="Initial")
     repository.branches.create("mybranch", repository.head.peel())
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -134,8 +134,7 @@ def test_cherrypick_conflict_deletion(
     removefile(path)
 
     repository.checkout(branch)
-    path.write_text("This is the version on the other branch.")
-    commit(repositorypath, message="Update README")
+    updatefile(path, "This is the version on the other branch.")
 
     repository.checkout(repository.references[main])
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -82,7 +82,7 @@ def test_createworktree_no_checkout(
 
 def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None:
     """It cherry-picks the commit onto the current branch."""
-    commit(repositorypath, message="Initial")
+    commit(repositorypath)
 
     currentbranch = repository.references["HEAD"].target
     otherbranch = "mybranch"

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -146,7 +146,7 @@ def test_cherrypick_conflict_deletion(
         cherrypick(repositorypath, branch.name)
 
 
-def createconflict(repositorypath: Path, path: Path, *, theirs: str, ours: str) -> None:
+def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:
     """Create an update conflict."""
     repository = pygit2.Repository(repositorypath)
     commit(repositorypath)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -80,7 +80,9 @@ def test_createworktree_no_checkout(
         assert not (worktree / "README").is_file()
 
 
-def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None:
+def test_cherrypick_adds_file(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It cherry-picks the commit onto the current branch."""
     commit(repositorypath)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -77,7 +77,6 @@ def test_createworktree_no_checkout(
     repository.branches.create("branch", repository.head.peel())
 
     with createworktree(repositorypath, "branch", checkout=False) as worktree:
-        assert (worktree / ".git").is_file()
         assert not (worktree / "README").is_file()
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -216,10 +216,10 @@ def test_resetmerge_restores_files_without_conflict(
     license = repositorypath / "LICENSE"
 
     repository.checkout(update)
-    updatefiles({license: "", readme: "This is the version on the update branch."})
+    updatefiles({license: "", readme: "a"})
 
     repository.checkout(main)
-    updatefile(readme, "This is the version on the main branch.")
+    updatefile(readme, "b")
 
     with pytest.raises(Exception, match=readme.name):
         cherrypick(repositorypath, update.name)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -33,15 +33,15 @@ def repositorypath(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def repositorypaths(repositorypath: Path) -> Iterator[Path]:
+def paths(repositorypath: Path) -> Iterator[Path]:
     """Return arbitrary paths in the repository."""
     return (repositorypath / letter for letter in string.ascii_letters)
 
 
 @pytest.fixture
-def path(repositorypaths: Iterator[Path]) -> Path:
+def path(paths: Iterator[Path]) -> Path:
     """Return an arbitrary path in the repository."""
-    return next(repositorypaths)
+    return next(paths)
 
 
 @pytest.fixture
@@ -216,11 +216,11 @@ def test_resetmerge_restores_files_with_conflicts(
 
 
 def test_resetmerge_restores_files_without_conflict(
-    repository: pygit2.Repository, repositorypath: Path, repositorypaths: Iterator[Path]
+    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
 ) -> None:
     """It restores non-conflicting files in the working tree to our version."""
     main, update, _ = cuttybranches(repository)
-    path1, path2 = next(repositorypaths), next(repositorypaths)
+    path1, path2 = next(paths), next(paths)
 
     repository.checkout(update)
     updatefiles({path1: "a", path2: ""})
@@ -237,11 +237,11 @@ def test_resetmerge_restores_files_without_conflict(
 
 
 def test_resetmerge_keeps_unrelated_additions(
-    repository: pygit2.Repository, repositorypath: Path, repositorypaths: Iterator[Path]
+    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
 ) -> None:
     """It keeps additions of files that did not change in the update."""
     main, update, _ = cuttybranches(repository)
-    path1, path2 = next(repositorypaths), next(repositorypaths)
+    path1, path2 = next(paths), next(paths)
 
     repository.checkout(update)
     updatefile(path1, "a")
@@ -260,11 +260,11 @@ def test_resetmerge_keeps_unrelated_additions(
 
 
 def test_resetmerge_keeps_unrelated_changes(
-    repository: pygit2.Repository, repositorypath: Path, repositorypaths: Iterator[Path]
+    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
     main, update, _ = cuttybranches(repository)
-    path1, path2 = next(repositorypaths), next(repositorypaths)
+    path1, path2 = next(paths), next(paths)
 
     repository.checkout(update)
     updatefile(path1, "a")
@@ -284,11 +284,11 @@ def test_resetmerge_keeps_unrelated_changes(
 
 
 def test_resetmerge_keeps_unrelated_deletions(
-    repository: pygit2.Repository, repositorypath: Path, repositorypaths: Iterator[Path]
+    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
     main, update, _ = cuttybranches(repository)
-    path1, path2 = next(repositorypaths), next(repositorypaths)
+    path1, path2 = next(paths), next(paths)
 
     repository.checkout(update)
     updatefile(path1, "a")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -143,7 +143,7 @@ def test_cherrypick_conflict_deletion(
 
 def test_continueupdate(repository: pygit2.Repository, repositorypath: Path) -> None:
     """It commits the changes and updates the latest branch."""
-    commit(repositorypath, message="Initial")
+    commit(repositorypath)
 
     mainbranch = repository.references[repository.references["HEAD"].target]
     repository.branches.create(LATEST_BRANCH, repository.head.peel())

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -195,16 +195,11 @@ def test_continueupdate_fastforwards_latest(
 def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:
     """It restores the conflicting files in the working tree to our version."""
     path = repositorypath / "README"
-    createconflict(
-        repositorypath,
-        path,
-        "This is the version on the update branch.",
-        "This is the version on the main branch.",
-    )
 
+    createconflict(repositorypath, path, "a", "b")
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
-    assert path.read_text() == "This is the version on the main branch."
+    assert path.read_text() == "b"
 
 
 def test_resetmerge_restores_files_without_conflict(repositorypath: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -212,21 +212,21 @@ def test_resetmerge_restores_files_without_conflict(
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
-    readme = repositorypath / "README"
-    license = repositorypath / "LICENSE"
+    path1 = repositorypath / "README"
+    path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
-    updatefiles({license: "", readme: "a"})
+    updatefiles({path1: "a", path2: ""})
 
     repository.checkout(main)
-    updatefile(readme, "b")
+    updatefile(path1, "b")
 
-    with pytest.raises(Exception, match=readme.name):
+    with pytest.raises(Exception, match=path1.name):
         cherrypick(repositorypath, update.name)
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
-    assert not license.exists()
+    assert not path2.exists()
 
 
 def test_resetmerge_keeps_unrelated_additions(repositorypath: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -104,7 +104,7 @@ def test_cherrypick_conflict(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It raises an exception on merge conflicts."""
-    commit(repositorypath, message="Initial")
+    commit(repositorypath)
 
     mainbranch = repository.references[repository.references["HEAD"].target]
     otherbranch = repository.branches.create("mybranch", repository.head.peel())

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -148,20 +148,21 @@ def test_continueupdate(repository: pygit2.Repository, repositorypath: Path) -> 
     main = repository.references[repository.references["HEAD"].target]
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    path = repositorypath / "README"
 
-    (repositorypath / "README").write_text("This is the version on the main branch.")
+    path.write_text("This is the version on the main branch.")
     commit(repositorypath, message="Add README")
 
     repository.checkout(update)
-    (repositorypath / "README").write_text("This is the version on the update branch.")
+    path.write_text("This is the version on the update branch.")
     commit(repositorypath, message="Add README")
 
     repository.checkout(main)
 
-    with pytest.raises(Exception, match="README"):
+    with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, update.name)
 
-    resolveconflicts(repositorypath, repositorypath / "README", Side.THEIRS)
+    resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
         continueupdate()

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -233,7 +233,7 @@ def test_resetmerge_keeps_unrelated_additions(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It keeps additions of files that did not change in the update."""
-    commit(repositorypath, message="Initial")
+    commit(repositorypath)
 
     main = repository.references[repository.references["HEAD"].target]
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -141,12 +141,20 @@ def test_cherrypick_conflict_deletion(
         cherrypick(repositorypath, branch.name)
 
 
+def cuttybranches(
+    repository: pygit2.Repository,
+) -> tuple[pygit2.Reference, pygit2.Reference, pygit2.Reference]:
+    """Return the current, the `cutty/latest`, and the `cutty/update` branches."""
+    main = repository.head
+    update = createbranch(repository, UPDATE_BRANCH)
+    latest = createbranch(repository, LATEST_BRANCH)
+    return main, update, latest
+
+
 def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:
     """Create an update conflict."""
     repository = pygit2.Repository(repositorypath)
-    main = repository.head
-    update = createbranch(repository, UPDATE_BRANCH)
-    createbranch(repository, LATEST_BRANCH)
+    main, update, _ = cuttybranches(repository)
 
     repository.checkout(update)
     updatefile(path, theirs)
@@ -204,9 +212,7 @@ def test_resetmerge_restores_files_without_conflict(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It restores non-conflicting files in the working tree to our version."""
-    main = repository.head
-    update = createbranch(repository, UPDATE_BRANCH)
-    createbranch(repository, LATEST_BRANCH)
+    main, update, _ = cuttybranches(repository)
 
     path1 = repositorypath / "README"
     path2 = repositorypath / "LICENSE"
@@ -229,9 +235,7 @@ def test_resetmerge_keeps_unrelated_additions(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It keeps additions of files that did not change in the update."""
-    main = repository.head
-    update = createbranch(repository, UPDATE_BRANCH)
-    createbranch(repository, LATEST_BRANCH)
+    main, update, _ = cuttybranches(repository)
 
     path1 = repositorypath / "README"
     path2 = repositorypath / "LICENSE"
@@ -256,9 +260,7 @@ def test_resetmerge_keeps_unrelated_changes(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
-    main = repository.head
-    update = createbranch(repository, UPDATE_BRANCH)
-    createbranch(repository, LATEST_BRANCH)
+    main, update, _ = cuttybranches(repository)
 
     path1 = repositorypath / "README"
     path2 = repositorypath / "LICENSE"
@@ -284,9 +286,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
-    main = repository.head
-    update = createbranch(repository, UPDATE_BRANCH)
-    createbranch(repository, LATEST_BRANCH)
+    main, update, _ = cuttybranches(repository)
 
     path1 = repositorypath / "README"
     path2 = repositorypath / "LICENSE"

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -329,7 +329,9 @@ def test_resetmerge_resets_index(
     assert repository.index.write_tree() == repository.head.peel().tree.id
 
 
-def test_skipupdate_fastforwards_latest(repositorypath: Path) -> None:
+def test_skipupdate_fastforwards_latest(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
     createconflict(
         repositorypath,
@@ -338,7 +340,7 @@ def test_skipupdate_fastforwards_latest(repositorypath: Path) -> None:
         "This is the version on the main branch.",
     )
 
-    branches = pygit2.Repository(repositorypath).branches
+    branches = repository.branches
     updatehead = branches[UPDATE_BRANCH].peel()
 
     with chdir(repositorypath):

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -144,7 +144,7 @@ def test_cherrypick_conflict_deletion(
 def createconflict(repositorypath: Path, path: Path, text1: str, text2: str) -> None:
     """Fixture for an update conflict."""
     repository = pygit2.Repository(repositorypath)
-    commit(repositorypath, message="Initial")
+    commit(repositorypath)
 
     main = repository.references[repository.references["HEAD"].target]
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -80,10 +80,8 @@ def test_createworktree_no_checkout(
         assert not (worktree / "README").is_file()
 
 
-def test_cherrypick(tmp_path: Path) -> None:
+def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None:
     """It cherry-picks the commit onto the current branch."""
-    repositorypath = tmp_path / "repository"
-    repository = pygit2.init_repository(repositorypath)
     commit(repositorypath, message="Initial")
 
     currentbranch = repository.references["HEAD"].target

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -318,7 +318,9 @@ def test_resetmerge_keeps_unrelated_deletions(
     assert not path2.exists()
 
 
-def test_resetmerge_resets_index(repositorypath: Path) -> None:
+def test_resetmerge_resets_index(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It resets the index to HEAD, removing conflicts."""
     createconflict(
         repositorypath,
@@ -329,7 +331,6 @@ def test_resetmerge_resets_index(repositorypath: Path) -> None:
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
-    repository = pygit2.Repository(repositorypath)
     assert repository.index.write_tree() == repository.head.peel().tree.id
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -68,6 +68,7 @@ def test_createworktree_does_checkout(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It checks out a working tree."""
+    commit(repositorypath)
     updatefile(repositorypath / "README")
     createbranch(repository, "branch")
 
@@ -79,6 +80,7 @@ def test_createworktree_no_checkout(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It creates a worktree without checking out the files."""
+    commit(repositorypath)
     updatefile(repositorypath / "README")
     createbranch(repository, "branch")
 
@@ -130,6 +132,8 @@ def test_cherrypick_conflict_deletion(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It raises an exception when one side modified and the other deleted the file."""
+    commit(repositorypath)
+
     path = repositorypath / "README"
     updatefile(path, "a")
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -92,14 +92,14 @@ def test_cherrypick_adds_file(
     """It cherry-picks the commit onto the current branch."""
     commit(repositorypath)
 
-    mainref = repository.references["HEAD"].target
+    main = repository.head
     branch = createbranch(repository, "branch")
     path = repositorypath / "README"
 
     repository.checkout(branch)
     updatefile(path)
 
-    repository.checkout(mainref)
+    repository.checkout(main)
     assert not path.is_file()
 
     cherrypick(repositorypath, branch.name)
@@ -112,14 +112,14 @@ def test_cherrypick_conflict_edit(
     """It raises an exception when both sides modified the file."""
     commit(repositorypath)
 
-    mainref = repository.references["HEAD"].target
+    main = repository.head
     branch = createbranch(repository, "branch")
     path = repositorypath / "README"
 
     repository.checkout(branch)
     updatefile(path, "a")
 
-    repository.checkout(mainref)
+    repository.checkout(main)
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
@@ -133,13 +133,13 @@ def test_cherrypick_conflict_deletion(
     path = repositorypath / "README"
     updatefile(path, "a")
 
-    mainref = repository.references["HEAD"].target
+    main = repository.head
     branch = createbranch(repository, "branch")
 
     repository.checkout(branch)
     updatefile(path, "b")
 
-    repository.checkout(mainref)
+    repository.checkout(main)
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -229,9 +229,10 @@ def test_resetmerge_restores_files_without_conflict(
     assert not path2.exists()
 
 
-def test_resetmerge_keeps_unrelated_additions(repositorypath: Path) -> None:
+def test_resetmerge_keeps_unrelated_additions(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It keeps additions of files that did not change in the update."""
-    repository = pygit2.Repository(repositorypath)
     commit(repositorypath, message="Initial")
 
     main = repository.references[repository.references["HEAD"].target]

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -171,7 +171,7 @@ def test_continueupdate_commits_changes(
     """It commits the changes."""
     path = repositorypath / "README"
 
-    createconflict(repositorypath, path, theirs="a", ours="b")
+    createconflict(repositorypath, path, ours="b", theirs="a")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -187,7 +187,7 @@ def test_continueupdate_fastforwards_latest(
     """It updates the latest branch to the tip of the update branch."""
     path = repositorypath / "README"
 
-    createconflict(repositorypath, path, theirs="a", ours="b")
+    createconflict(repositorypath, path, ours="b", theirs="a")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -201,7 +201,7 @@ def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:
     """It restores the conflicting files in the working tree to our version."""
     path = repositorypath / "README"
 
-    createconflict(repositorypath, path, theirs="a", ours="b")
+    createconflict(repositorypath, path, ours="b", theirs="a")
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
     assert path.read_text() == "b"
@@ -327,7 +327,7 @@ def test_resetmerge_resets_index(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    createconflict(repositorypath, repositorypath / "README", theirs="a", ours="b")
+    createconflict(repositorypath, repositorypath / "README", ours="b", theirs="a")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
@@ -338,7 +338,7 @@ def test_skipupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
-    createconflict(repositorypath, repositorypath / "README", theirs="a", ours="b")
+    createconflict(repositorypath, repositorypath / "README", ours="b", theirs="a")
 
     updatehead = repository.branches[UPDATE_BRANCH].peel()
 
@@ -352,7 +352,7 @@ def test_abortupdate_rewinds_update_branch(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
-    createconflict(repositorypath, repositorypath / "README", theirs="a", ours="b")
+    createconflict(repositorypath, repositorypath / "README", ours="b", theirs="a")
 
     branches = repository.branches
     latesthead = branches[LATEST_BRANCH].peel()

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -153,7 +153,6 @@ def test_cherrypick_conflict_deletion(
 def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:
     """Create an update conflict."""
     repository = pygit2.Repository(repositorypath)
-    commit(repositorypath)
 
     main = repository.head
     update = createbranch(repository, UPDATE_BRANCH)
@@ -175,6 +174,7 @@ def test_continueupdate_commits_changes(
     """It commits the changes."""
     path = repositorypath / "README"
 
+    commit(repositorypath)
     createconflict(repositorypath, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
@@ -191,6 +191,7 @@ def test_continueupdate_fastforwards_latest(
     """It updates the latest branch to the tip of the update branch."""
     path = repositorypath / "README"
 
+    commit(repositorypath)
     createconflict(repositorypath, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
@@ -205,6 +206,7 @@ def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:
     """It restores the conflicting files in the working tree to our version."""
     path = repositorypath / "README"
 
+    commit(repositorypath)
     createconflict(repositorypath, path, ours="a", theirs="b")
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
@@ -331,6 +333,7 @@ def test_resetmerge_resets_index(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the index to HEAD, removing conflicts."""
+    commit(repositorypath)
     createconflict(repositorypath, repositorypath / "README", ours="a", theirs="b")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
@@ -342,6 +345,7 @@ def test_skipupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
+    commit(repositorypath)
     createconflict(repositorypath, repositorypath / "README", ours="a", theirs="b")
 
     updatehead = repository.branches[UPDATE_BRANCH].peel()
@@ -356,6 +360,7 @@ def test_abortupdate_rewinds_update_branch(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
+    commit(repositorypath)
     createconflict(repositorypath, repositorypath / "README", ours="a", theirs="b")
 
     branches = repository.branches

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -88,8 +88,7 @@ def test_cherrypick(repository: pygit2.Repository, repositorypath: Path) -> None
 
     repository.branches.create("branch", repository.head.peel())
     repository.set_head("refs/heads/branch")
-    (repositorypath / "README").touch()
-    commit(repositorypath, message="Add README")
+    updatefile(repositorypath / "README")
 
     repository.checkout(currentbranch)
     assert not (repositorypath / "README").is_file()

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -272,20 +272,20 @@ def test_resetmerge_keeps_unrelated_changes(
     path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
-    updatefile(path1, "This is the version on the update branch.")
+    updatefile(path1, "a")
 
     repository.checkout(main)
     updatefile(path2)
-    updatefile(path1, "This is the version on the main branch.")
+    updatefile(path1, "b")
 
-    path2.write_text("This is an unstaged change.")
+    path2.write_text("c")
 
     with pytest.raises(Exception, match=path1.name):
         cherrypick(repositorypath, update.name)
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
-    assert path2.read_text() == "This is an unstaged change."
+    assert path2.read_text() == "c"
 
 
 def test_resetmerge_keeps_unrelated_deletions(repositorypath: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -127,6 +127,7 @@ def test_cherrypick_conflict_deletion(
     """It raises an exception when one side modified and the other deleted the file."""
     path = repositorypath / "README"
     updatefile(path, "a")
+
     main = repository.head
     branch = createbranch(repository, "branch")
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -131,12 +131,11 @@ def test_cherrypick_conflict_deletion(
     main = repository.references["HEAD"].target
     branch = repository.branches.create("branch", repository.head.peel())
 
-    removefile(path)
-
     repository.checkout(branch)
     updatefile(path, "b")
 
     repository.checkout(main)
+    removefile(path)
 
     with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, branch.name)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -39,9 +39,9 @@ def test_createworktree_creates_worktree(
 ) -> None:
     """It creates a worktree."""
     commit(repositorypath)
-    repository.branches.create("mybranch", repository.head.peel())
+    repository.branches.create("branch", repository.head.peel())
 
-    with createworktree(repositorypath, "mybranch") as worktree:
+    with createworktree(repositorypath, "branch") as worktree:
         assert (worktree / ".git").is_file()
 
 
@@ -50,9 +50,9 @@ def test_createworktree_removes_worktree_on_exit(
 ) -> None:
     """It removes the worktree on exit."""
     commit(repositorypath)
-    repository.branches.create("mybranch", repository.head.peel())
+    repository.branches.create("branch", repository.head.peel())
 
-    with createworktree(repositorypath, "mybranch") as worktree:
+    with createworktree(repositorypath, "branch") as worktree:
         pass
 
     assert not worktree.is_dir()
@@ -63,9 +63,9 @@ def test_createworktree_does_checkout(
 ) -> None:
     """It checks out a working tree."""
     updatefile(repositorypath / "README")
-    repository.branches.create("mybranch", repository.head.peel())
+    repository.branches.create("branch", repository.head.peel())
 
-    with createworktree(repositorypath, "mybranch") as worktree:
+    with createworktree(repositorypath, "branch") as worktree:
         assert (worktree / "README").is_file()
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -108,12 +108,13 @@ def test_cherrypick_conflict(
 
     main = repository.references[repository.references["HEAD"].target]
     branch = repository.branches.create("mybranch", repository.head.peel())
+    path = repositorypath / "README"
 
-    (repositorypath / "README").write_text("This is the version on the main branch.")
+    path.write_text("This is the version on the main branch.")
     commit(repositorypath, message="Add README")
 
     repository.checkout(branch)
-    (repositorypath / "README").write_text("This is the version on the other branch.")
+    path.write_text("This is the version on the other branch.")
     commit(repositorypath, message="Add README")
 
     repository.checkout(main)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -102,7 +102,7 @@ def test_cherrypick_adds_file(
     repository.checkout(mainref)
     assert not path.is_file()
 
-    cherrypick(repositorypath, "refs/heads/branch")
+    cherrypick(repositorypath, branch.name)
     assert path.is_file()
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -125,8 +125,7 @@ def test_cherrypick_conflict_deletion(
 ) -> None:
     """It does not crash when the merge conflict involves file deletions."""
     path = repositorypath / "README"
-    path.write_text("This is the initial version.")
-    commit(repositorypath, message="Initial")
+    updatefile(path, "This is the initial version.")
 
     mainbranch = repository.references["HEAD"].target
     otherbranch = repository.branches.create("mybranch", repository.head.peel())

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -268,24 +268,24 @@ def test_resetmerge_keeps_unrelated_changes(
     update = repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
 
-    readme = repositorypath / "README"
-    license = repositorypath / "LICENSE"
+    path1 = repositorypath / "README"
+    path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
-    updatefile(readme, "This is the version on the update branch.")
+    updatefile(path1, "This is the version on the update branch.")
 
     repository.checkout(main)
-    updatefile(license)
-    updatefile(readme, "This is the version on the main branch.")
+    updatefile(path2)
+    updatefile(path1, "This is the version on the main branch.")
 
-    license.write_text("This is an unstaged change.")
+    path2.write_text("This is an unstaged change.")
 
-    with pytest.raises(Exception, match=readme.name):
+    with pytest.raises(Exception, match=path1.name):
         cherrypick(repositorypath, update.name)
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
-    assert license.read_text() == "This is an unstaged change."
+    assert path2.read_text() == "This is an unstaged change."
 
 
 def test_resetmerge_keeps_unrelated_deletions(repositorypath: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -172,9 +172,9 @@ def test_continueupdate_commits_changes(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It commits the changes."""
+    commit(repositorypath)
     path = repositorypath / "README"
 
-    commit(repositorypath)
     createconflict(repositorypath, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
@@ -189,9 +189,9 @@ def test_continueupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It updates the latest branch to the tip of the update branch."""
+    commit(repositorypath)
     path = repositorypath / "README"
 
-    commit(repositorypath)
     createconflict(repositorypath, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
@@ -204,9 +204,9 @@ def test_continueupdate_fastforwards_latest(
 
 def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:
     """It restores the conflicting files in the working tree to our version."""
+    commit(repositorypath)
     path = repositorypath / "README"
 
-    commit(repositorypath)
     createconflict(repositorypath, path, ours="a", theirs="b")
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -127,20 +127,20 @@ def test_cherrypick_conflict_deletion(
     path = repositorypath / "README"
     updatefile(path, "This is the initial version.")
 
-    mainbranch = repository.references["HEAD"].target
-    otherbranch = repository.branches.create("mybranch", repository.head.peel())
+    main = repository.references["HEAD"].target
+    branch = repository.branches.create("mybranch", repository.head.peel())
 
     path.unlink()
     commit(repositorypath, message="Remove README")
 
-    repository.checkout(otherbranch)
+    repository.checkout(branch)
     path.write_text("This is the version on the other branch.")
     commit(repositorypath, message="Update README")
 
-    repository.checkout(repository.references[mainbranch])
+    repository.checkout(repository.references[main])
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, otherbranch.name)
+        cherrypick(repositorypath, branch.name)
 
 
 def test_continueupdate(tmp_path: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -67,22 +67,22 @@ def test_createworktree_does_checkout(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It checks out a working tree."""
-    updatefile(repositorypath / "README")
+    updatefile(repositorypath / "a")
     createbranch(repository, "branch")
 
     with createworktree(repositorypath, "branch") as worktree:
-        assert (worktree / "README").is_file()
+        assert (worktree / "a").is_file()
 
 
 def test_createworktree_no_checkout(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It creates a worktree without checking out the files."""
-    updatefile(repositorypath / "README")
+    updatefile(repositorypath / "a")
     createbranch(repository, "branch")
 
     with createworktree(repositorypath, "branch", checkout=False) as worktree:
-        assert not (worktree / "README").is_file()
+        assert not (worktree / "a").is_file()
 
 
 def test_cherrypick_adds_file(
@@ -91,7 +91,7 @@ def test_cherrypick_adds_file(
     """It cherry-picks the commit onto the current branch."""
     main = repository.head
     branch = createbranch(repository, "branch")
-    path = repositorypath / "README"
+    path = repositorypath / "a"
 
     repository.checkout(branch)
     updatefile(path)
@@ -109,7 +109,7 @@ def test_cherrypick_conflict_edit(
     """It raises an exception when both sides modified the file."""
     main = repository.head
     branch = createbranch(repository, "branch")
-    path = repositorypath / "README"
+    path = repositorypath / "a"
 
     repository.checkout(branch)
     updatefile(path, "a")
@@ -125,7 +125,7 @@ def test_cherrypick_conflict_deletion(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It raises an exception when one side modified and the other deleted the file."""
-    path = repositorypath / "README"
+    path = repositorypath / "a"
     updatefile(path, "a")
 
     main = repository.head
@@ -170,7 +170,7 @@ def test_continueupdate_commits_changes(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It commits the changes."""
-    path = repositorypath / "README"
+    path = repositorypath / "a"
 
     createconflict(repositorypath, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
@@ -186,7 +186,7 @@ def test_continueupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It updates the latest branch to the tip of the update branch."""
-    path = repositorypath / "README"
+    path = repositorypath / "a"
 
     createconflict(repositorypath, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
@@ -200,7 +200,7 @@ def test_continueupdate_fastforwards_latest(
 
 def test_resetmerge_restores_files_with_conflicts(repositorypath: Path) -> None:
     """It restores the conflicting files in the working tree to our version."""
-    path = repositorypath / "README"
+    path = repositorypath / "a"
 
     createconflict(repositorypath, path, ours="a", theirs="b")
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
@@ -214,7 +214,7 @@ def test_resetmerge_restores_files_without_conflict(
     """It restores non-conflicting files in the working tree to our version."""
     main, update, _ = cuttybranches(repository)
 
-    path1 = repositorypath / "README"
+    path1 = repositorypath / "a"
     path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
@@ -237,7 +237,7 @@ def test_resetmerge_keeps_unrelated_additions(
     """It keeps additions of files that did not change in the update."""
     main, update, _ = cuttybranches(repository)
 
-    path1 = repositorypath / "README"
+    path1 = repositorypath / "a"
     path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
@@ -262,7 +262,7 @@ def test_resetmerge_keeps_unrelated_changes(
     """It keeps modifications to files that did not change in the update."""
     main, update, _ = cuttybranches(repository)
 
-    path1 = repositorypath / "README"
+    path1 = repositorypath / "a"
     path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
@@ -288,7 +288,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     """It keeps deletions of files that did not change in the update."""
     main, update, _ = cuttybranches(repository)
 
-    path1 = repositorypath / "README"
+    path1 = repositorypath / "a"
     path2 = repositorypath / "LICENSE"
 
     repository.checkout(update)
@@ -312,7 +312,7 @@ def test_resetmerge_resets_index(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    createconflict(repositorypath, repositorypath / "README", ours="a", theirs="b")
+    createconflict(repositorypath, repositorypath / "a", ours="a", theirs="b")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
@@ -323,7 +323,7 @@ def test_skipupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
-    createconflict(repositorypath, repositorypath / "README", ours="a", theirs="b")
+    createconflict(repositorypath, repositorypath / "a", ours="a", theirs="b")
 
     updatehead = repository.branches[UPDATE_BRANCH].peel()
 
@@ -337,7 +337,7 @@ def test_abortupdate_rewinds_update_branch(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
-    createconflict(repositorypath, repositorypath / "README", ours="a", theirs="b")
+    createconflict(repositorypath, repositorypath / "a", ours="a", theirs="b")
 
     branches = repository.branches
     latesthead = branches[LATEST_BRANCH].peel()

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -74,9 +74,9 @@ def test_createworktree_no_checkout(
 ) -> None:
     """It creates a worktree without checking out the files."""
     updatefile(repositorypath / "README")
-    repository.branches.create("mybranch", repository.head.peel())
+    repository.branches.create("branch", repository.head.peel())
 
-    with createworktree(repositorypath, "mybranch", checkout=False) as worktree:
+    with createworktree(repositorypath, "branch", checkout=False) as worktree:
         assert (worktree / ".git").is_file()
         assert not (worktree / "README").is_file()
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -340,13 +340,12 @@ def test_skipupdate_fastforwards_latest(
         "This is the version on the main branch.",
     )
 
-    branches = repository.branches
-    updatehead = branches[UPDATE_BRANCH].peel()
+    updatehead = repository.branches[UPDATE_BRANCH].peel()
 
     with chdir(repositorypath):
         skipupdate()
 
-    assert branches[LATEST_BRANCH].peel() == updatehead
+    assert repository.branches[LATEST_BRANCH].peel() == updatehead
 
 
 def test_abortupdate_rewinds_update_branch(repositorypath: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -33,15 +33,15 @@ def repositorypath(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def path(repositorypath: Path) -> Path:
-    """Return an arbitrary path in the repository."""
-    return repositorypath / "a"
-
-
-@pytest.fixture
 def repositorypaths(repositorypath: Path) -> Iterator[Path]:
     """Return arbitrary paths in the repository."""
     return (repositorypath / letter for letter in string.ascii_letters)
+
+
+@pytest.fixture
+def path(repositorypaths: Iterator[Path]) -> Path:
+    """Return an arbitrary path in the repository."""
+    return next(repositorypaths)
 
 
 @pytest.fixture

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -258,9 +258,10 @@ def test_resetmerge_keeps_unrelated_additions(
     assert path2.exists()
 
 
-def test_resetmerge_keeps_unrelated_changes(repositorypath: Path) -> None:
+def test_resetmerge_keeps_unrelated_changes(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
     """It keeps modifications to files that did not change in the update."""
-    repository = pygit2.Repository(repositorypath)
     commit(repositorypath, message="Initial")
 
     main = repository.references[repository.references["HEAD"].target]

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -8,7 +8,7 @@ import pygit2
 from cutty.filestorage.adapters.observers.git import commit as _commit
 
 
-def commit(repositorypath: Path, *, message: str) -> None:
+def commit(repositorypath: Path, *, message: str = "") -> None:
     """Commit all changes in the repository."""
     repository = pygit2.Repository(repositorypath)
     signature = pygit2.Signature("you", "you@example.com")


### PR DESCRIPTION
- :recycle: [services] Slide definition of `repositorypath` fixture
- :recycle: [services] Add `repository` fixture
- :recycle: [services] Replace inline code with fixtures
- :recycle: [services] Remove inline code with call to `updatefile`
- :recycle: [services] Split up `createworktree` test by assertion
- :recycle: [tests] Do not require `message` in `util.git.commit`
- :recycle: [services] Remove redundant file creation
- :recycle: [services] Simplify branch name
- :recycle: [services] Replace inline code with fixtures
- :recycle: [services] Replace inline code with call to `updatefile`
- :recycle: [services] Simplify branch name
- :recycle: [services] Remove redundant assertion
- :recycle: [services] Replace inline code with fixtures
- :recycle: [services] Use empty commit message for simplicity
- :recycle: [services] Simplify branch name
- :recycle: [services] Inline variable `otherbranch`
- slide statement
- replace inline code with function call
- use checkout instead of set_head
- rename variable to `main`, use reference instead of str
- extract variable `path`
- rename function
- replace inline code with fixtures
- use empty commit message
- rename variables to `main` and `branch`
- extract variable `path`
- replace inline code with call to `updatefile`
- replace literal with query
- simplify literal
- slide statement
- replace inline code with fixtures
- extract variable `path`
- replace inline code with call to `updatefile`
- rename variables to `main` and `branch`
- simplify literal
- replace inline code with call to `removefile`
- replace inline code with call to `updatefile`
- remove redundant resolution of git ref
- simplify literal
- simplify literal
- slide statement
- rename function
- update docstrings
- replace inline code with fixtures
- simplify literal
- rename variables to `main` and `branch`
- extract variable `path`
- replace inline code with call to `updatefile`
- replace inline code with call to `updatefile`
- slide statement
- simplify literal
- split test by assertion
- slide function definition
- replace inline code with call to `createconflict`
- extract variable `branches`
- replace literal with query
- simplify literal
- fix docstring
- simplify literal
- replace inline code with fixture
- simplify literal
- rename variables to `path1` and `path2`
- replace inline code with fixtures
- simplify literal
- rename variables to `path1` and `path2`
- simplify literal
- replace inline code with fixtures
- rename variables to `path1` and `path2`
- simplify literals
- slide statement
- replace inline code with fixtures
- simplify literal
- rename variables
- simplify literals
- replace inline code with fixtures
- simplify literals
- replace inline code with fixtures
- inline variable
- simplify literals
- simplify literals
- replace inline code with fixtures
- replace inline code with `repository.head`
- rename variable
- extract function `createbranch`
- replace literal by query
- replace inline code by `repository.head`
- replace inline code with call to `createbranch`
- replace inline code with call to `createbranch`
- simplify literal
- rename parameters
- use keyword-only arguments
- reverse declaration order
- reverse argument order
- assign literals in argument order
- use an initial empty commit in every test function
- move statement to callers
- slide statement
- move statement to fixture
- add blank line
- slide statement
- extract function `cuttybranches`
- simplify literal
- simplify literal
- extract fixture `repositorypaths`
- extract fixture `path`
- fix docstrings
- write `path` in terms of `repositorypaths`
- rename fixture `repositorypaths` to `paths`
- improve test name and docstring
