### PR TITLE
:recycle: [util] Move function `cherrypick` to `git.Repository`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -11,7 +11,6 @@ from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
-from cutty.util.git import cherrypick
 from cutty.util.git import createbranch
 from cutty.util.git import Repository
 from cutty.util.git import resetmerge
@@ -52,7 +51,7 @@ def update(
             directory=directory,
         )
 
-    cherrypick(repository, UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
+    Repository(repository).cherrypick(UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
     updatebranch(repository, LATEST_BRANCH, target=UPDATE_BRANCH)
 
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -102,6 +102,10 @@ class Repository:
         # https://github.com/libgit2/libgit2/issues/5280
         worktree.prune(True)
 
+    def cherrypick(self, reference: str, *, message: str) -> None:
+        """Cherry-pick the commit onto the current branch."""
+        cherrypick(self.repository, reference, message=message)
+
 
 def _fix_repository_head(repository: pygit2.Repository) -> pygit2.Reference:
     """Work around a bug in libgit2 resulting in a bogus HEAD reference.

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -9,7 +9,7 @@ from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import skipupdate
-from cutty.util.git import cherrypick
+from cutty.util.git import Repository
 from tests.util.files import chdir
 from tests.util.git import createbranches
 from tests.util.git import resolveconflicts
@@ -34,7 +34,7 @@ def createconflict(
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repository, update.name, message="")
+        Repository(repository).cherrypick(update.name, message="")
 
 
 def test_continueupdate_commits_changes(

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pygit2
 import pytest
 
-from cutty.util.git import cherrypick
 from cutty.util.git import createbranch
 from cutty.util.git import Repository
 from cutty.util.git import resetmerge
@@ -118,7 +117,7 @@ def createconflict(
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repository, update.name, message="")
+        Repository(repository).cherrypick(update.name, message="")
 
 
 def test_createworktree_creates_worktree(repository: pygit2.Repository) -> None:
@@ -170,7 +169,7 @@ def test_cherrypick_adds_file(repository: pygit2.Repository, path: Path) -> None
     repository.checkout(main)
     assert not path.is_file()
 
-    cherrypick(repository, branch.name, message="")
+    Repository(repository).cherrypick(branch.name, message="")
     assert path.is_file()
 
 
@@ -186,7 +185,7 @@ def test_cherrypick_conflict_edit(repository: pygit2.Repository, path: Path) -> 
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repository, branch.name, message="")
+        Repository(repository).cherrypick(branch.name, message="")
 
 
 def test_cherrypick_conflict_deletion(
@@ -205,7 +204,7 @@ def test_cherrypick_conflict_deletion(
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):
-        cherrypick(repository, branch.name, message="")
+        Repository(repository).cherrypick(branch.name, message="")
 
 
 def test_resetmerge_restores_files_with_conflicts(
@@ -233,7 +232,7 @@ def test_resetmerge_removes_added_files(
     updatefile(path1, "b")
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repository, update.name, message="")
+        Repository(repository).cherrypick(update.name, message="")
 
     resetmerge(repository, parent="latest", cherry="update")
 
@@ -257,7 +256,7 @@ def test_resetmerge_keeps_unrelated_additions(
     path2.touch()
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repository, update.name, message="")
+        Repository(repository).cherrypick(update.name, message="")
 
     resetmerge(repository, parent="latest", cherry="update")
 
@@ -282,7 +281,7 @@ def test_resetmerge_keeps_unrelated_changes(
     path2.write_text("c")
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repository, update.name, message="")
+        Repository(repository).cherrypick(update.name, message="")
 
     resetmerge(repository, parent="latest", cherry="update")
 
@@ -307,7 +306,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     path2.unlink()
 
     with pytest.raises(Exception, match=path1.name):
-        cherrypick(repository, update.name, message="")
+        Repository(repository).cherrypick(update.name, message="")
 
     resetmerge(repository, parent="latest", cherry="update")
 


### PR DESCRIPTION
- :recycle: [util] Extract function `git.Repository.cherrypick`
- :recycle: [util] Inline function `git.cherrypick`
