### PR TITLE
:recycle: [util] Pass `pygit2.Repository` to git test utilities instead of `Path`

### DIFF
--- a/tests/fixtures/git.py
+++ b/tests/fixtures/git.py
@@ -6,15 +6,15 @@ from pathlib import Path
 import pygit2
 import pytest
 
-from tests.util.git import commit
+from cutty.util.git import commit
 
 
 @pytest.fixture
 def repositorypath(tmp_path: Path) -> Path:
     """Fixture for a repository."""
     repositorypath = tmp_path / "repository"
-    pygit2.init_repository(repositorypath)
-    commit(repositorypath)
+    repository = pygit2.init_repository(repositorypath)
+    commit(repository)
     return repositorypath
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -11,7 +11,7 @@ import pytest
 from click.testing import CliRunner
 
 from cutty.entrypoints.cli import main
-from tests.util.git import commit
+from cutty.util.git import commit
 
 
 @pytest.fixture
@@ -84,6 +84,6 @@ def template_directory(tmp_path: Path) -> Path:
 @pytest.fixture
 def template(template_directory: Path) -> Path:
     """Fixture for a template repository."""
-    pygit2.init_repository(template_directory)
-    commit(template_directory, message="Initial")
+    repository = pygit2.init_repository(template_directory)
+    commit(repository, message="Initial")
     return template_directory

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -14,7 +14,7 @@ from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
-from tests.util.git import commit
+from cutty.util.git import commit
 
 
 @pytest.fixture
@@ -111,7 +111,7 @@ def test_existing_repository(
 ) -> None:
     """It creates the commit in an existing repository."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
 
     with storage:
         storage.add(file)
@@ -145,7 +145,7 @@ def test_existing_branch(
 ) -> None:
     """It updates the `update` branch if it exists."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
 
@@ -160,7 +160,7 @@ def test_existing_branch_not_head(
 ) -> None:
     """It raises an exception if `update` exists but HEAD points elsewhere."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
 
     with pytest.raises(Exception):
@@ -175,7 +175,7 @@ def test_existing_branch_commit_message(
 ) -> None:
     """It uses a different commit message on updates."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
@@ -192,7 +192,7 @@ def test_existing_branch_no_changes(
 ) -> None:
     """It does not create an empty commit."""
     repository = pygit2.init_repository(project)
-    commit(project)
+    commit(repository)
 
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -20,9 +20,10 @@ from tests.util.git import updatefile
 pytest_plugins = ["tests.fixtures.git"]
 
 
-def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:
+def createconflict(
+    repository: pygit2.Repository, path: Path, *, ours: str, theirs: str
+) -> None:
     """Create an update conflict."""
-    repository = pygit2.Repository(repositorypath)
     main = repository.head
     update, _ = createbranches(repository, UPDATE_BRANCH, LATEST_BRANCH)
 
