### PR TITLE
:recycle: [util] Pass `pygit2.Repository` to git utilities instead of `Path`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -39,9 +39,9 @@ def update(
     if directory is None:
         directory = projectconfig.directory
 
-    createbranch(projectdir, UPDATE_BRANCH, target=LATEST_BRANCH, force=True)
-
     repository = pygit2.Repository(projectdir)
+    createbranch(repository, UPDATE_BRANCH, target=LATEST_BRANCH, force=True)
+
     with createworktree(repository, UPDATE_BRANCH, checkout=False) as worktree:
         create(
             projectconfig.template,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -41,7 +41,8 @@ def update(
 
     createbranch(projectdir, UPDATE_BRANCH, target=LATEST_BRANCH, force=True)
 
-    with createworktree(projectdir, UPDATE_BRANCH, checkout=False) as worktree:
+    repository = pygit2.Repository(projectdir)
+    with createworktree(repository, UPDATE_BRANCH, checkout=False) as worktree:
         create(
             projectconfig.template,
             outputdir=worktree,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -73,7 +73,7 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
         projectdir = Path.cwd()
 
     repository = pygit2.Repository(projectdir)
-    resetmerge(projectdir, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+    resetmerge(repository, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
     updatebranch(repository, LATEST_BRANCH, target=UPDATE_BRANCH)
 
 
@@ -83,5 +83,5 @@ def abortupdate(*, projectdir: Optional[Path] = None) -> None:
         projectdir = Path.cwd()
 
     repository = pygit2.Repository(projectdir)
-    resetmerge(projectdir, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+    resetmerge(repository, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
     updatebranch(repository, UPDATE_BRANCH, target=LATEST_BRANCH)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -53,7 +53,7 @@ def update(
             directory=directory,
         )
 
-    cherrypick(projectdir, UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
+    cherrypick(repository, UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
     updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
 
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -54,7 +54,7 @@ def update(
         )
 
     cherrypick(repository, UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
-    updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
+    updatebranch(repository, LATEST_BRANCH, target=UPDATE_BRANCH)
 
 
 def continueupdate(*, projectdir: Optional[Path] = None) -> None:
@@ -62,8 +62,9 @@ def continueupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
-    commit(pygit2.Repository(projectdir), message=UPDATE_MESSAGE)
-    updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
+    repository = pygit2.Repository(projectdir)
+    commit(repository, message=UPDATE_MESSAGE)
+    updatebranch(repository, LATEST_BRANCH, target=UPDATE_BRANCH)
 
 
 def skipupdate(*, projectdir: Optional[Path] = None) -> None:
@@ -71,8 +72,9 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
+    repository = pygit2.Repository(projectdir)
     resetmerge(projectdir, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
-    updatebranch(projectdir, LATEST_BRANCH, target=UPDATE_BRANCH)
+    updatebranch(repository, LATEST_BRANCH, target=UPDATE_BRANCH)
 
 
 def abortupdate(*, projectdir: Optional[Path] = None) -> None:
@@ -80,5 +82,6 @@ def abortupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
+    repository = pygit2.Repository(projectdir)
     resetmerge(projectdir, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
-    updatebranch(projectdir, UPDATE_BRANCH, target=LATEST_BRANCH)
+    updatebranch(repository, UPDATE_BRANCH, target=LATEST_BRANCH)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -105,9 +105,8 @@ def createbranch(
     repository.branches.create(branch, commit, force=force)
 
 
-def updatebranch(repositorypath: Path, branch: str, *, target: str) -> None:
+def updatebranch(repository: pygit2.Repository, branch: str, *, target: str) -> None:
     """Update a branch to the given target, another branch."""
-    repository = pygit2.Repository(repositorypath)
     commit = repository.branches[target].peel()
     repository.branches[branch].set_target(commit.id)
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -55,14 +55,12 @@ def checkoutemptytree(repository: pygit2.Repository) -> None:
 
 @contextmanager
 def createworktree(
-    repositorypath: Path,
+    repository: pygit2.Repository,
     branch: str,
     *,
     checkout: bool = True,
 ) -> Iterator[Path]:
     """Create a worktree for the branch in the repository."""
-    repository = pygit2.Repository(repositorypath)
-
     with tempfile.TemporaryDirectory() as directory:
         name = hashlib.blake2b(branch.encode(), digest_size=32).hexdigest()
         path = Path(directory) / name

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -98,10 +98,9 @@ def cherrypick(repository: pygit2.Repository, reference: str, *, message: str) -
 
 
 def createbranch(
-    repositorypath: Path, branch: str, *, target: str, force: bool = False
+    repository: pygit2.Repository, branch: str, *, target: str, force: bool = False
 ) -> None:
     """Create a branch pointing to the given target, another branch."""
-    repository = pygit2.Repository(repositorypath)
     commit = repository.branches[target].peel()
     repository.branches.create(branch, commit, force=force)
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -47,9 +47,8 @@ def commit(
     repository.create_commit("HEAD", signature, signature, message, tree, parents)
 
 
-def checkoutemptytree(repositorypath: Path) -> None:
+def checkoutemptytree(repository: pygit2.Repository) -> None:
     """Check out an empty tree from the repository."""
-    repository = pygit2.Repository(repositorypath)
     oid = repository.TreeBuilder().write()
     repository.checkout_tree(repository[oid])
 
@@ -72,7 +71,8 @@ def createworktree(
         if not checkout:
             # Emulate `--no-checkout` by checking out an empty tree after the fact.
             # https://github.com/libgit2/libgit2/issues/5949
-            checkoutemptytree(path)
+            worktreerepository = pygit2.Repository(path)
+            checkoutemptytree(worktreerepository)
 
         yield path
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -79,9 +79,8 @@ def createworktree(
     worktree.prune(True)
 
 
-def cherrypick(repositorypath: Path, reference: str, *, message: str) -> None:
+def cherrypick(repository: pygit2.Repository, reference: str, *, message: str) -> None:
     """Cherry-pick the commit onto the current branch."""
-    repository = pygit2.Repository(repositorypath)
     oid = repository.references[reference].resolve().target
     repository.cherrypick(oid)
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -111,14 +111,13 @@ def updatebranch(repository: pygit2.Repository, branch: str, *, target: str) -> 
     repository.branches[branch].set_target(commit.id)
 
 
-def resetmerge(repositorypath: Path, parent: str, cherry: str) -> None:
+def resetmerge(repository: pygit2.Repository, parent: str, cherry: str) -> None:
     """Reset only files that were touched by a cherry-pick.
 
     This emulates `git reset --merge HEAD` by performing a hard reset on the
     files that were updated by the cherry-picked commit, and resetting the index
     to HEAD.
     """
-    repository = pygit2.Repository(repositorypath)
     repository.index.read_tree(repository.head.peel().tree)
     repository.index.write()
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -46,7 +46,7 @@ def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) 
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, update.name, message="")
+        cherrypick(repository, update.name, message="")
 
 
 def test_continueupdate_commits_changes(

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -142,11 +142,11 @@ def test_cherrypick_conflict_deletion(
 
 
 def test_resetmerge_restores_files_with_conflicts(
-    repositorypath: Path, path: Path
+    repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It restores the conflicting files in the working tree to our version."""
     createconflict(repositorypath, path, ours="a", theirs="b")
-    resetmerge(repositorypath, parent="latest", cherry="update")
+    resetmerge(repository, parent="latest", cherry="update")
 
     assert path.read_text() == "a"
 
@@ -168,7 +168,7 @@ def test_resetmerge_removes_added_files(
     with pytest.raises(Exception, match=path1.name):
         cherrypick(repository, update.name, message="")
 
-    resetmerge(repositorypath, parent="latest", cherry="update")
+    resetmerge(repository, parent="latest", cherry="update")
 
     assert not path2.exists()
 
@@ -192,7 +192,7 @@ def test_resetmerge_keeps_unrelated_additions(
     with pytest.raises(Exception, match=path1.name):
         cherrypick(repository, update.name, message="")
 
-    resetmerge(repositorypath, parent="latest", cherry="update")
+    resetmerge(repository, parent="latest", cherry="update")
 
     assert path2.exists()
 
@@ -217,7 +217,7 @@ def test_resetmerge_keeps_unrelated_changes(
     with pytest.raises(Exception, match=path1.name):
         cherrypick(repository, update.name, message="")
 
-    resetmerge(repositorypath, parent="latest", cherry="update")
+    resetmerge(repository, parent="latest", cherry="update")
 
     assert path2.read_text() == "c"
 
@@ -242,7 +242,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     with pytest.raises(Exception, match=path1.name):
         cherrypick(repository, update.name, message="")
 
-    resetmerge(repositorypath, parent="latest", cherry="update")
+    resetmerge(repository, parent="latest", cherry="update")
 
     assert not path2.exists()
 
@@ -253,6 +253,6 @@ def test_resetmerge_resets_index(
     """It resets the index to HEAD, removing conflicts."""
     createconflict(repositorypath, path, ours="a", theirs="b")
 
-    resetmerge(repositorypath, parent="latest", cherry="update")
+    resetmerge(repository, parent="latest", cherry="update")
 
     assert repository.index.write_tree() == repository.head.peel().tree.id

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -41,7 +41,7 @@ def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) 
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, update.name, message="")
+        cherrypick(repository, update.name, message="")
 
 
 def test_createworktree_creates_worktree(
@@ -101,7 +101,7 @@ def test_cherrypick_adds_file(
     repository.checkout(main)
     assert not path.is_file()
 
-    cherrypick(repositorypath, branch.name, message="")
+    cherrypick(repository, branch.name, message="")
     assert path.is_file()
 
 
@@ -119,7 +119,7 @@ def test_cherrypick_conflict_edit(
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, branch.name, message="")
+        cherrypick(repository, branch.name, message="")
 
 
 def test_cherrypick_conflict_deletion(
@@ -138,7 +138,7 @@ def test_cherrypick_conflict_deletion(
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repositorypath, branch.name, message="")
+        cherrypick(repository, branch.name, message="")
 
 
 def test_resetmerge_restores_files_with_conflicts(
@@ -166,7 +166,7 @@ def test_resetmerge_removes_added_files(
     updatefile(path1, "b")
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repositorypath, update.name, message="")
+        cherrypick(repository, update.name, message="")
 
     resetmerge(repositorypath, parent="latest", cherry="update")
 
@@ -190,7 +190,7 @@ def test_resetmerge_keeps_unrelated_additions(
     path2.touch()
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repositorypath, update.name, message="")
+        cherrypick(repository, update.name, message="")
 
     resetmerge(repositorypath, parent="latest", cherry="update")
 
@@ -215,7 +215,7 @@ def test_resetmerge_keeps_unrelated_changes(
     path2.write_text("c")
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repositorypath, update.name, message="")
+        cherrypick(repository, update.name, message="")
 
     resetmerge(repositorypath, parent="latest", cherry="update")
 
@@ -240,7 +240,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     path2.unlink()
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repositorypath, update.name, message="")
+        cherrypick(repository, update.name, message="")
 
     resetmerge(repositorypath, parent="latest", cherry="update")
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -50,7 +50,7 @@ def test_createworktree_creates_worktree(
     """It creates a worktree."""
     createbranch(repository, "branch")
 
-    with createworktree(repositorypath, "branch") as worktree:
+    with createworktree(repository, "branch") as worktree:
         assert (worktree / ".git").is_file()
 
 
@@ -60,7 +60,7 @@ def test_createworktree_removes_worktree_on_exit(
     """It removes the worktree on exit."""
     createbranch(repository, "branch")
 
-    with createworktree(repositorypath, "branch") as worktree:
+    with createworktree(repository, "branch") as worktree:
         pass
 
     assert not worktree.is_dir()
@@ -73,7 +73,7 @@ def test_createworktree_does_checkout(
     updatefile(path)
     createbranch(repository, "branch")
 
-    with createworktree(repositorypath, "branch") as worktree:
+    with createworktree(repository, "branch") as worktree:
         assert (worktree / path.name).is_file()
 
 
@@ -84,7 +84,7 @@ def test_createworktree_no_checkout(
     updatefile(path)
     createbranch(repository, "branch")
 
-    with createworktree(repositorypath, "branch", checkout=False) as worktree:
+    with createworktree(repository, "branch", checkout=False) as worktree:
         assert not (worktree / path.name).is_file()
 
 


### PR DESCRIPTION
- checkoutemptytree: move statement to callers
- createworktree: move statement to callers
- cherrypick: move statement to callers
- createbranch: move statement to callers
- updatebranch: move statement to callers
- resetmerge: move statement to callers
