### PR TITLE
:recycle: [util] Generalize `util.git.createbranch` to refs and oids

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -103,10 +103,10 @@ def createbranch(
     *,
     target: str = "HEAD",
     force: bool = False,
-) -> None:
+) -> pygit2.Branch:
     """Create a branch pointing to the given target."""
     commit = repository.revparse_single(target)
-    repository.branches.create(branch, commit, force=force)
+    return repository.branches.create(branch, commit, force=force)
 
 
 def updatebranch(repository: pygit2.Repository, branch: str, *, target: str) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -105,11 +105,7 @@ def createbranch(
     force: bool = False,
 ) -> None:
     """Create a branch pointing to the given target."""
-    commit = (
-        repository.branches[target].peel()
-        if target != "HEAD"
-        else repository.head.peel()
-    )
+    commit = repository.revparse_single(target)
     repository.branches.create(branch, commit, force=force)
 
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -98,10 +98,18 @@ def cherrypick(repository: pygit2.Repository, reference: str, *, message: str) -
 
 
 def createbranch(
-    repository: pygit2.Repository, branch: str, *, target: str, force: bool = False
+    repository: pygit2.Repository,
+    branch: str,
+    *,
+    target: str = "HEAD",
+    force: bool = False,
 ) -> None:
-    """Create a branch pointing to the given target, another branch."""
-    commit = repository.branches[target].peel()
+    """Create a branch pointing to the given target."""
+    commit = (
+        repository.branches[target].peel()
+        if target != "HEAD"
+        else repository.head.peel()
+    )
     repository.branches.create(branch, commit, force=force)
 
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -47,6 +47,21 @@ def test_createbranch_target_branch(
     assert branch1.peel() == branch2.peel()
 
 
+def test_createbranch_target_oid(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
+    """It creates the branch at the commit with the given OID."""
+    main = repository.head
+    oid = main.peel().id
+
+    commit(repositorypath)
+
+    createbranch_(repository, "branch", target=str(oid))
+    branch = repository.branches["branch"]
+
+    assert oid == branch.peel().id
+
+
 def createbranches(
     repository: pygit2.Repository, *names: str
 ) -> tuple[pygit2.Branch, ...]:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -62,6 +62,14 @@ def test_createbranch_target_oid(
     assert oid == branch.peel().id
 
 
+def test_createbranch_returns_branch(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
+    """It returns the branch object."""
+    branch = createbranch_(repository, "branch")
+    assert branch == repository.branches["branch"]
+
+
 def createbranches(
     repository: pygit2.Repository, *names: str
 ) -> tuple[pygit2.Branch, ...]:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -9,6 +9,7 @@ from cutty.util.git import cherrypick
 from cutty.util.git import createbranch as createbranch_
 from cutty.util.git import createworktree
 from cutty.util.git import resetmerge
+from tests.util.git import commit
 from tests.util.git import removefile
 from tests.util.git import updatefile
 from tests.util.git import updatefiles
@@ -27,6 +28,23 @@ def test_createbranch_target_default(repository: pygit2.Repository) -> None:
 def createbranch(repository: pygit2.Repository, name: str) -> pygit2.Branch:
     """Create a branch at HEAD."""
     return repository.branches.create(name, repository.head.peel())
+
+
+def test_createbranch_target_branch(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
+    """It creates the branch at the head of the given branch."""
+    main = repository.head
+    branch1 = createbranch(repository, "branch1")
+
+    repository.checkout(branch1)
+    commit(repositorypath)
+
+    repository.checkout(main)
+    createbranch_(repository, "branch2", target="branch1")
+    branch2 = repository.branches["branch2"]
+
+    assert branch1.peel() == branch2.peel()
 
 
 def createbranches(

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -6,6 +6,7 @@ import pygit2
 import pytest
 
 from cutty.util.git import cherrypick
+from cutty.util.git import createbranch as createbranch_
 from cutty.util.git import createworktree
 from cutty.util.git import resetmerge
 from tests.util.git import removefile
@@ -14,6 +15,13 @@ from tests.util.git import updatefiles
 
 
 pytest_plugins = ["tests.fixtures.git"]
+
+
+def test_createbranch_target_default(repository: pygit2.Repository) -> None:
+    """It creates the branch at HEAD by default."""
+    createbranch_(repository, "branch")
+
+    assert repository.branches["branch"].peel() == repository.head.peel()
 
 
 def createbranch(repository: pygit2.Repository, name: str) -> pygit2.Branch:


### PR DESCRIPTION
- :white_check_mark: [util] Add test for createbranch without explicit target
- :sparkles: [util] Create branch at HEAD by default
- :white_check_mark: [util] Add test for createbranch with branch target
- :white_check_mark: [util] Add test for `createbranch` with OID
- :sparkles: [util] Support refs and oids in `createbranch`
- :white_check_mark: [util] Add test that `createbranch` returns the branch object
- :sparkles: [util] Return branch object from `createbranch`
