### PR TITLE
:recycle: [util] Pass `pygit2.Repository` to git test utilities instead of `Path`

### DIFF
--- a/tests/fixtures/git.py
+++ b/tests/fixtures/git.py
@@ -13,8 +13,8 @@ from tests.util.git import commit
 def repositorypath(tmp_path: Path) -> Path:
     """Fixture for a repository."""
     repositorypath = tmp_path / "repository"
-    pygit2.init_repository(repositorypath)
-    commit(repositorypath)
+    repository = pygit2.init_repository(repositorypath)
+    commit(repository)
     return repositorypath
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -84,6 +84,6 @@ def template_directory(tmp_path: Path) -> Path:
 @pytest.fixture
 def template(template_directory: Path) -> Path:
     """Fixture for a template repository."""
-    pygit2.init_repository(template_directory)
-    commit(template_directory, message="Initial")
+    repository = pygit2.init_repository(template_directory)
+    commit(repository, message="Initial")
     return template_directory

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -91,7 +91,7 @@ def test_output_dir(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
 def test_directory(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
     """It uses the template in the given subdirectory."""
     directory = "a"
-    move_repository_files_to_subdirectory(template, directory)
+    move_repository_files_to_subdirectory(pygit2.Repository(template), directory)
 
     runcutty("cookiecutter", f"--directory={directory}", str(template))
 

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -1,6 +1,7 @@
 """Functional tests for the create CLI."""
 from pathlib import Path
 
+import pygit2
 import pytest
 
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
@@ -65,7 +66,7 @@ def test_inplace(runcutty: RunCutty, template: Path) -> None:
 def test_directory(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
     """It uses the template in the given subdirectory."""
     directory = "a"
-    move_repository_files_to_subdirectory(template, directory)
+    move_repository_files_to_subdirectory(pygit2.Repository(template), directory)
 
     runcutty("create", f"--directory={directory}", str(template))
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -324,7 +324,7 @@ def test_continue(runcutty: RunCutty, templateproject: Path, project: Path) -> N
     with pytest.raises(Exception, match="conflict"):
         runcutty("update", f"--cwd={project}")
 
-    resolveconflicts(project, project / "LICENSE", Side.THEIRS)
+    resolveconflicts(pygit2.Repository(project), project / "LICENSE", Side.THEIRS)
 
     runcutty("update", f"--cwd={project}", "--continue")
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -262,7 +262,7 @@ def test_directory_projectconfig(runcutty: RunCutty, template: Path) -> None:
     """It uses the template directory specified in the project configuration."""
     project = Path("example")
     directory = "a"
-    move_repository_files_to_subdirectory(template, directory)
+    move_repository_files_to_subdirectory(pygit2.Repository(template), directory)
 
     runcutty("create", f"--directory={directory}", str(template))
     updatefile(template / "a" / "{{ cookiecutter.project }}" / "LICENSE")
@@ -274,7 +274,7 @@ def test_directory_projectconfig(runcutty: RunCutty, template: Path) -> None:
 def test_directory_update(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It uses the template directory specified when updating."""
     directory = "a"
-    move_repository_files_to_subdirectory(template, directory)
+    move_repository_files_to_subdirectory(pygit2.Repository(template), directory)
 
     runcutty("update", f"--cwd={project}", f"--directory={directory}")
 

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -111,7 +111,7 @@ def test_existing_repository(
 ) -> None:
     """It creates the commit in an existing repository."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
 
     with storage:
         storage.add(file)
@@ -145,7 +145,7 @@ def test_existing_branch(
 ) -> None:
     """It updates the `update` branch if it exists."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
 
@@ -160,7 +160,7 @@ def test_existing_branch_not_head(
 ) -> None:
     """It raises an exception if `update` exists but HEAD points elsewhere."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
 
     with pytest.raises(Exception):
@@ -175,7 +175,7 @@ def test_existing_branch_commit_message(
 ) -> None:
     """It uses a different commit message on updates."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
@@ -192,7 +192,7 @@ def test_existing_branch_no_changes(
 ) -> None:
     """It does not create an empty commit."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
 
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -54,7 +54,7 @@ def test_continueupdate_commits_changes(
 ) -> None:
     """It commits the changes."""
     createconflict(repositorypath, path, ours="a", theirs="b")
-    resolveconflicts(repositorypath, path, Side.THEIRS)
+    resolveconflicts(repository, path, Side.THEIRS)
 
     with chdir(repositorypath):
         continueupdate()
@@ -68,7 +68,7 @@ def test_continueupdate_fastforwards_latest(
 ) -> None:
     """It updates the latest branch to the tip of the update branch."""
     createconflict(repositorypath, path, ours="a", theirs="b")
-    resolveconflicts(repositorypath, path, Side.THEIRS)
+    resolveconflicts(repository, path, Side.THEIRS)
 
     with chdir(repositorypath):
         continueupdate()

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -34,9 +34,10 @@ def cuttybranches(
     return main, update, latest
 
 
-def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:
+def createconflict(
+    repository: pygit2.Repository, path: Path, *, ours: str, theirs: str
+) -> None:
     """Create an update conflict."""
-    repository = pygit2.Repository(repositorypath)
     main, update, _ = cuttybranches(repository)
 
     repository.checkout(update)
@@ -53,7 +54,7 @@ def test_continueupdate_commits_changes(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It commits the changes."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -67,7 +68,7 @@ def test_continueupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It updates the latest branch to the tip of the update branch."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -81,7 +82,7 @@ def test_skipupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
 
     updatehead = repository.branches[UPDATE_BRANCH].peel()
 
@@ -95,7 +96,7 @@ def test_abortupdate_rewinds_update_branch(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
 
     branches = repository.branches
     latesthead = branches[LATEST_BRANCH].peel()

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -28,9 +28,10 @@ def createbranches(
     return tuple(createbranch(repository, name) for name in names)
 
 
-def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:
+def createconflict(
+    repository: pygit2.Repository, path: Path, *, ours: str, theirs: str
+) -> None:
     """Create an update conflict."""
-    repository = pygit2.Repository(repositorypath)
     main = repository.head
     update, _ = createbranches(repository, "update", "latest")
 
@@ -145,7 +146,7 @@ def test_resetmerge_restores_files_with_conflicts(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It restores the conflicting files in the working tree to our version."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
     resetmerge(repository, parent="latest", cherry="update")
 
     assert path.read_text() == "a"
@@ -251,7 +252,7 @@ def test_resetmerge_resets_index(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
 
     resetmerge(repository, parent="latest", cherry="update")
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -45,9 +45,7 @@ def createconflict(
         cherrypick(repository, update.name, message="")
 
 
-def test_createworktree_creates_worktree(
-    repository: pygit2.Repository, repositorypath: Path
-) -> None:
+def test_createworktree_creates_worktree(repository: pygit2.Repository) -> None:
     """It creates a worktree."""
     createbranch(repository, "branch")
 
@@ -55,9 +53,7 @@ def test_createworktree_creates_worktree(
         assert (worktree / ".git").is_file()
 
 
-def test_createworktree_removes_worktree_on_exit(
-    repository: pygit2.Repository, repositorypath: Path
-) -> None:
+def test_createworktree_removes_worktree_on_exit(repository: pygit2.Repository) -> None:
     """It removes the worktree on exit."""
     createbranch(repository, "branch")
 
@@ -68,7 +64,7 @@ def test_createworktree_removes_worktree_on_exit(
 
 
 def test_createworktree_does_checkout(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
+    repository: pygit2.Repository, path: Path
 ) -> None:
     """It checks out a working tree."""
     updatefile(path)
@@ -78,9 +74,7 @@ def test_createworktree_does_checkout(
         assert (worktree / path.name).is_file()
 
 
-def test_createworktree_no_checkout(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
+def test_createworktree_no_checkout(repository: pygit2.Repository, path: Path) -> None:
     """It creates a worktree without checking out the files."""
     updatefile(path)
     createbranch(repository, "branch")
@@ -89,9 +83,7 @@ def test_createworktree_no_checkout(
         assert not (worktree / path.name).is_file()
 
 
-def test_cherrypick_adds_file(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
+def test_cherrypick_adds_file(repository: pygit2.Repository, path: Path) -> None:
     """It cherry-picks the commit onto the current branch."""
     main = repository.head
     branch = createbranch(repository, "branch")
@@ -106,9 +98,7 @@ def test_cherrypick_adds_file(
     assert path.is_file()
 
 
-def test_cherrypick_conflict_edit(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
+def test_cherrypick_conflict_edit(repository: pygit2.Repository, path: Path) -> None:
     """It raises an exception when both sides modified the file."""
     main = repository.head
     branch = createbranch(repository, "branch")
@@ -124,7 +114,7 @@ def test_cherrypick_conflict_edit(
 
 
 def test_cherrypick_conflict_deletion(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
+    repository: pygit2.Repository, path: Path
 ) -> None:
     """It raises an exception when one side modified and the other deleted the file."""
     updatefile(path, "a")
@@ -143,7 +133,7 @@ def test_cherrypick_conflict_deletion(
 
 
 def test_resetmerge_restores_files_with_conflicts(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
+    repository: pygit2.Repository, path: Path
 ) -> None:
     """It restores the conflicting files in the working tree to our version."""
     createconflict(repository, path, ours="a", theirs="b")
@@ -153,7 +143,7 @@ def test_resetmerge_restores_files_with_conflicts(
 
 
 def test_resetmerge_removes_added_files(
-    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
+    repository: pygit2.Repository, paths: Iterator[Path]
 ) -> None:
     """It removes files added by the cherry-picked commit."""
     main = repository.head
@@ -175,7 +165,7 @@ def test_resetmerge_removes_added_files(
 
 
 def test_resetmerge_keeps_unrelated_additions(
-    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
+    repository: pygit2.Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps additions of files that did not change in the update."""
     main = repository.head
@@ -199,7 +189,7 @@ def test_resetmerge_keeps_unrelated_additions(
 
 
 def test_resetmerge_keeps_unrelated_changes(
-    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
+    repository: pygit2.Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
     main = repository.head
@@ -224,7 +214,7 @@ def test_resetmerge_keeps_unrelated_changes(
 
 
 def test_resetmerge_keeps_unrelated_deletions(
-    repository: pygit2.Repository, repositorypath: Path, paths: Iterator[Path]
+    repository: pygit2.Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
     main = repository.head
@@ -248,9 +238,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     assert not path2.exists()
 
 
-def test_resetmerge_resets_index(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
+def test_resetmerge_resets_index(repository: pygit2.Repository, path: Path) -> None:
     """It resets the index to HEAD, removing conflicts."""
     createconflict(repository, path, ours="a", theirs="b")
 

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -83,10 +83,12 @@ class Side(enum.Enum):
     THEIRS = 2
 
 
-def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
+def resolveconflicts(repository: pygit2.Repository, path: Path, side: Side) -> None:
     """Resolve the conflicts."""
-    repository = pygit2.Repository(repositorypath)
-    pathstr = str(path.relative_to(repositorypath))
+    repositorypath = Path(
+        repository.workdir if repository.workdir is not None else repository.path
+    )
+    pathstr = str(path.resolve().relative_to(repositorypath))
     ancestor, ours, theirs = repository.index.conflicts[pathstr]
     resolution = (ancestor, ours, theirs)[side.value]
 

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -8,9 +8,8 @@ import pygit2
 from cutty.util.git import commit as _commit
 
 
-def commit(repositorypath: Path, *, message: str = "") -> None:
+def commit(repository: pygit2.Repository, *, message: str = "") -> None:
     """Commit all changes in the repository."""
-    repository = pygit2.Repository(repositorypath)
     signature = pygit2.Signature("you", "you@example.com")
     _commit(repository, message=message, signature=signature)
 
@@ -23,7 +22,7 @@ def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) 
     tree = repository[builder.write()]
     repository.checkout_tree(tree)
 
-    commit(repositorypath, message=f"Move files to subdirectory {directory}")
+    commit(repository, message=f"Move files to subdirectory {directory}")
 
 
 def discoverrepository(path: Path) -> Path:
@@ -42,7 +41,7 @@ def updatefile(path: Path, text: str = "") -> None:
 
     path.write_text(dedent(text).lstrip())
 
-    commit(repository, message=f"{verb} {path.name}")
+    commit(pygit2.Repository(repository), message=f"{verb} {path.name}")
 
 
 def updatefiles(paths: dict[Path, str]) -> None:
@@ -58,7 +57,7 @@ def updatefiles(paths: dict[Path, str]) -> None:
         path.write_text(dedent(text).lstrip())
 
     pathlist = " and ".join(path.name for path in paths)
-    commit(repository, message=f"{verb} {pathlist}")
+    commit(pygit2.Repository(repository), message=f"{verb} {pathlist}")
 
 
 def appendfile(path: Path, text: str) -> None:
@@ -72,7 +71,7 @@ def removefile(path: Path) -> None:
 
     path.unlink()
 
-    commit(repository, message=f"Remove {path.name}")
+    commit(pygit2.Repository(repository), message=f"Remove {path.name}")
 
 
 class Side(enum.Enum):

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -88,7 +88,7 @@ def resolveconflicts(repository: pygit2.Repository, path: Path, side: Side) -> N
     repositorypath = Path(
         repository.workdir if repository.workdir is not None else repository.path
     )
-    pathstr = str(path.resolve().relative_to(repositorypath))
+    pathstr = str(path.resolve().relative_to(repositorypath.resolve()))
     ancestor, ours, theirs = repository.index.conflicts[pathstr]
     resolution = (ancestor, ours, theirs)[side.value]
 

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -14,9 +14,10 @@ def commit(repository: pygit2.Repository, *, message: str = "") -> None:
     _commit(repository, message=message, signature=signature)
 
 
-def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) -> None:
+def move_repository_files_to_subdirectory(
+    repository: pygit2.Repository, directory: str
+) -> None:
     """Move all files in the repository to the given subdirectory."""
-    repository = pygit2.Repository(repositorypath)
     builder = repository.TreeBuilder()
     builder.insert(directory, repository.head.peel().tree.id, pygit2.GIT_FILEMODE_TREE)
     tree = repository[builder.write()]

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -26,12 +26,12 @@ def move_repository_files_to_subdirectory(
     commit(repository, message=f"Move files to subdirectory {directory}")
 
 
-def discoverrepository(path: Path) -> Path:
+def discoverrepository(path: Path) -> pygit2.Repository:
     """Discover a git repository."""
     while path.name and not path.exists():
         path = path.parent
 
-    return Path(pygit2.discover_repository(path))
+    return pygit2.Repository(pygit2.discover_repository(path))
 
 
 def updatefile(path: Path, text: str = "") -> None:
@@ -42,7 +42,7 @@ def updatefile(path: Path, text: str = "") -> None:
 
     path.write_text(dedent(text).lstrip())
 
-    commit(pygit2.Repository(repository), message=f"{verb} {path.name}")
+    commit(repository, message=f"{verb} {path.name}")
 
 
 def updatefiles(paths: dict[Path, str]) -> None:
@@ -58,7 +58,7 @@ def updatefiles(paths: dict[Path, str]) -> None:
         path.write_text(dedent(text).lstrip())
 
     pathlist = " and ".join(path.name for path in paths)
-    commit(pygit2.Repository(repository), message=f"{verb} {pathlist}")
+    commit(repository, message=f"{verb} {pathlist}")
 
 
 def appendfile(path: Path, text: str) -> None:
@@ -72,7 +72,7 @@ def removefile(path: Path) -> None:
 
     path.unlink()
 
-    commit(pygit2.Repository(repository), message=f"Remove {path.name}")
+    commit(repository, message=f"Remove {path.name}")
 
 
 class Side(enum.Enum):


### PR DESCRIPTION
- commit: move statement to callers
- move_repository_files_to_subdirectory: move statement to callers
- discoverrepository: move statement into function
- resolveconflicts: move statement to callers
- createconflict: move statement to callers
- repositorypath: remove unused parameters
