### PR TITLE
:recycle: [util] Move function `commit` to `git.Repository`

### DIFF
--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -4,7 +4,6 @@ import pathlib
 import pygit2
 
 from cutty.filestorage.domain.observers import FileStorageObserver
-from cutty.util.git import commit
 from cutty.util.git import Repository
 
 
@@ -42,7 +41,7 @@ class GitRepositoryObserver(FileStorageObserver):
             else UPDATE_MESSAGE
         )
 
-        commit(repository, message=message)
+        Repository(repository).commit(message=message)
 
         if LATEST_BRANCH not in repository.branches:
             repository.branches.create(LATEST_BRANCH, repository.head.peel())

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -12,7 +12,6 @@ from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import cherrypick
-from cutty.util.git import commit
 from cutty.util.git import createbranch
 from cutty.util.git import createworktree
 from cutty.util.git import Repository
@@ -61,9 +60,9 @@ def continueupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
-    repository = Repository.open(projectdir).repository
-    commit(repository, message=UPDATE_MESSAGE)
-    updatebranch(repository, LATEST_BRANCH, target=UPDATE_BRANCH)
+    repository = Repository.open(projectdir)
+    repository.commit(message=UPDATE_MESSAGE)
+    updatebranch(repository.repository, LATEST_BRANCH, target=UPDATE_BRANCH)
 
 
 def skipupdate(*, projectdir: Optional[Path] = None) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -58,6 +58,15 @@ class Repository:
 
         _fix_repository_head(repository)
 
