### PR TITLE
:recycle: [tests] Use `git.util.createbranch` in tests

### DIFF
--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -20,19 +20,11 @@ from tests.util.git import updatefile
 pytest_plugins = ["tests.fixtures.git"]
 
 
-def cuttybranches(
-    repository: pygit2.Repository,
-) -> tuple[pygit2.Reference, pygit2.Reference, pygit2.Reference]:
-    """Return the current, the `cutty/latest`, and the `cutty/update` branches."""
-    main = repository.head
-    update, latest = createbranches(repository, UPDATE_BRANCH, LATEST_BRANCH)
-    return main, update, latest
-
-
 def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:
     """Create an update conflict."""
     repository = pygit2.Repository(repositorypath)
-    main, update, _ = cuttybranches(repository)
+    main = repository.head
+    update, _ = createbranches(repository, UPDATE_BRANCH, LATEST_BRANCH)
 
     repository.checkout(update)
     updatefile(path, theirs)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -10,6 +10,7 @@ from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import skipupdate
 from cutty.util.git import cherrypick
+from cutty.util.git import createbranch
 from tests.util.files import chdir
 from tests.util.git import resolveconflicts
 from tests.util.git import Side
@@ -17,11 +18,6 @@ from tests.util.git import updatefile
 
 
 pytest_plugins = ["tests.fixtures.git"]
-
-
-def createbranch(repository: pygit2.Repository, name: str) -> pygit2.Branch:
-    """Create a branch at HEAD."""
-    return repository.branches.create(name, repository.head.peel())
 
 
 def cuttybranches(

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -10,8 +10,8 @@ from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import skipupdate
 from cutty.util.git import cherrypick
-from cutty.util.git import createbranch
 from tests.util.files import chdir
+from tests.util.git import createbranches
 from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
@@ -25,8 +25,7 @@ def cuttybranches(
 ) -> tuple[pygit2.Reference, pygit2.Reference, pygit2.Reference]:
     """Return the current, the `cutty/latest`, and the `cutty/update` branches."""
     main = repository.head
-    update = createbranch(repository, UPDATE_BRANCH)
-    latest = createbranch(repository, LATEST_BRANCH)
+    update, latest = createbranches(repository, UPDATE_BRANCH, LATEST_BRANCH)
     return main, update, latest
 
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -68,7 +68,7 @@ def test_createbranch_returns_branch(
 def createbranches(
     repository: pygit2.Repository, *names: str
 ) -> tuple[pygit2.Branch, ...]:
-    """Create a branch at HEAD."""
+    """Create branches at HEAD."""
     return tuple(createbranch(repository, name) for name in names)
 
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -10,6 +10,7 @@ from cutty.util.git import createbranch
 from cutty.util.git import createworktree
 from cutty.util.git import resetmerge
 from tests.util.git import commit
+from tests.util.git import createbranches
 from tests.util.git import removefile
 from tests.util.git import updatefile
 from tests.util.git import updatefiles
@@ -63,13 +64,6 @@ def test_createbranch_returns_branch(
     """It returns the branch object."""
     branch = createbranch(repository, "branch")
     assert branch == repository.branches["branch"]
-
-
-def createbranches(
-    repository: pygit2.Repository, *names: str
-) -> tuple[pygit2.Branch, ...]:
-    """Create branches at HEAD."""
-    return tuple(createbranch(repository, name) for name in names)
 
 
 def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -6,7 +6,7 @@ import pygit2
 import pytest
 
 from cutty.util.git import cherrypick
-from cutty.util.git import createbranch as createbranch_
+from cutty.util.git import createbranch
 from cutty.util.git import createworktree
 from cutty.util.git import resetmerge
 from tests.util.git import commit
@@ -20,14 +20,9 @@ pytest_plugins = ["tests.fixtures.git"]
 
 def test_createbranch_target_default(repository: pygit2.Repository) -> None:
     """It creates the branch at HEAD by default."""
-    createbranch_(repository, "branch")
+    createbranch(repository, "branch")
 
     assert repository.branches["branch"].peel() == repository.head.peel()
-
-
-def createbranch(repository: pygit2.Repository, name: str) -> pygit2.Branch:
-    """Create a branch at HEAD."""
-    return repository.branches.create(name, repository.head.peel())
 
 
 def test_createbranch_target_branch(
@@ -41,7 +36,7 @@ def test_createbranch_target_branch(
     commit(repositorypath)
 
     repository.checkout(main)
-    createbranch_(repository, "branch2", target="branch1")
+    createbranch(repository, "branch2", target="branch1")
     branch2 = repository.branches["branch2"]
 
     assert branch1.peel() == branch2.peel()
@@ -56,7 +51,7 @@ def test_createbranch_target_oid(
 
     commit(repositorypath)
 
-    createbranch_(repository, "branch", target=str(oid))
+    createbranch(repository, "branch", target=str(oid))
     branch = repository.branches["branch"]
 
     assert oid == branch.peel().id
@@ -66,7 +61,7 @@ def test_createbranch_returns_branch(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It returns the branch object."""
-    branch = createbranch_(repository, "branch")
+    branch = createbranch(repository, "branch")
     assert branch == repository.branches["branch"]
 
 

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -6,6 +6,14 @@ from textwrap import dedent
 import pygit2
 
 from cutty.util.git import commit as _commit
+from cutty.util.git import createbranch
+
+
+def createbranches(
+    repository: pygit2.Repository, *names: str
+) -> tuple[pygit2.Branch, ...]:
+    """Create branches at HEAD."""
+    return tuple(createbranch(repository, name) for name in names)
 
 
 def commit(repositorypath: Path, *, message: str = "") -> None:


### PR DESCRIPTION
- :recycle: [util] Replace `createbranch` in test module by `util.git.createbranch`
- :bulb: [util] Fix docstring
- :recycle: [services] Replace `createbranch` in test module with `util.git.createbranch`
- :recycle: [util] Move `createbranches` to `tests.util.git`
- :recycle: [services] Replace inline code in test with `createbranches`
- :recycle: [services] Inline function in test
