### PR TITLE
:recycle: [util] Move factory functions to `git.Repository`

### DIFF
--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -5,7 +5,6 @@ import pygit2
 
 from cutty.filestorage.domain.observers import FileStorageObserver
 from cutty.util.git import commit
-from cutty.util.git import initrepository
 from cutty.util.git import Repository
 
 
@@ -29,7 +28,7 @@ class GitRepositoryObserver(FileStorageObserver):
         try:
             repository = Repository.open(self.project).repository
         except pygit2.GitError:
-            repository = initrepository(self.project)
+            repository = Repository.init(self.project).repository
 
         if UPDATE_BRANCH in repository.branches:
             # HEAD must point to update branch if it exists.

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -6,7 +6,7 @@ import pygit2
 from cutty.filestorage.domain.observers import FileStorageObserver
 from cutty.util.git import commit
 from cutty.util.git import initrepository
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 
 
 LATEST_BRANCH = "cutty/latest"
@@ -27,7 +27,7 @@ class GitRepositoryObserver(FileStorageObserver):
     def commit(self) -> None:
         """A storage transaction was completed."""
         try:
-            repository = openrepository(self.project)
+            repository = Repository.open(self.project).repository
         except pygit2.GitError:
             repository = initrepository(self.project)
 

--- a/src/cutty/filesystems/adapters/git.py
+++ b/src/cutty/filesystems/adapters/git.py
@@ -8,7 +8,7 @@ from cutty.filesystems.domain.filesystem import Access
 from cutty.filesystems.domain.nodefs import FilesystemNode
 from cutty.filesystems.domain.nodefs import NodeFilesystem
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 
 
 class GitFilesystemNode(FilesystemNode):
@@ -76,6 +76,6 @@ class GitFilesystem(NodeFilesystem):
 
     def __init__(self, repository: pathlib.Path, ref: str = "HEAD") -> None:
         """Inititalize."""
-        repo = openrepository(repository)
+        repo = Repository.open(repository).repository
         tree = repo.revparse_single(ref).peel(pygit2.Tree)
         self.root = GitFilesystemNode(tree)

--- a/src/cutty/repositories/adapters/fetchers/git.py
+++ b/src/cutty/repositories/adapters/fetchers/git.py
@@ -9,7 +9,6 @@ from cutty.repositories.domain.fetchers import fetcher
 from cutty.repositories.domain.matchers import scheme
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import defaultstore
-from cutty.util.git import clonerepository
 from cutty.util.git import Repository
 
 
