### PR TITLE
:recycle: [util] Move git utilities from `services` and `filestorage` to `util.git`

### DIFF
--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -32,19 +32,9 @@ def commit(
 
     If there are no changes relative to the parent, this is a noop.
     """
-    repository.index.add_all()
+    from cutty.util.git import commit
 
-    tree = repository.index.write_tree()
-    if not repository.head_is_unborn and tree == repository.head.peel().tree.id:
-        return
-
-    repository.index.write()
-
-    if signature is None:
-        signature = default_signature(repository)
-
-    parents = [] if repository.head_is_unborn else [repository.head.target]
-    repository.create_commit("HEAD", signature, signature, message, tree, parents)
+    commit(repository, message=message, signature=signature)
 
 
 class GitRepositoryObserver(FileStorageObserver):

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -15,13 +15,6 @@ CREATE_MESSAGE = "Initial import"
 UPDATE_MESSAGE = "Update project template"
 
 
-def default_signature(repository: pygit2.Repository) -> pygit2.Signature:
-    """Return the default signature."""
-    from cutty.util.git import default_signature
-
-    return default_signature(repository)
-
-
 def commit(
     repository: pygit2.Repository,
     *,

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -1,10 +1,10 @@
 """Storing files in a Git repository."""
 import pathlib
-from typing import Optional
 
 import pygit2
 
 from cutty.filestorage.domain.observers import FileStorageObserver
+from cutty.util.git import commit
 
 
 LATEST_BRANCH = "cutty/latest"
@@ -13,21 +13,6 @@ UPDATE_BRANCH = "cutty/update"
 UPDATE_BRANCH_REF = f"refs/heads/{UPDATE_BRANCH}"
 CREATE_MESSAGE = "Initial import"
 UPDATE_MESSAGE = "Update project template"
-
-
-def commit(
-    repository: pygit2.Repository,
-    *,
-    message: str,
-    signature: Optional[pygit2.Signature] = None,
-) -> None:
-    """Commit all changes in the repository.
-
-    If there are no changes relative to the parent, this is a noop.
-    """
-    from cutty.util.git import commit
-
-    commit(repository, message=message, signature=signature)
 
 
 class GitRepositoryObserver(FileStorageObserver):

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -1,6 +1,4 @@
 """Storing files in a Git repository."""
-import contextlib
-import os
 import pathlib
 from typing import Optional
 
@@ -19,12 +17,9 @@ UPDATE_MESSAGE = "Update project template"
 
 def default_signature(repository: pygit2.Repository) -> pygit2.Signature:
     """Return the default signature."""
-    with contextlib.suppress(KeyError):
-        return pygit2.Signature(
-            os.environ["GIT_AUTHOR_NAME"],
-            os.environ["GIT_AUTHOR_EMAIL"],
-        )
-    return repository.default_signature  # pragma: no cover
+    from cutty.util.git import default_signature
+
+    return default_signature(repository)
 
 
 def commit(

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -13,15 +13,9 @@ from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
+from cutty.util.git import cherrypick
 from cutty.util.git import commit
 from cutty.util.git import createworktree
-
-
-def cherrypick(repositorypath: Path, reference: str) -> None:
-    """Cherry-pick the commit onto the current branch."""
-    from cutty.util.git import cherrypick as _cherrypick
-
-    return _cherrypick(repositorypath, reference, message=UPDATE_MESSAGE)
 
 
 def createbranch(
@@ -71,7 +65,7 @@ def update(
             directory=directory,
         )
 
-    cherrypick(projectdir, UPDATE_BRANCH_REF)
+    cherrypick(projectdir, UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
 
     updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -17,13 +17,7 @@ from cutty.util.git import cherrypick
 from cutty.util.git import commit
 from cutty.util.git import createbranch
 from cutty.util.git import createworktree
-
-
-def updatebranch(repositorypath: Path, branch: str, *, target: str) -> None:
-    """Update a branch to the given target, another branch."""
-    repository = pygit2.Repository(repositorypath)
-    commit = repository.branches[target].peel()
-    repository.branches[branch].set_target(commit.id)
+from cutty.util.git import updatebranch
 
 
 def update(

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -19,21 +19,9 @@ from cutty.util.git import createworktree
 
 def cherrypick(repositorypath: Path, reference: str) -> None:
     """Cherry-pick the commit onto the current branch."""
-    repository = pygit2.Repository(repositorypath)
-    oid = repository.references[reference].resolve().target
-    repository.cherrypick(oid)
+    from cutty.util.git import cherrypick as _cherrypick
 
-    if repository.index.conflicts:
-        paths = {
-            side.path
-            for _, ours, theirs in repository.index.conflicts
-            for side in (ours, theirs)
-            if side is not None
-        }
-        raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
-
-    commit(repository, message=UPDATE_MESSAGE)
-    repository.state_cleanup()
+    return _cherrypick(repositorypath, reference, message=UPDATE_MESSAGE)
 
 
 def createbranch(

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -17,14 +17,8 @@ from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
+from cutty.util.git import checkoutemptytree
 from cutty.util.git import commit
-
-
-def checkoutemptytree(repositorypath: Path) -> None:
-    """Check out an empty tree from the repository."""
-    repository = pygit2.Repository(repositorypath)
-    oid = repository.TreeBuilder().write()
-    repository.checkout_tree(repository[oid])
 
 
 @contextmanager

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -22,9 +22,9 @@ def createbranch(
     repositorypath: Path, branch: str, *, target: str, force: bool = False
 ) -> None:
     """Create a branch pointing to the given target, another branch."""
-    repository = pygit2.Repository(repositorypath)
-    commit = repository.branches[target].peel()
-    repository.branches.create(branch, commit, force=force)
+    from cutty.util.git import createbranch
+
+    return createbranch(repositorypath, branch, target=target, force=force)
 
 
 def updatebranch(repositorypath: Path, branch: str, *, target: str) -> None:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -2,10 +2,10 @@
 import hashlib
 import tempfile
 from collections.abc import Iterator
+from collections.abc import Sequence
 from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
-from typing import Sequence
 
 import pygit2
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -1,6 +1,5 @@
 """Update a project with changes from its Cookiecutter template."""
 from collections.abc import Sequence
-from contextlib import AbstractContextManager
 from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
@@ -15,18 +14,7 @@ from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import commit
-
-
-def createworktree(
-    repositorypath: Path,
-    branch: str,
-    *,
-    checkout: bool = True,
-) -> AbstractContextManager[Path]:
-    """Create a worktree for the branch in the repository."""
-    from cutty.util.git import createworktree
-
-    return createworktree(repositorypath, branch, checkout=checkout)
+from cutty.util.git import createworktree
 
 
 def cherrypick(repositorypath: Path, reference: str) -> None:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -15,16 +15,8 @@ from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfi
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import cherrypick
 from cutty.util.git import commit
+from cutty.util.git import createbranch
 from cutty.util.git import createworktree
-
-
-def createbranch(
-    repositorypath: Path, branch: str, *, target: str, force: bool = False
-) -> None:
-    """Create a branch pointing to the given target, another branch."""
-    from cutty.util.git import createbranch
-
-    return createbranch(repositorypath, branch, target=target, force=force)
 
 
 def updatebranch(repositorypath: Path, branch: str, *, target: str) -> None:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -53,7 +53,6 @@ def update(
         )
 
     cherrypick(projectdir, UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
-
     updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
 
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -17,6 +17,7 @@ from cutty.util.git import cherrypick
 from cutty.util.git import commit
 from cutty.util.git import createbranch
 from cutty.util.git import createworktree
+from cutty.util.git import resetmerge
 from cutty.util.git import updatebranch
 
 
@@ -63,18 +64,6 @@ def continueupdate(*, projectdir: Optional[Path] = None) -> None:
 
     commit(pygit2.Repository(projectdir), message=UPDATE_MESSAGE)
     updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
-
-
-def resetmerge(repositorypath: Path, parent: str, cherry: str) -> None:
-    """Reset only files that were touched by a cherry-pick.
-
-    This emulates `git reset --merge HEAD` by performing a hard reset on the
-    files that were updated by the cherry-picked commit, and resetting the index
-    to HEAD.
-    """
-    from cutty.util.git import resetmerge
-
-    resetmerge(repositorypath, parent, cherry)
 
 
 def skipupdate(*, projectdir: Optional[Path] = None) -> None:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -72,21 +72,9 @@ def resetmerge(repositorypath: Path, parent: str, cherry: str) -> None:
     files that were updated by the cherry-picked commit, and resetting the index
     to HEAD.
     """
-    repository = pygit2.Repository(repositorypath)
-    repository.index.read_tree(repository.head.peel().tree)
-    repository.index.write()
+    from cutty.util.git import resetmerge
 
-    parenttree = repository.branches[parent].peel(pygit2.Tree)
-    cherrytree = repository.branches[cherry].peel(pygit2.Tree)
-    diff = cherrytree.diff_to_tree(parenttree)
-    paths = [
-        file.path for delta in diff.deltas for file in (delta.old_file, delta.new_file)
-    ]
-
-    repository.checkout(
-        strategy=pygit2.GIT_CHECKOUT_FORCE | pygit2.GIT_CHECKOUT_REMOVE_UNTRACKED,
-        paths=paths,
-    )
+    resetmerge(repositorypath, parent, cherry)
 
 
 def skipupdate(*, projectdir: Optional[Path] = None) -> None:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -10,7 +10,6 @@ from typing import Sequence
 import pygit2
 
 from cutty.compat.contextlib import contextmanager
-from cutty.filestorage.adapters.observers.git import commit
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH_REF
@@ -18,6 +17,7 @@ from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
+from cutty.util.git import commit
 
 
 def checkoutemptytree(repositorypath: Path) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -107,3 +107,10 @@ def createbranch(
     repository = pygit2.Repository(repositorypath)
     commit = repository.branches[target].peel()
     repository.branches.create(branch, commit, force=force)
+
+
+def updatebranch(repositorypath: Path, branch: str, *, target: str) -> None:
+    """Update a branch to the given target, another branch."""
+    repository = pygit2.Repository(repositorypath)
+    commit = repository.branches[target].peel()
+    repository.branches[branch].set_target(commit.id)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -1,0 +1,1 @@
+"""Git utilities."""

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -1,1 +1,41 @@
 """Git utilities."""
+import contextlib
+import os
+from typing import Optional
+
+import pygit2
+
+
+def default_signature(repository: pygit2.Repository) -> pygit2.Signature:
+    """Return the default signature."""
+    with contextlib.suppress(KeyError):
+        return pygit2.Signature(
+            os.environ["GIT_AUTHOR_NAME"],
+            os.environ["GIT_AUTHOR_EMAIL"],
+        )
+    return repository.default_signature  # pragma: no cover
+
+
+def commit(
+    repository: pygit2.Repository,
+    *,
+    message: str,
+    signature: Optional[pygit2.Signature] = None,
+) -> None:
+    """Commit all changes in the repository.
+
+    If there are no changes relative to the parent, this is a noop.
+    """
+    repository.index.add_all()
+
+    tree = repository.index.write_tree()
+    if not repository.head_is_unborn and tree == repository.head.peel().tree.id:
+        return
+
+    repository.index.write()
+
+    if signature is None:
+        signature = default_signature(repository)
+
+    parents = [] if repository.head_is_unborn else [repository.head.target]
+    repository.create_commit("HEAD", signature, signature, message, tree, parents)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -98,3 +98,12 @@ def cherrypick(repositorypath: Path, reference: str, *, message: str) -> None:
 
     commit(repository, message=message)
     repository.state_cleanup()
+
+
+def createbranch(
+    repositorypath: Path, branch: str, *, target: str, force: bool = False
+) -> None:
+    """Create a branch pointing to the given target, another branch."""
+    repository = pygit2.Repository(repositorypath)
+    commit = repository.branches[target].peel()
+    repository.branches.create(branch, commit, force=force)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -1,6 +1,7 @@
 """Git utilities."""
 import contextlib
 import os
+from pathlib import Path
 from typing import Optional
 
 import pygit2
@@ -39,3 +40,10 @@ def commit(
 
     parents = [] if repository.head_is_unborn else [repository.head.target]
     repository.create_commit("HEAD", signature, signature, message, tree, parents)
+
+
+def checkoutemptytree(repositorypath: Path) -> None:
+    """Check out an empty tree from the repository."""
+    repository = pygit2.Repository(repositorypath)
+    oid = repository.TreeBuilder().write()
+    repository.checkout_tree(repository[oid])

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -109,7 +109,7 @@ def test_hook_additions(storage: FileStorage, project: pathlib.Path) -> None:
 def commit(repository: pygit2.Repository) -> None:
     """Create an initial empty commit."""
     signature = pygit2.Signature("you", "you@example.com")
-    _commit(repository, message="Initial", signature=signature)
+    _commit(repository, message="", signature=signature)
 
 
 def test_existing_repository(

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -14,7 +14,7 @@ from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.util.git import commit as _commit
+from tests.util.git import commit
 
 
 @pytest.fixture
@@ -106,18 +106,12 @@ def test_hook_additions(storage: FileStorage, project: pathlib.Path) -> None:
     assert "marker" in tree(repository)
 
 
-def commit(repository: pygit2.Repository) -> None:
-    """Create an initial empty commit."""
-    signature = pygit2.Signature("you", "you@example.com")
-    _commit(repository, message="", signature=signature)
-
-
 def test_existing_repository(
     storage: FileStorage, file: RegularFile, project: pathlib.Path
 ) -> None:
     """It creates the commit in an existing repository."""
     repository = pygit2.init_repository(project)
-    commit(repository)
+    commit(project)
 
     with storage:
         storage.add(file)
@@ -151,7 +145,7 @@ def test_existing_branch(
 ) -> None:
     """It updates the `update` branch if it exists."""
     repository = pygit2.init_repository(project)
-    commit(repository)
+    commit(project)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
 
@@ -166,7 +160,7 @@ def test_existing_branch_not_head(
 ) -> None:
     """It raises an exception if `update` exists but HEAD points elsewhere."""
     repository = pygit2.init_repository(project)
-    commit(repository)
+    commit(project)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
 
     with pytest.raises(Exception):
@@ -181,7 +175,7 @@ def test_existing_branch_commit_message(
 ) -> None:
     """It uses a different commit message on updates."""
     repository = pygit2.init_repository(project)
-    commit(repository)
+    commit(project)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
@@ -198,7 +192,7 @@ def test_existing_branch_no_changes(
 ) -> None:
     """It does not create an empty commit."""
     repository = pygit2.init_repository(project)
-    commit(repository)
+    commit(project)
 
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -5,7 +5,6 @@ import pygit2
 import pytest
 
 from cutty.filestorage.adapters.disk import DiskFileStorage
-from cutty.filestorage.adapters.observers.git import commit as _commit
 from cutty.filestorage.adapters.observers.git import GitRepositoryObserver
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH_REF
@@ -15,6 +14,7 @@ from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
+from cutty.util.git import commit as _commit
 
 
 @pytest.fixture

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -11,9 +11,9 @@ from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.update import abortupdate
 from cutty.services.update import cherrypick
 from cutty.services.update import continueupdate
-from cutty.services.update import createworktree
 from cutty.services.update import resetmerge
 from cutty.services.update import skipupdate
+from cutty.util.git import createworktree
 from tests.util.files import chdir
 from tests.util.git import commit
 from tests.util.git import removefile

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -10,9 +10,9 @@ from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
-from cutty.services.update import resetmerge
 from cutty.services.update import skipupdate
 from cutty.util.git import cherrypick
+from cutty.util.git import resetmerge
 from tests.util.files import chdir
 from tests.util.git import commit
 from tests.util.git import resolveconflicts

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -13,7 +13,6 @@ from cutty.services.update import cherrypick
 from cutty.services.update import continueupdate
 from cutty.services.update import resetmerge
 from cutty.services.update import skipupdate
-from cutty.util.git import createworktree
 from tests.util.files import chdir
 from tests.util.git import commit
 from tests.util.git import removefile
@@ -53,50 +52,6 @@ def repository(repositorypath: Path) -> pygit2.Repository:
 def createbranch(repository: pygit2.Repository, name: str) -> pygit2.Branch:
     """Create a branch at HEAD."""
     return repository.branches.create(name, repository.head.peel())
-
-
-def test_createworktree_creates_worktree(
-    repository: pygit2.Repository, repositorypath: Path
-) -> None:
-    """It creates a worktree."""
-    createbranch(repository, "branch")
-
-    with createworktree(repositorypath, "branch") as worktree:
-        assert (worktree / ".git").is_file()
-
-
-def test_createworktree_removes_worktree_on_exit(
-    repository: pygit2.Repository, repositorypath: Path
-) -> None:
-    """It removes the worktree on exit."""
-    createbranch(repository, "branch")
-
-    with createworktree(repositorypath, "branch") as worktree:
-        pass
-
-    assert not worktree.is_dir()
-
-
-def test_createworktree_does_checkout(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
-    """It checks out a working tree."""
-    updatefile(path)
-    createbranch(repository, "branch")
-
-    with createworktree(repositorypath, "branch") as worktree:
-        assert (worktree / path.name).is_file()
-
-
-def test_createworktree_no_checkout(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
-    """It creates a worktree without checking out the files."""
-    updatefile(path)
-    createbranch(repository, "branch")
-
-    with createworktree(repositorypath, "branch", checkout=False) as worktree:
-        assert not (worktree / path.name).is_file()
 
 
 def test_cherrypick_adds_file(

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -9,10 +9,10 @@ import pytest
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.update import abortupdate
-from cutty.services.update import cherrypick
 from cutty.services.update import continueupdate
 from cutty.services.update import resetmerge
 from cutty.services.update import skipupdate
+from cutty.util.git import cherrypick
 from tests.util.files import chdir
 from tests.util.git import commit
 from tests.util.git import resolveconflicts
@@ -75,7 +75,7 @@ def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) 
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, update.name)
+        cherrypick(repositorypath, update.name, message="")
 
 
 def test_continueupdate_commits_changes(
@@ -130,7 +130,7 @@ def test_resetmerge_removes_added_files(
     updatefile(path1, "b")
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repositorypath, update.name)
+        cherrypick(repositorypath, update.name, message="")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
@@ -153,7 +153,7 @@ def test_resetmerge_keeps_unrelated_additions(
     path2.touch()
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repositorypath, update.name)
+        cherrypick(repositorypath, update.name, message="")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
@@ -177,7 +177,7 @@ def test_resetmerge_keeps_unrelated_changes(
     path2.write_text("c")
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repositorypath, update.name)
+        cherrypick(repositorypath, update.name, message="")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 
@@ -201,7 +201,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     path2.unlink()
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repositorypath, update.name)
+        cherrypick(repositorypath, update.name, message="")
 
     resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -15,7 +15,6 @@ from cutty.services.update import resetmerge
 from cutty.services.update import skipupdate
 from tests.util.files import chdir
 from tests.util.git import commit
-from tests.util.git import removefile
 from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
@@ -52,59 +51,6 @@ def repository(repositorypath: Path) -> pygit2.Repository:
 def createbranch(repository: pygit2.Repository, name: str) -> pygit2.Branch:
     """Create a branch at HEAD."""
     return repository.branches.create(name, repository.head.peel())
-
-
-def test_cherrypick_adds_file(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
-    """It cherry-picks the commit onto the current branch."""
-    main = repository.head
-    branch = createbranch(repository, "branch")
-
-    repository.checkout(branch)
-    updatefile(path)
-
-    repository.checkout(main)
-    assert not path.is_file()
-
-    cherrypick(repositorypath, branch.name)
-    assert path.is_file()
-
-
-def test_cherrypick_conflict_edit(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
-    """It raises an exception when both sides modified the file."""
-    main = repository.head
-    branch = createbranch(repository, "branch")
-
-    repository.checkout(branch)
-    updatefile(path, "a")
-
-    repository.checkout(main)
-    updatefile(path, "b")
-
-    with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, branch.name)
-
-
-def test_cherrypick_conflict_deletion(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
-    """It raises an exception when one side modified and the other deleted the file."""
-    updatefile(path, "a")
-
-    main = repository.head
-    branch = createbranch(repository, "branch")
-
-    repository.checkout(branch)
-    updatefile(path, "b")
-
-    repository.checkout(main)
-    removefile(path)
-
-    with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, branch.name)
 
 
 def cuttybranches(

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pygit2
 import pytest
 
-from cutty.services.update import cherrypick
+from cutty.util.git import cherrypick
 from cutty.util.git import createworktree
 from tests.util.git import commit
 from tests.util.git import removefile
@@ -102,7 +102,7 @@ def test_cherrypick_adds_file(
     repository.checkout(main)
     assert not path.is_file()
 
-    cherrypick(repositorypath, branch.name)
+    cherrypick(repositorypath, branch.name, message="")
     assert path.is_file()
 
 
@@ -120,7 +120,7 @@ def test_cherrypick_conflict_edit(
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, branch.name)
+        cherrypick(repositorypath, branch.name, message="")
 
 
 def test_cherrypick_conflict_deletion(
@@ -139,4 +139,4 @@ def test_cherrypick_conflict_deletion(
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, branch.name)
+        cherrypick(repositorypath, branch.name, message="")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -6,11 +6,15 @@ from pathlib import Path
 import pygit2
 import pytest
 
+from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
+from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.util.git import cherrypick
 from cutty.util.git import createworktree
+from cutty.util.git import resetmerge
 from tests.util.git import commit
 from tests.util.git import removefile
 from tests.util.git import updatefile
+from tests.util.git import updatefiles
 
 
 @pytest.fixture
@@ -140,3 +144,141 @@ def test_cherrypick_conflict_deletion(
 
     with pytest.raises(Exception, match=path.name):
         cherrypick(repositorypath, branch.name, message="")
+
+
+def cuttybranches(
+    repository: pygit2.Repository,
+) -> tuple[pygit2.Reference, pygit2.Reference, pygit2.Reference]:
+    """Return the current, the `cutty/latest`, and the `cutty/update` branches."""
+    main = repository.head
+    update = createbranch(repository, UPDATE_BRANCH)
+    latest = createbranch(repository, LATEST_BRANCH)
+    return main, update, latest
+
+
+def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:
+    """Create an update conflict."""
+    repository = pygit2.Repository(repositorypath)
+    main, update, _ = cuttybranches(repository)
+
+    repository.checkout(update)
+    updatefile(path, theirs)
+
+    repository.checkout(main)
+    updatefile(path, ours)
+
+    with pytest.raises(Exception, match=path.name):
+        cherrypick(repositorypath, update.name, message="")
+
+
+def test_resetmerge_restores_files_with_conflicts(
+    repositorypath: Path, path: Path
+) -> None:
+    """It restores the conflicting files in the working tree to our version."""
+    createconflict(repositorypath, path, ours="a", theirs="b")
+    resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+
+    assert path.read_text() == "a"
+
+
+def test_resetmerge_removes_added_files(
+    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
+) -> None:
+    """It removes files added by the cherry-picked commit."""
+    main, update, _ = cuttybranches(repository)
+    path1, path2 = next(paths), next(paths)
+
+    repository.checkout(update)
+    updatefiles({path1: "a", path2: ""})
+
+    repository.checkout(main)
+    updatefile(path1, "b")
+
+    with pytest.raises(Exception, match=path1.name):
+        cherrypick(repositorypath, update.name, message="")
+
+    resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+
+    assert not path2.exists()
+
+
+def test_resetmerge_keeps_unrelated_additions(
+    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
+) -> None:
+    """It keeps additions of files that did not change in the update."""
+    main, update, _ = cuttybranches(repository)
+    path1, path2 = next(paths), next(paths)
+
+    repository.checkout(update)
+    updatefile(path1, "a")
+
+    repository.checkout(main)
+    updatefile(path1, "b")
+
+    path2.touch()
+
+    with pytest.raises(Exception, match=path1.name):
+        cherrypick(repositorypath, update.name, message="")
+
+    resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+
+    assert path2.exists()
+
+
+def test_resetmerge_keeps_unrelated_changes(
+    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
+) -> None:
+    """It keeps modifications to files that did not change in the update."""
+    main, update, _ = cuttybranches(repository)
+    path1, path2 = next(paths), next(paths)
+
+    repository.checkout(update)
+    updatefile(path1, "a")
+
+    repository.checkout(main)
+    updatefile(path1, "b")
+    updatefile(path2)
+
+    path2.write_text("c")
+
+    with pytest.raises(Exception, match=path1.name):
+        cherrypick(repositorypath, update.name, message="")
+
+    resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+
+    assert path2.read_text() == "c"
+
+
+def test_resetmerge_keeps_unrelated_deletions(
+    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
+) -> None:
+    """It keeps deletions of files that did not change in the update."""
+    main, update, _ = cuttybranches(repository)
+    path1, path2 = next(paths), next(paths)
+
+    repository.checkout(update)
+    updatefile(path1, "a")
+
+    repository.checkout(main)
+    updatefile(path1, "b")
+    updatefile(path2)
+
+    path2.unlink()
+
+    with pytest.raises(Exception, match=path1.name):
+        cherrypick(repositorypath, update.name, message="")
+
+    resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+
+    assert not path2.exists()
+
+
+def test_resetmerge_resets_index(
+    repository: pygit2.Repository, repositorypath: Path, path: Path
+) -> None:
+    """It resets the index to HEAD, removing conflicts."""
+    createconflict(repositorypath, path, ours="a", theirs="b")
+
+    resetmerge(repositorypath, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+
+    assert repository.index.write_tree() == repository.head.peel().tree.id

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -1,1 +1,80 @@
 """Unit tests for cutty.util.git."""
+from collections.abc import Iterator
+from pathlib import Path
+
+import pygit2
+import pytest
+
+from cutty.util.git import createworktree
+from tests.util.git import commit
+from tests.util.git import updatefile
+
+
+@pytest.fixture
+def repositorypath(tmp_path: Path) -> Path:
+    """Fixture for a repository."""
+    repositorypath = tmp_path / "repository"
+    pygit2.init_repository(repositorypath)
+    commit(repositorypath)
+    return repositorypath
+
+
+@pytest.fixture
+def repository(repositorypath: Path) -> pygit2.Repository:
+    """Fixture for a repository."""
+    return pygit2.Repository(repositorypath)
+
+
+@pytest.fixture
+def path(paths: Iterator[Path]) -> Path:
+    """Return an arbitrary path in the repository."""
+    return next(paths)
+
+
+def createbranch(repository: pygit2.Repository, name: str) -> pygit2.Branch:
+    """Create a branch at HEAD."""
+    return repository.branches.create(name, repository.head.peel())
+
+
+def test_createworktree_creates_worktree(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
+    """It creates a worktree."""
+    createbranch(repository, "branch")
+
+    with createworktree(repositorypath, "branch") as worktree:
+        assert (worktree / ".git").is_file()
+
+
+def test_createworktree_removes_worktree_on_exit(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
+    """It removes the worktree on exit."""
+    createbranch(repository, "branch")
+
+    with createworktree(repositorypath, "branch") as worktree:
+        pass
+
+    assert not worktree.is_dir()
+
+
+def test_createworktree_does_checkout(
+    repository: pygit2.Repository, repositorypath: Path, path: Path
+) -> None:
+    """It checks out a working tree."""
+    updatefile(path)
+    createbranch(repository, "branch")
+
+    with createworktree(repositorypath, "branch") as worktree:
+        assert (worktree / path.name).is_file()
+
+
+def test_createworktree_no_checkout(
+    repository: pygit2.Repository, repositorypath: Path, path: Path
+) -> None:
+    """It creates a worktree without checking out the files."""
+    updatefile(path)
+    createbranch(repository, "branch")
+
+    with createworktree(repositorypath, "branch", checkout=False) as worktree:
+        assert not (worktree / path.name).is_file()

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -1,4 +1,5 @@
 """Unit tests for cutty.util.git."""
+import string
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -23,6 +24,12 @@ def repositorypath(tmp_path: Path) -> Path:
 def repository(repositorypath: Path) -> pygit2.Repository:
     """Fixture for a repository."""
     return pygit2.Repository(repositorypath)
+
+
+@pytest.fixture
+def paths(repositorypath: Path) -> Iterator[Path]:
+    """Return arbitrary paths in the repository."""
+    return (repositorypath / letter for letter in string.ascii_letters)
 
 
 @pytest.fixture

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -1,0 +1,1 @@
+"""Unit tests for cutty.util.git."""

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 
 import pygit2
 
-from cutty.filestorage.adapters.observers.git import commit as _commit
+from cutty.util.git import commit as _commit
 
 
 def commit(repositorypath: Path, *, message: str = "") -> None:


### PR DESCRIPTION
- :tada: [util] Add module for git utilities
- copy functions `commit` and `default_signature`
- default_signature: replace inline code with function call
- commit: replace inline code with function call
- default_signature: remove function
- commit: inline function
- simplify literal
- replace inline code with function call to `tests.util.git`
- checkoutemptytree: move function
- createworktree: copy function
- fix deprecated import
- createworktree: replace inline code with function call
- createworktree: inline function
- createworktree: move tests
- cherrypick: copy function
- cherrypick: replace inline code with function call
- cherrypick: move tests
- cherrypick: inline function and simplify literal
- cherrypick: inline function and simplify literal
- cherrypick: inline function
- createbranch: copy function
- createbranch: replace inline code with function call
- createbranch: inline function
- updatebranch: move function
- resetmerge: copy function
- resetmerge: replace inline code with function call
- resetmerge: inline function
- remove blank line
- resetmerge: move tests