@@ -40,7 +41,7 @@ def test_continueupdate_commits_changes(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It commits the changes."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -54,7 +55,7 @@ def test_continueupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It updates the latest branch to the tip of the update branch."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
@@ -68,7 +69,7 @@ def test_skipupdate_fastforwards_latest(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
 
     updatehead = repository.branches[UPDATE_BRANCH].peel()
 
@@ -82,7 +83,7 @@ def test_abortupdate_rewinds_update_branch(
     repository: pygit2.Repository, repositorypath: Path, path: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
 
     branches = repository.branches
     latesthead = branches[LATEST_BRANCH].peel()

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -107,9 +107,10 @@ def test_createbranch_returns_branch(
     assert branch == repository.branches["branch"]
 
 
-def createconflict(repositorypath: Path, path: Path, *, ours: str, theirs: str) -> None:
+def createconflict(
+    repository: pygit2.Repository, path: Path, *, ours: str, theirs: str
+) -> None:
     """Create an update conflict."""
-    repository = pygit2.Repository(repositorypath)
     main = repository.head
     update, _ = createbranches(repository, "update", "latest")
 
@@ -211,10 +212,10 @@ def test_cherrypick_conflict_deletion(
 
 
 def test_resetmerge_restores_files_with_conflicts(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
+    repository: pygit2.Repository, path: Path
 ) -> None:
     """It restores the conflicting files in the working tree to our version."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
     resetmerge(repository, parent="latest", cherry="update")
 
     assert path.read_text() == "a"
@@ -316,11 +317,9 @@ def test_resetmerge_keeps_unrelated_deletions(
     assert not path2.exists()
 
 
-def test_resetmerge_resets_index(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
-) -> None:
+def test_resetmerge_resets_index(repository: pygit2.Repository, path: Path) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    createconflict(repositorypath, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
 
     resetmerge(repository, parent="latest", cherry="update")
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -6,11 +6,10 @@ import pygit2
 import pytest
 
 from cutty.util.git import cherrypick
-from cutty.util.git import commit as commit_
+from cutty.util.git import commit
 from cutty.util.git import createbranch
 from cutty.util.git import createworktree
 from cutty.util.git import resetmerge
-from tests.util.git import commit
 from tests.util.git import createbranches
 from tests.util.git import removefile
 from tests.util.git import updatefile
@@ -23,7 +22,7 @@ pytest_plugins = ["tests.fixtures.git"]
 def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     """It creates a commit without parents."""
     repository = pygit2.init_repository(tmp_path / "repository")
-    commit_(repository, message="initial")
+    commit(repository, message="initial")
 
     assert not repository.head.peel().parents
 
@@ -32,7 +31,7 @@ def test_commit_empty(repository: pygit2.Repository) -> None:
     """It does not produce an empty commit (unless the branch is unborn)."""
     head = repository.head.peel()
 
-    commit_(repository, message="empty")
+    commit(repository, message="empty")
 
     assert head == repository.head.peel()
 
@@ -42,7 +41,7 @@ def test_commit_signature(repository: pygit2.Repository, repositorypath: Path) -
     (repositorypath / "a").touch()
 
     signature = pygit2.Signature("Katherine", "katherine@example.com")
-    commit_(repository, message="empty", signature=signature)
+    commit(repository, message="empty", signature=signature)
 
     head = repository.head.peel()
     assert signature.name == head.author.name and signature.email == head.author.email
@@ -54,7 +53,7 @@ def test_commit_message_default(
     """It uses an empty message by default."""
     (repositorypath / "a").touch()
 
-    commit_(repository)
+    commit(repository)
 
     head = repository.head.peel()
     assert "" == head.message
@@ -67,15 +66,13 @@ def test_createbranch_target_default(repository: pygit2.Repository) -> None:
     assert repository.branches["branch"].peel() == repository.head.peel()
 
 
-def test_createbranch_target_branch(
-    repository: pygit2.Repository, repositorypath: Path
-) -> None:
+def test_createbranch_target_branch(repository: pygit2.Repository) -> None:
     """It creates the branch at the head of the given branch."""
     main = repository.head
     branch1 = createbranch(repository, "branch1")
 
     repository.checkout(branch1)
-    commit(repositorypath)
+    commit(repository)
 
     repository.checkout(main)
     createbranch(repository, "branch2", target="branch1")
@@ -84,14 +81,12 @@ def test_createbranch_target_branch(
     assert branch1.peel() == branch2.peel()
 
 
-def test_createbranch_target_oid(
-    repository: pygit2.Repository, repositorypath: Path
-) -> None:
+def test_createbranch_target_oid(repository: pygit2.Repository) -> None:
     """It creates the branch at the commit with the given OID."""
     main = repository.head
     oid = main.peel().id
 
-    commit(repositorypath)
+    commit(repository)
 
     createbranch(repository, "branch", target=str(oid))
     branch = repository.branches["branch"]
@@ -99,9 +94,7 @@ def test_createbranch_target_oid(
     assert oid == branch.peel().id
 
 
-def test_createbranch_returns_branch(
-    repository: pygit2.Repository, repositorypath: Path
-) -> None:
+def test_createbranch_returns_branch(repository: pygit2.Repository) -> None:
     """It returns the branch object."""
     branch = createbranch(repository, "branch")
     assert branch == repository.branches["branch"]

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 
 import pygit2
 
-from cutty.util.git import commit as _commit
+from cutty.util.git import commit
 from cutty.util.git import createbranch
 
 
@@ -16,12 +16,6 @@ def createbranches(
     return tuple(createbranch(repository, name) for name in names)
 
 
-def commit(repositorypath: Path, *, message: str = "") -> None:
-    """Commit all changes in the repository."""
-    repository = pygit2.Repository(repositorypath)
-    _commit(repository, message=message)
-
-
 def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) -> None:
     """Move all files in the repository to the given subdirectory."""
     repository = pygit2.Repository(repositorypath)
@@ -30,7 +24,7 @@ def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) 
     tree = repository[builder.write()]
     repository.checkout_tree(tree)
 
-    commit(repositorypath, message=f"Move files to subdirectory {directory}")
+    commit(repository, message=f"Move files to subdirectory {directory}")
 
 
 def discoverrepository(path: Path) -> Path:
@@ -49,7 +43,7 @@ def updatefile(path: Path, text: str = "") -> None:
 
     path.write_text(dedent(text).lstrip())
 
-    commit(repository, message=f"{verb} {path.name}")
+    commit(pygit2.Repository(repository), message=f"{verb} {path.name}")
 
 
 def updatefiles(paths: dict[Path, str]) -> None:
@@ -65,7 +59,7 @@ def updatefiles(paths: dict[Path, str]) -> None:
         path.write_text(dedent(text).lstrip())
 
     pathlist = " and ".join(path.name for path in paths)
-    commit(repository, message=f"{verb} {pathlist}")
+    commit(pygit2.Repository(repository), message=f"{verb} {pathlist}")
 
 
 def appendfile(path: Path, text: str) -> None:
@@ -79,7 +73,7 @@ def removefile(path: Path) -> None:
 
     path.unlink()
 
-    commit(repository, message=f"Remove {path.name}")
+    commit(pygit2.Repository(repository), message=f"Remove {path.name}")
 
 
 class Side(enum.Enum):

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -19,8 +19,7 @@ def createbranches(
 def commit(repositorypath: Path, *, message: str = "") -> None:
     """Commit all changes in the repository."""
     repository = pygit2.Repository(repositorypath)
-    signature = pygit2.Signature("you", "you@example.com")
-    _commit(repository, message=message, signature=signature)
+    _commit(repository, message=message)
 
 
 def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) -> None:

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -27,12 +27,12 @@ def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) 
     commit(repository, message=f"Move files to subdirectory {directory}")
 
 
-def discoverrepository(path: Path) -> Path:
+def discoverrepository(path: Path) -> pygit2.Repository:
     """Discover a git repository."""
     while path.name and not path.exists():
         path = path.parent
 
-    return Path(pygit2.discover_repository(path))
+    return pygit2.Repository(pygit2.discover_repository(path))
 
 
 def updatefile(path: Path, text: str = "") -> None:
@@ -43,7 +43,7 @@ def updatefile(path: Path, text: str = "") -> None:
 
     path.write_text(dedent(text).lstrip())
 
-    commit(pygit2.Repository(repository), message=f"{verb} {path.name}")
+    commit(repository, message=f"{verb} {path.name}")
 
 
 def updatefiles(paths: dict[Path, str]) -> None:
@@ -59,7 +59,7 @@ def updatefiles(paths: dict[Path, str]) -> None:
         path.write_text(dedent(text).lstrip())
 
     pathlist = " and ".join(path.name for path in paths)
-    commit(pygit2.Repository(repository), message=f"{verb} {pathlist}")
+    commit(repository, message=f"{verb} {pathlist}")
 
 
 def appendfile(path: Path, text: str) -> None:
@@ -73,7 +73,7 @@ def removefile(path: Path) -> None:
 
     path.unlink()
 
-    commit(pygit2.Repository(repository), message=f"Remove {path.name}")
+    commit(repository, message=f"Remove {path.name}")
 
 
 class Side(enum.Enum):


### PR DESCRIPTION
- :recycle: [services] Move statement to callers of `createconflict`
- :recycle: [util] Move statement to callers of `createconflict`
- :recycle: [util] Omit redundant `signature` argument to `commit` in tests
- :recycle: [util] Inline function `tests.util.git.commit`
- :recycle: [util] Move statement into function `discoverrepository`