@@ -26,4 +25,4 @@ def gitfetcher(
         for remote in repository.remotes:
             remote.fetch(prune=pygit2.GIT_FETCH_PRUNE)
     else:
-        clonerepository(str(url), destination)
+        Repository.clone(str(url), destination)

--- a/src/cutty/repositories/adapters/fetchers/git.py
+++ b/src/cutty/repositories/adapters/fetchers/git.py
@@ -10,7 +10,7 @@ from cutty.repositories.domain.matchers import scheme
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import defaultstore
 from cutty.util.git import clonerepository
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 
 
 @fetcher(
@@ -22,7 +22,7 @@ def gitfetcher(
 ) -> None:
     """Fetch a git repository."""
     if destination.exists():
-        repository = openrepository(destination)
+        repository = Repository.open(destination).repository
         for remote in repository.remotes:
             remote.fetch(prune=pygit2.GIT_FETCH_PRUNE)
     else:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -15,7 +15,7 @@ from cutty.util.git import cherrypick
 from cutty.util.git import commit
 from cutty.util.git import createbranch
 from cutty.util.git import createworktree
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 from cutty.util.git import resetmerge
 from cutty.util.git import updatebranch
 
@@ -38,7 +38,7 @@ def update(
     if directory is None:
         directory = projectconfig.directory
 
-    repository = openrepository(projectdir)
+    repository = Repository.open(projectdir).repository
     createbranch(repository, UPDATE_BRANCH, target=LATEST_BRANCH, force=True)
 
     with createworktree(repository, UPDATE_BRANCH, checkout=False) as worktree:
@@ -61,7 +61,7 @@ def continueupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
-    repository = openrepository(projectdir)
+    repository = Repository.open(projectdir).repository
     commit(repository, message=UPDATE_MESSAGE)
     updatebranch(repository, LATEST_BRANCH, target=UPDATE_BRANCH)
 
@@ -71,7 +71,7 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
-    repository = openrepository(projectdir)
+    repository = Repository.open(projectdir).repository
     resetmerge(repository, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
     updatebranch(repository, LATEST_BRANCH, target=UPDATE_BRANCH)
 
@@ -81,6 +81,6 @@ def abortupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
-    repository = openrepository(projectdir)
+    repository = Repository.open(projectdir).repository
     resetmerge(repository, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
     updatebranch(repository, UPDATE_BRANCH, target=LATEST_BRANCH)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -24,13 +24,8 @@ class Repository:
     @classmethod
     def open(cls, path: Path) -> Repository:
         """Open an existing repository."""
-        repository = openrepository(path)
+        repository = pygit2.Repository(path)
         return cls(repository)
-
-
-def openrepository(path: Path) -> pygit2.Repository:
-    """Return an existing repository."""
-    return pygit2.Repository(path)
 
 
 def initrepository(path: Path, *, head: Optional[str] = None) -> pygit2.Repository:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -30,13 +30,8 @@ class Repository:
     @classmethod
     def init(cls, path: Path, *, head: Optional[str] = None) -> Repository:
         """Create a repository."""
-        repository = initrepository(path, head=head)
+        repository = pygit2.init_repository(path, initial_head=head)
         return cls(repository)
-
-
-def initrepository(path: Path, *, head: Optional[str] = None) -> pygit2.Repository:
-    """Create a repository."""
-    return pygit2.init_repository(path, initial_head=head)
 
 
 def _fix_repository_head(repository: pygit2.Repository) -> pygit2.Reference:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -1,4 +1,6 @@
 """Git utilities."""
+from __future__ import annotations
+
 import contextlib
 import hashlib
 import os
@@ -18,6 +20,12 @@ class Repository:
     """Git repository."""
 
     repository: pygit2.Repository
+
+    @classmethod
+    def open(cls, path: Path) -> Repository:
+        """Open an existing repository."""
+        repository = openrepository(path)
+        return cls(repository)
 
 
 def openrepository(path: Path) -> pygit2.Repository:
@@ -125,7 +133,7 @@ def createworktree(
         if not checkout:
             # Emulate `--no-checkout` by checking out an empty tree after the fact.
             # https://github.com/libgit2/libgit2/issues/5949
-            worktreerepository = openrepository(path)
+            worktreerepository = Repository.open(path).repository
             checkoutemptytree(worktreerepository)
 
         yield path

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -4,12 +4,20 @@ import hashlib
 import os
 import tempfile
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 import pygit2
 
 from cutty.compat.contextlib import contextmanager
+
+
+@dataclass
+class Repository:
+    """Git repository."""
+
+    repository: pygit2.Repository
 
 
 def openrepository(path: Path) -> pygit2.Repository:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -28,6 +28,14 @@ class Repository:
         return cls(repository)
 
     @classmethod
+    def discover(cls, path: Path) -> Optional[Repository]:
+        """Discover an existing repository."""
+        repositorypath = pygit2.discover_repository(path)
+        if repositorypath is None:
+            return None
+        return cls.open(Path(repositorypath))
+
+    @classmethod
     def init(cls, path: Path, *, head: Optional[str] = None) -> Repository:
         """Create a repository."""
         repository = pygit2.init_repository(path, initial_head=head)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -33,6 +33,11 @@ class Repository:
         repository = pygit2.init_repository(path, initial_head=head)
         return cls(repository)
 
+    @classmethod
+    def clone(cls, url: str, destination: Path) -> None:
+        """Clone a repository using a mirror configuration."""
+        clonerepository(url, destination)
+
 
 def _fix_repository_head(repository: pygit2.Repository) -> pygit2.Reference:
     """Work around a bug in libgit2 resulting in a bogus HEAD reference.

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -27,6 +27,12 @@ class Repository:
         repository = pygit2.Repository(path)
         return cls(repository)
 
+    @classmethod
+    def init(cls, path: Path, *, head: Optional[str] = None) -> Repository:
+        """Create a repository."""
+        repository = initrepository(path, head=head)
+        return cls(repository)
+
 
 def initrepository(path: Path, *, head: Optional[str] = None) -> pygit2.Repository:
     """Create a repository."""

--- a/tests/fixtures/git.py
+++ b/tests/fixtures/git.py
@@ -8,7 +8,7 @@ import pytest
 
 from cutty.util.git import commit
 from cutty.util.git import initrepository
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 
 
 @pytest.fixture
@@ -23,7 +23,7 @@ def repositorypath(tmp_path: Path) -> Path:
 @pytest.fixture
 def repository(repositorypath: Path) -> pygit2.Repository:
     """Fixture for a repository."""
-    return openrepository(repositorypath)
+    return Repository.open(repositorypath).repository
 
 
 @pytest.fixture

--- a/tests/fixtures/git.py
+++ b/tests/fixtures/git.py
@@ -7,7 +7,6 @@ import pygit2
 import pytest
 
 from cutty.util.git import commit
-from cutty.util.git import initrepository
 from cutty.util.git import Repository
 
 
@@ -15,7 +14,7 @@ from cutty.util.git import Repository
 def repositorypath(tmp_path: Path) -> Path:
     """Fixture for a repository."""
     repositorypath = tmp_path / "repository"
-    repository = initrepository(repositorypath)
+    repository = Repository.init(repositorypath).repository
     commit(repository)
     return repositorypath
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 
 from cutty.entrypoints.cli import main
 from cutty.util.git import commit
-from cutty.util.git import initrepository
+from cutty.util.git import Repository
 
 
 @pytest.fixture
@@ -84,6 +84,6 @@ def template_directory(tmp_path: Path) -> Path:
 @pytest.fixture
 def template(template_directory: Path) -> Path:
     """Fixture for a template repository."""
-    repository = initrepository(template_directory)
+    repository = Repository.init(template_directory).repository
     commit(repository, message="Initial")
     return template_directory

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
 from tests.util.files import project_files
 from tests.util.files import template_files
@@ -70,7 +70,7 @@ def test_extra_context_invalid(runcutty: RunCutty, template: Path) -> None:
 
 def test_checkout(runcutty: RunCutty, template: Path) -> None:
     """It uses the specified revision of the template."""
-    initial = openrepository(template).head.target
+    initial = Repository.open(template).repository.head.target
 
     updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
 from tests.util.files import chdir
 from tests.util.git import appendfile
@@ -104,12 +104,12 @@ def test_remove(runcutty: RunCutty, templateproject: Path, project: Path) -> Non
 
 def test_noop(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does nothing if the generated project did not change."""
-    oldhead = openrepository(project).head.target
+    oldhead = Repository.open(project).repository.head.target
 
     with chdir(project):
         runcutty("update")
 
-    assert oldhead == openrepository(project).head.target
+    assert oldhead == Repository.open(project).repository.head.target
 
 
 def test_new_variables(runcutty: RunCutty, template: Path, project: Path) -> None:
@@ -288,7 +288,7 @@ def test_checkout(
     """It uses the specified revision of the template."""
     updatefile(templateproject / "LICENSE", "a")
 
-    revision = openrepository(template).head.target
+    revision = Repository.open(template).repository.head.target
 
     updatefile(templateproject / "LICENSE", "b")
 

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -16,7 +16,7 @@ from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.util.git import commit
 from cutty.util.git import initrepository
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 
 
 @pytest.fixture
@@ -47,7 +47,7 @@ def test_repository(
     with storage:
         storage.add(file)
 
-    openrepository(project)  # does not raise
+    Repository.open(project).repository  # does not raise
 
 
 def test_commit(storage: FileStorage, file: RegularFile, project: pathlib.Path) -> None:
@@ -55,7 +55,7 @@ def test_commit(storage: FileStorage, file: RegularFile, project: pathlib.Path) 
     with storage:
         storage.add(file)
 
-    repository = openrepository(project)
+    repository = Repository.open(project).repository
     repository.head  # does not raise
 
 
@@ -64,7 +64,7 @@ def test_index(storage: FileStorage, file: RegularFile, project: pathlib.Path) -
     with storage:
         storage.add(file)
 
-    repository = openrepository(project)
+    repository = Repository.open(project).repository
     assert file.path.name in repository.index
 
 
@@ -81,7 +81,7 @@ def test_hook_edits(
         storage.add(file)
         (project / file.path.name).write_bytes(b"teapot")
 
-    repository = openrepository(project)
+    repository = Repository.open(project).repository
     blob = tree(repository) / file.path.name
     assert b"teapot" == blob.data
 
@@ -94,7 +94,7 @@ def test_hook_deletes(
         storage.add(file)
         (project / file.path.name).unlink()
 
-    repository = openrepository(project)
+    repository = Repository.open(project).repository
     assert file.path.name not in tree(repository)
 
 
@@ -104,7 +104,7 @@ def test_hook_additions(storage: FileStorage, project: pathlib.Path) -> None:
         project.mkdir()
         (project / "marker").touch()
 
-    repository = openrepository(project)
+    repository = Repository.open(project).repository
     assert "marker" in tree(repository)
 
 
@@ -126,7 +126,7 @@ def test_branch(storage: FileStorage, file: RegularFile, project: pathlib.Path) 
     with storage:
         storage.add(file)
 
-    repository = openrepository(project)
+    repository = Repository.open(project).repository
     reference = repository.references[LATEST_BRANCH_REF]
     assert repository.head.peel() == reference.peel()
 
@@ -138,7 +138,7 @@ def test_branch_not_checked_out(
     with storage:
         storage.add(file)
 
-    repository = openrepository(project)
+    repository = Repository.open(project).repository
     assert repository.references["HEAD"].target != LATEST_BRANCH_REF
 
 

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -15,7 +15,6 @@ from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.util.git import commit
-from cutty.util.git import initrepository
 from cutty.util.git import Repository
 
 
@@ -112,7 +111,7 @@ def test_existing_repository(
     storage: FileStorage, file: RegularFile, project: pathlib.Path
 ) -> None:
     """It creates the commit in an existing repository."""
-    repository = initrepository(project)
+    repository = Repository.init(project).repository
     commit(repository)
 
     with storage:
@@ -146,7 +145,7 @@ def test_existing_branch(
     storage: FileStorage, file: RegularFile, project: pathlib.Path
 ) -> None:
     """It updates the `update` branch if it exists."""
-    repository = initrepository(project)
+    repository = Repository.init(project).repository
     commit(repository)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
@@ -161,7 +160,7 @@ def test_existing_branch_not_head(
     storage: FileStorage, file: RegularFile, project: pathlib.Path
 ) -> None:
     """It raises an exception if `update` exists but HEAD points elsewhere."""
-    repository = initrepository(project)
+    repository = Repository.init(project).repository
     commit(repository)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
 
@@ -176,7 +175,7 @@ def test_existing_branch_commit_message(
     storage: FileStorage, file: RegularFile, project: pathlib.Path
 ) -> None:
     """It uses a different commit message on updates."""
-    repository = initrepository(project)
+    repository = Repository.init(project).repository
     commit(repository)
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
@@ -193,7 +192,7 @@ def test_existing_branch_no_changes(
     storage: FileStorage, project: pathlib.Path
 ) -> None:
     """It does not create an empty commit."""
-    repository = initrepository(project)
+    repository = Repository.init(project).repository
     commit(repository)
 
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())

--- a/tests/unit/filesystems/adapters/test_git.py
+++ b/tests/unit/filesystems/adapters/test_git.py
@@ -7,7 +7,7 @@ import pytest
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.filesystems.domain.filesystem import Access
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.util.git import initrepository
+from cutty.util.git import Repository
 
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def filesystem(tmp_path: Path) -> GitFilesystem:
         builder.insert(name, tree.write(), pygit2.GIT_FILEMODE_TREE)
 
     signature = pygit2.Signature("you", "you@example.com")
-    repository = initrepository(tmp_path)
+    repository = Repository.init(tmp_path).repository
 
     root = repository.TreeBuilder()
     root_dir = repository.TreeBuilder()

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -15,7 +15,7 @@ from cutty.repositories.domain.locations import aspath
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.stores import Store
 from cutty.util.git import initrepository
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 
 
 signature = pygit2.Signature("you", "you@example.com")
@@ -64,7 +64,7 @@ def test_gitfetcher_update(url: URL, store: Store) -> None:
     gitfetcher(url, store, None, FetchMode.ALWAYS)
 
     # Remove the marker file.
-    repository = openrepository(aspath(url))
+    repository = Repository.open(aspath(url)).repository
     tree = repository.head.peel(pygit2.Tree)
     repository.index.read_tree(tree)
     repository.index.remove("marker")
@@ -125,7 +125,7 @@ def test_broken_head_after_clone(
     """It works around a bug in libgit2 resulting in a broken HEAD reference."""
     destination = gitfetcher(url, store, None, FetchMode.ALWAYS)
     assert destination is not None
-    repository = openrepository(destination)
+    repository = Repository.open(destination).repository
     head = repository.references["HEAD"]
     assert head.target != f"refs/heads/{custom_default_branch}"
 

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -14,7 +14,6 @@ from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import aspath
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.stores import Store
-from cutty.util.git import initrepository
 from cutty.util.git import Repository
 
 
@@ -28,7 +27,7 @@ def url(tmp_path: pathlib.Path) -> URL:
     path.mkdir()
     (path / "marker").write_text("Lorem")
 
-    repository = initrepository(path)
+    repository = Repository.init(path).repository
     repository.index.add("marker")
     repository.create_commit(
         "HEAD",
@@ -137,7 +136,7 @@ def test_broken_head_after_clone_unexpected_branch(
     path = tmp_path / "repository"
     path.mkdir()
 
-    repository = initrepository(path, head="refs/heads/whoops")
+    repository = Repository.init(path, head="refs/heads/whoops").repository
     repository.create_commit(
         "HEAD",
         signature,

--- a/tests/unit/repositories/adapters/providers/test_git.py
+++ b/tests/unit/repositories/adapters/providers/test_git.py
@@ -12,7 +12,7 @@ from cutty.repositories.adapters.providers.git import localgitprovider
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.stores import Store
-from cutty.util.git import initrepository
+from cutty.util.git import Repository
 
 
 signature = pygit2.Signature("you", "you@example.com")
@@ -25,7 +25,7 @@ def url(tmp_path: pathlib.Path) -> URL:
     path.mkdir()
     (path / "marker").write_text("Lorem")
 
-    repository = initrepository(path)
+    repository = Repository.init(path).repository
     repository.index.add("marker")
     repository.create_commit(
         "HEAD",

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -9,7 +9,7 @@ from cutty.util.git import cherrypick
 from cutty.util.git import commit
 from cutty.util.git import createbranch
 from cutty.util.git import createworktree
-from cutty.util.git import initrepository
+from cutty.util.git import Repository
 from cutty.util.git import resetmerge
 from tests.util.git import createbranches
 from tests.util.git import removefile
@@ -22,7 +22,7 @@ pytest_plugins = ["tests.fixtures.git"]
 
 def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     """It creates a commit without parents."""
-    repository = initrepository(tmp_path / "repository")
+    repository = Repository.init(tmp_path / "repository").repository
     commit(repository, message="initial")
 
     assert not repository.head.peel().parents

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -20,6 +20,11 @@ from tests.util.git import updatefiles
 pytest_plugins = ["tests.fixtures.git"]
 
 
+def test_discover_fail(tmp_path: Path) -> None:
+    """It returns None."""
+    assert None is Repository.discover(tmp_path)
+
+
 def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     """It creates a commit without parents."""
     repository = Repository.init(tmp_path / "repository").repository

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -33,9 +33,9 @@ def discoverrepository(path: Path) -> pygit2.Repository:
     while path.name and not path.exists():
         path = path.parent
 
-    repositorypath = pygit2.discover_repository(path)
-    assert repositorypath is not None
-    return Repository.open(Path(repositorypath)).repository
+    repository = Repository.discover(path)
+    assert repository is not None
+    return repository.repository
 
 
 def updatefile(path: Path, text: str = "") -> None:

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -28,8 +28,8 @@ def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) 
     commit(repository, message=f"Move files to subdirectory {directory}")
 
 
-def discoverrepository(path: Path) -> pygit2.Repository:
-    """Discover a git repository."""
+def locaterepository(path: Path) -> pygit2.Repository:
+    """Locate the git repository containing the given path."""
     while path.name and not path.exists():
         path = path.parent
 
@@ -40,7 +40,7 @@ def discoverrepository(path: Path) -> pygit2.Repository:
 
 def updatefile(path: Path, text: str = "") -> None:
     """Add or update a repository file."""
-    repository = discoverrepository(path)
+    repository = locaterepository(path)
 
     verb = "Update" if path.exists() else "Add"
 
@@ -54,7 +54,7 @@ def updatefiles(paths: dict[Path, str]) -> None:
     verb = "Add"
 
     for path, text in paths.items():
-        repository = discoverrepository(path)
+        repository = locaterepository(path)
 
         if path.exists():
             verb = "Update"
@@ -72,7 +72,7 @@ def appendfile(path: Path, text: str) -> None:
 
 def removefile(path: Path) -> None:
     """Remove a repository file."""
-    repository = discoverrepository(path)
+    repository = locaterepository(path)
 
     path.unlink()
 

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -7,7 +7,7 @@ import pygit2
 
 from cutty.util.git import commit
 from cutty.util.git import createbranch
-from cutty.util.git import openrepository
+from cutty.util.git import Repository
 
 
 def createbranches(
@@ -19,7 +19,7 @@ def createbranches(
 
 def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) -> None:
     """Move all files in the repository to the given subdirectory."""
-    repository = openrepository(repositorypath)
+    repository = Repository.open(repositorypath).repository
     builder = repository.TreeBuilder()
     builder.insert(directory, repository.head.peel().tree.id, pygit2.GIT_FILEMODE_TREE)
     tree = repository[builder.write()]
@@ -35,7 +35,7 @@ def discoverrepository(path: Path) -> pygit2.Repository:
 
     repositorypath = pygit2.discover_repository(path)
     assert repositorypath is not None
-    return openrepository(Path(repositorypath))
+    return Repository.open(Path(repositorypath)).repository
 
 
 def updatefile(path: Path, text: str = "") -> None:
@@ -89,7 +89,7 @@ class Side(enum.Enum):
 
 def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
     """Resolve the conflicts."""
-    repository = openrepository(repositorypath)
+    repository = Repository.open(repositorypath).repository
     pathstr = str(path.relative_to(repositorypath))
     ancestor, ours, theirs = repository.index.conflicts[pathstr]
     resolution = (ancestor, ours, theirs)[side.value]


### PR DESCRIPTION
- :recycle: [util] Add `git.Repository`
- :recycle: [util] Encapsulate factory function `git.Repository.open`
- :recycle: [util] Inline function `git.openrepository`
- :recycle: [util] Encapsulate factory function `git.Repository.init`
- :recycle: [util] Inline function `git.initrepository`
- :recycle: [util] Encapsulate factory function `git.Repository.clone`
- :recycle: [util] Inline function `git.clonerepository`
- :recycle: [util] Encapsulate factory function `git.Repository.discover`
- :recycle: [tests] Rename function to `locaterepository`
- :white_check_mark: [util] Add test for `git.Repository.discover`
