### PR TITLE
:recycle: [util] Use an empty message by default in `commit`

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -25,7 +25,7 @@ def default_signature(repository: pygit2.Repository) -> pygit2.Signature:
 def commit(
     repository: pygit2.Repository,
     *,
-    message: str,
+    message: str = "",
     signature: Optional[pygit2.Signature] = None,
 ) -> None:
     """Commit all changes in the repository.

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -19,6 +19,16 @@ from tests.util.git import updatefiles
 pytest_plugins = ["tests.fixtures.git"]
 
 
+def test_commit_on_unborn_branch(tmp_path: Path) -> None:
+    """It creates a commit without parents."""
+    from cutty.util.git import commit as commit_
+
+    repository = pygit2.init_repository(tmp_path / "repository")
+    commit_(repository, message="initial")
+
+    assert not repository.head.peel().parents
+
+
 def test_createbranch_target_default(repository: pygit2.Repository) -> None:
     """It creates the branch at HEAD by default."""
     createbranch(repository, "branch")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -53,6 +53,20 @@ def test_commit_signature(repository: pygit2.Repository, repositorypath: Path) -
     assert signature.name == head.author.name and signature.email == head.author.email
 
 
+def test_commit_message_default(
+    repository: pygit2.Repository, repositorypath: Path
+) -> None:
+    """It uses an empty message by default."""
+    from cutty.util.git import commit as commit_
+
+    (repositorypath / "a").touch()
+
+    commit_(repository)
+
+    head = repository.head.peel()
+    assert "" == head.message
+
+
 def test_createbranch_target_default(repository: pygit2.Repository) -> None:
     """It creates the branch at HEAD by default."""
     createbranch(repository, "branch")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -29,6 +29,19 @@ def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     assert not repository.head.peel().parents
 
 
+def test_commit_signature(repository: pygit2.Repository, repositorypath: Path) -> None:
+    """It uses the provided signature."""
+    from cutty.util.git import commit as commit_
+
+    (repositorypath / "a").touch()
+
+    signature = pygit2.Signature("Katherine", "katherine@example.com")
+    commit_(repository, message="empty", signature=signature)
+
+    head = repository.head.peel()
+    assert signature.name == head.author.name and signature.email == head.author.email
+
+
 def test_createbranch_target_default(repository: pygit2.Repository) -> None:
     """It creates the branch at HEAD by default."""
     createbranch(repository, "branch")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -29,6 +29,17 @@ def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     assert not repository.head.peel().parents
 
 
+def test_commit_empty(repository: pygit2.Repository) -> None:
+    """It does not produce an empty commit (unless the branch is unborn)."""
+    from cutty.util.git import commit as commit_
+
+    head = repository.head.peel()
+
+    commit_(repository, message="empty")
+
+    assert head == repository.head.peel()
+
+
 def test_commit_signature(repository: pygit2.Repository, repositorypath: Path) -> None:
     """It uses the provided signature."""
     from cutty.util.git import commit as commit_

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -6,6 +6,7 @@ import pygit2
 import pytest
 
 from cutty.util.git import cherrypick
+from cutty.util.git import commit as commit_
 from cutty.util.git import createbranch
 from cutty.util.git import createworktree
 from cutty.util.git import resetmerge
@@ -21,8 +22,6 @@ pytest_plugins = ["tests.fixtures.git"]
 
 def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     """It creates a commit without parents."""
-    from cutty.util.git import commit as commit_
-
     repository = pygit2.init_repository(tmp_path / "repository")
     commit_(repository, message="initial")
 
@@ -31,8 +30,6 @@ def test_commit_on_unborn_branch(tmp_path: Path) -> None:
 
 def test_commit_empty(repository: pygit2.Repository) -> None:
     """It does not produce an empty commit (unless the branch is unborn)."""
-    from cutty.util.git import commit as commit_
-
     head = repository.head.peel()
 
     commit_(repository, message="empty")
@@ -42,8 +39,6 @@ def test_commit_empty(repository: pygit2.Repository) -> None:
 
 def test_commit_signature(repository: pygit2.Repository, repositorypath: Path) -> None:
     """It uses the provided signature."""
-    from cutty.util.git import commit as commit_
-
     (repositorypath / "a").touch()
 
     signature = pygit2.Signature("Katherine", "katherine@example.com")
@@ -57,8 +52,6 @@ def test_commit_message_default(
     repository: pygit2.Repository, repositorypath: Path
 ) -> None:
     """It uses an empty message by default."""
-    from cutty.util.git import commit as commit_
-
     (repositorypath / "a").touch()
 
     commit_(repository)


### PR DESCRIPTION
- :white_check_mark: [util] Add test for `commit` on unborn branch
- :white_check_mark: [util] Add test for `git` with explicit signature
- :white_check_mark: [util] Add test for empty commits
- :white_check_mark: [util] Add test for `commit` without message
- :sparkles: [util] Use an empty message by default when committing
- :recycle: [util] Move import to module level in test
