### PR TITLE
:recycle: [util] Move function `createworktree` to `git.Repository`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -13,7 +13,6 @@ from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfi
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import cherrypick
 from cutty.util.git import createbranch
-from cutty.util.git import createworktree
 from cutty.util.git import Repository
 from cutty.util.git import resetmerge
 from cutty.util.git import updatebranch
@@ -40,7 +39,9 @@ def update(
     repository = Repository.open(projectdir).repository
     createbranch(repository, UPDATE_BRANCH, target=LATEST_BRANCH, force=True)
 
-    with createworktree(repository, UPDATE_BRANCH, checkout=False) as worktree:
+    with Repository(repository).createworktree(
+        UPDATE_BRANCH, checkout=False
+    ) as worktree:
         create(
             projectconfig.template,
             outputdir=worktree,

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -80,6 +80,12 @@ class Repository:
         parents = [] if repository.head_is_unborn else [repository.head.target]
         repository.create_commit("HEAD", signature, signature, message, tree, parents)
 
+    @contextmanager
+    def createworktree(self, branch: str, *, checkout: bool = True) -> Iterator[Path]:
+        """Create a worktree for the branch in the repository."""
+        with createworktree(self.repository, branch, checkout=checkout) as path:
+            yield path
+
 
 def _fix_repository_head(repository: pygit2.Repository) -> pygit2.Reference:
     """Work around a bug in libgit2 resulting in a bogus HEAD reference.

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -7,7 +7,6 @@ import pytest
 
 from cutty.util.git import cherrypick
 from cutty.util.git import createbranch
-from cutty.util.git import createworktree
 from cutty.util.git import Repository
 from cutty.util.git import resetmerge
 from tests.util.git import createbranches
@@ -126,7 +125,7 @@ def test_createworktree_creates_worktree(repository: pygit2.Repository) -> None:
     """It creates a worktree."""
     createbranch(repository, "branch")
 
-    with createworktree(repository, "branch") as worktree:
+    with Repository(repository).createworktree("branch") as worktree:
         assert (worktree / ".git").is_file()
 
 
@@ -134,7 +133,7 @@ def test_createworktree_removes_worktree_on_exit(repository: pygit2.Repository) 
     """It removes the worktree on exit."""
     createbranch(repository, "branch")
 
-    with createworktree(repository, "branch") as worktree:
+    with Repository(repository).createworktree("branch") as worktree:
         pass
 
     assert not worktree.is_dir()
@@ -147,7 +146,7 @@ def test_createworktree_does_checkout(
     updatefile(path)
     createbranch(repository, "branch")
 
-    with createworktree(repository, "branch") as worktree:
+    with Repository(repository).createworktree("branch") as worktree:
         assert (worktree / path.name).is_file()
 
 
@@ -156,7 +155,7 @@ def test_createworktree_no_checkout(repository: pygit2.Repository, path: Path) -
     updatefile(path)
     createbranch(repository, "branch")
 
-    with createworktree(repository, "branch", checkout=False) as worktree:
+    with Repository(repository).createworktree("branch", checkout=False) as worktree:
         assert not (worktree / path.name).is_file()
 
 


### PR DESCRIPTION
- :recycle: [util] Extract function `git.Repository.createworktree`
- :recycle: [util] Inline function `git.createworktree`