+    def commit(
+        self, *, message: str = "", signature: Optional[pygit2.Signature] = None
+    ) -> None:
+        """Commit all changes in the repository.
+
+        If there are no changes relative to the parent, this is a noop.
+        """
+        return commit(self.repository, message=message, signature=signature)
+
 
 def _fix_repository_head(repository: pygit2.Repository) -> pygit2.Reference:
     """Work around a bug in libgit2 resulting in a bogus HEAD reference.
@@ -161,7 +170,7 @@ def cherrypick(repository: pygit2.Repository, reference: str, *, message: str) -
         }
         raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
 
-    commit(repository, message=message)
+    Repository(repository).commit(message=message)
     repository.state_cleanup()
 
 

--- a/tests/fixtures/git.py
+++ b/tests/fixtures/git.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pygit2
 import pytest
 
-from cutty.util.git import commit
 from cutty.util.git import Repository
 
 
@@ -14,8 +13,8 @@ from cutty.util.git import Repository
 def repositorypath(tmp_path: Path) -> Path:
     """Fixture for a repository."""
     repositorypath = tmp_path / "repository"
-    repository = Repository.init(repositorypath).repository
-    commit(repository)
+    repository = Repository.init(repositorypath)
+    repository.commit()
     return repositorypath
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -10,7 +10,6 @@ import pytest
 from click.testing import CliRunner
 
 from cutty.entrypoints.cli import main
-from cutty.util.git import commit
 from cutty.util.git import Repository
 
 
@@ -84,6 +83,6 @@ def template_directory(tmp_path: Path) -> Path:
 @pytest.fixture
 def template(template_directory: Path) -> Path:
     """Fixture for a template repository."""
-    repository = Repository.init(template_directory).repository
-    commit(repository, message="Initial")
+    repository = Repository.init(template_directory)
+    repository.commit(message="Initial")
     return template_directory

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -14,7 +14,6 @@ from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.util.git import commit
 from cutty.util.git import Repository
 
 
@@ -112,7 +111,7 @@ def test_existing_repository(
 ) -> None:
     """It creates the commit in an existing repository."""
     repository = Repository.init(project)
-    commit(repository.repository)
+    repository.commit()
 
     with storage:
         storage.add(file)
@@ -146,8 +145,9 @@ def test_existing_branch(
 ) -> None:
     """It updates the `update` branch if it exists."""
     repository2 = Repository.init(project)
+    repository2.commit()
+
     repository = repository2.repository
-    commit(repository)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
 
@@ -162,8 +162,9 @@ def test_existing_branch_not_head(
 ) -> None:
     """It raises an exception if `update` exists but HEAD points elsewhere."""
     repository2 = Repository.init(project)
+    repository2.commit()
+
     repository = repository2.repository
-    commit(repository)
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
 
     with pytest.raises(Exception):
@@ -177,8 +178,10 @@ def test_existing_branch_commit_message(
     storage: FileStorage, file: RegularFile, project: pathlib.Path
 ) -> None:
     """It uses a different commit message on updates."""
-    repository = Repository.init(project).repository
-    commit(repository)
+    repository2 = Repository.init(project)
+    repository2.commit()
+
+    repository = repository2.repository
     repository.branches.create(LATEST_BRANCH, repository.head.peel())
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
@@ -194,9 +197,10 @@ def test_existing_branch_no_changes(
     storage: FileStorage, project: pathlib.Path
 ) -> None:
     """It does not create an empty commit."""
-    repository = Repository.init(project).repository
-    commit(repository)
+    repository2 = Repository.init(project)
+    repository2.commit()
 
+    repository = repository2.repository
     repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
     oldhead = repository.head.target

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -6,7 +6,6 @@ import pygit2
 import pytest
 
 from cutty.util.git import cherrypick
-from cutty.util.git import commit
 from cutty.util.git import createbranch
 from cutty.util.git import createworktree
 from cutty.util.git import Repository
@@ -27,17 +26,17 @@ def test_discover_fail(tmp_path: Path) -> None:
 
 def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     """It creates a commit without parents."""
-    repository = Repository.init(tmp_path / "repository").repository
-    commit(repository, message="initial")
+    repository = Repository.init(tmp_path / "repository")
+    repository.commit(message="initial")
 
-    assert not repository.head.peel().parents
+    assert not repository.repository.head.peel().parents
 
 
 def test_commit_empty(repository: pygit2.Repository) -> None:
     """It does not produce an empty commit (unless the branch is unborn)."""
     head = repository.head.peel()
 
-    commit(repository, message="empty")
+    Repository(repository).commit(message="empty")
 
     assert head == repository.head.peel()
 
@@ -47,7 +46,7 @@ def test_commit_signature(repository: pygit2.Repository, repositorypath: Path) -
     (repositorypath / "a").touch()
 
     signature = pygit2.Signature("Katherine", "katherine@example.com")
-    commit(repository, message="empty", signature=signature)
+    Repository(repository).commit(message="empty", signature=signature)
 
     head = repository.head.peel()
     assert signature.name == head.author.name and signature.email == head.author.email
@@ -59,7 +58,7 @@ def test_commit_message_default(
     """It uses an empty message by default."""
     (repositorypath / "a").touch()
 
-    commit(repository)
+    Repository(repository).commit()
 
     head = repository.head.peel()
     assert "" == head.message
@@ -78,7 +77,7 @@ def test_createbranch_target_branch(repository: pygit2.Repository) -> None:
     branch1 = createbranch(repository, "branch1")
 
     repository.checkout(branch1)
-    commit(repository)
+    Repository(repository).commit()
 
     repository.checkout(main)
     createbranch(repository, "branch2", target="branch1")
@@ -92,7 +91,7 @@ def test_createbranch_target_oid(repository: pygit2.Repository) -> None:
     main = repository.head
     oid = main.peel().id
 
-    commit(repository)
+    Repository(repository).commit()
 
     createbranch(repository, "branch", target=str(oid))
     branch = repository.branches["branch"]

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -28,19 +28,19 @@ def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) 
     commit(repository, message=f"Move files to subdirectory {directory}")
 
 
-def locaterepository(path: Path) -> pygit2.Repository:
+def locaterepository(path: Path) -> Repository:
     """Locate the git repository containing the given path."""
     while path.name and not path.exists():
         path = path.parent
 
     repository = Repository.discover(path)
     assert repository is not None
-    return repository.repository
+    return repository
 
 
 def updatefile(path: Path, text: str = "") -> None:
     """Add or update a repository file."""
-    repository = locaterepository(path)
+    repository = locaterepository(path).repository
 
     verb = "Update" if path.exists() else "Add"
 
@@ -57,7 +57,7 @@ def updatefiles(paths: dict[Path, str]) -> None:
     verb = "Add"
 
     for path, text in paths.items():
-        repository = locaterepository(path)
+        repository = locaterepository(path).repository
 
         if path.exists():
             verb = "Update"
@@ -75,7 +75,7 @@ def appendfile(path: Path, text: str) -> None:
 
 def removefile(path: Path) -> None:
     """Remove a repository file."""
-    repository = locaterepository(path)
+    repository = locaterepository(path).repository
 
     path.unlink()
 

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -51,6 +51,9 @@ def updatefile(path: Path, text: str = "") -> None:
 
 def updatefiles(paths: dict[Path, str]) -> None:
     """Add or update repository files."""
+    if not paths:
+        return
+
     verb = "Add"
 
     for path, text in paths.items():

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 
 import pygit2
 
-from cutty.util.git import commit
 from cutty.util.git import createbranch
 from cutty.util.git import Repository
 
@@ -25,7 +24,7 @@ def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) 
     tree = repository[builder.write()]
     repository.checkout_tree(tree)
 
-    commit(repository, message=f"Move files to subdirectory {directory}")
+    Repository(repository).commit(message=f"Move files to subdirectory {directory}")
 
 
 def locaterepository(path: Path) -> Repository:
@@ -40,13 +39,13 @@ def locaterepository(path: Path) -> Repository:
 
 def updatefile(path: Path, text: str = "") -> None:
     """Add or update a repository file."""
-    repository = locaterepository(path).repository
+    repository = locaterepository(path)
 
     verb = "Update" if path.exists() else "Add"
 
     path.write_text(dedent(text).lstrip())
 
-    commit(repository, message=f"{verb} {path.name}")
+    repository.commit(message=f"{verb} {path.name}")
 
 
 def updatefiles(paths: dict[Path, str]) -> None:
@@ -57,7 +56,7 @@ def updatefiles(paths: dict[Path, str]) -> None:
     verb = "Add"
 
     for path, text in paths.items():
-        repository = locaterepository(path).repository
+        repository = locaterepository(path)
 
         if path.exists():
             verb = "Update"
@@ -65,7 +64,7 @@ def updatefiles(paths: dict[Path, str]) -> None:
         path.write_text(dedent(text).lstrip())
 
     pathlist = " and ".join(path.name for path in paths)
-    commit(repository, message=f"{verb} {pathlist}")
+    repository.commit(message=f"{verb} {pathlist}")
 
 
 def appendfile(path: Path, text: str) -> None:
@@ -75,11 +74,11 @@ def appendfile(path: Path, text: str) -> None:
 
 def removefile(path: Path) -> None:
     """Remove a repository file."""
-    repository = locaterepository(path).repository
+    repository = locaterepository(path)
 
     path.unlink()
 
-    commit(repository, message=f"Remove {path.name}")
+    repository.commit(message=f"Remove {path.name}")
 
 
 class Side(enum.Enum):


### PR DESCRIPTION
- :recycle: [tests] Do not crash when `updatefiles` is passed empty dict
- :recycle: [tests] Return `git.Repository` from `locaterepository`
- :recycle: [filestorage] Pass `git.Repository` to `tree` in git observer tests
- :recycle: [util] Extract function `git.Repository.commit`
- :recycle: [util] Inline function `git.commit`
