### PR TITLE
:recycle: [util] Move function `resetmerge` to `git.Repository`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -32,12 +32,10 @@ def update(
     if directory is None:
         directory = projectconfig.directory
 
-    repository = Repository.open(projectdir).repository
-    Repository(repository).createbranch(UPDATE_BRANCH, target=LATEST_BRANCH, force=True)
+    repository = Repository.open(projectdir)
+    repository.createbranch(UPDATE_BRANCH, target=LATEST_BRANCH, force=True)
 
-    with Repository(repository).createworktree(
-        UPDATE_BRANCH, checkout=False
-    ) as worktree:
+    with repository.createworktree(UPDATE_BRANCH, checkout=False) as worktree:
         create(
             projectconfig.template,
             outputdir=worktree,
@@ -48,8 +46,8 @@ def update(
             directory=directory,
         )
 
-    Repository(repository).cherrypick(UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
-    Repository(repository).updatebranch(LATEST_BRANCH, target=UPDATE_BRANCH)
+    repository.cherrypick(UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
+    repository.updatebranch(LATEST_BRANCH, target=UPDATE_BRANCH)
 
 
 def continueupdate(*, projectdir: Optional[Path] = None) -> None:
@@ -67,9 +65,9 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
-    repository = Repository.open(projectdir).repository
-    Repository(repository).resetmerge(parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
-    Repository(repository).updatebranch(LATEST_BRANCH, target=UPDATE_BRANCH)
+    repository = Repository.open(projectdir)
+    repository.resetmerge(parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+    repository.updatebranch(LATEST_BRANCH, target=UPDATE_BRANCH)
 
 
 def abortupdate(*, projectdir: Optional[Path] = None) -> None:
@@ -77,6 +75,6 @@ def abortupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
-    repository = Repository.open(projectdir).repository
-    Repository(repository).resetmerge(parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
-    Repository(repository).updatebranch(UPDATE_BRANCH, target=LATEST_BRANCH)
+    repository = Repository.open(projectdir)
+    repository.resetmerge(parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+    repository.updatebranch(UPDATE_BRANCH, target=LATEST_BRANCH)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -12,7 +12,6 @@ from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
-from cutty.util.git import resetmerge
 
 
 def update(
@@ -69,7 +68,7 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
         projectdir = Path.cwd()
 
     repository = Repository.open(projectdir).repository
-    resetmerge(repository, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+    Repository(repository).resetmerge(parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
     Repository(repository).updatebranch(LATEST_BRANCH, target=UPDATE_BRANCH)
 
 
@@ -79,5 +78,5 @@ def abortupdate(*, projectdir: Optional[Path] = None) -> None:
         projectdir = Path.cwd()
 
     repository = Repository.open(projectdir).repository
-    resetmerge(repository, parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+    Repository(repository).resetmerge(parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
     Repository(repository).updatebranch(UPDATE_BRANCH, target=LATEST_BRANCH)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -131,6 +131,30 @@ class Repository:
         commit = self.repository.branches[target].peel()
         self.repository.branches[branch].set_target(commit.id)
 
+    def resetmerge(self, parent: str, cherry: str) -> None:
+        """Reset only files that were touched by a cherry-pick.
+
+        This emulates `git reset --merge HEAD` by performing a hard reset on the
+        files that were updated by the cherry-picked commit, and resetting the index
+        to HEAD.
+        """
+        self.repository.index.read_tree(self.repository.head.peel().tree)
+        self.repository.index.write()
+
+        parenttree = self.repository.branches[parent].peel(pygit2.Tree)
+        cherrytree = self.repository.branches[cherry].peel(pygit2.Tree)
+        diff = cherrytree.diff_to_tree(parenttree)
+        paths = [
+            file.path
+            for delta in diff.deltas
+            for file in (delta.old_file, delta.new_file)
+        ]
+
+        self.repository.checkout(
+            strategy=pygit2.GIT_CHECKOUT_FORCE | pygit2.GIT_CHECKOUT_REMOVE_UNTRACKED,
+            paths=paths,
+        )
+
 
 def _fix_repository_head(repository: pygit2.Repository) -> pygit2.Reference:
     """Work around a bug in libgit2 resulting in a bogus HEAD reference.
@@ -176,17 +200,4 @@ def resetmerge(repository: pygit2.Repository, parent: str, cherry: str) -> None:
     files that were updated by the cherry-picked commit, and resetting the index
     to HEAD.
     """
-    repository.index.read_tree(repository.head.peel().tree)
-    repository.index.write()
-
-    parenttree = repository.branches[parent].peel(pygit2.Tree)
-    cherrytree = repository.branches[cherry].peel(pygit2.Tree)
-    diff = cherrytree.diff_to_tree(parenttree)
-    paths = [
-        file.path for delta in diff.deltas for file in (delta.old_file, delta.new_file)
-    ]
-
-    repository.checkout(
-        strategy=pygit2.GIT_CHECKOUT_FORCE | pygit2.GIT_CHECKOUT_REMOVE_UNTRACKED,
-        paths=paths,
-    )
+    Repository(repository).resetmerge(parent, cherry)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -191,13 +191,3 @@ def checkoutemptytree(repository: pygit2.Repository) -> None:
     """Check out an empty tree from the repository."""
     oid = repository.TreeBuilder().write()
     repository.checkout_tree(repository[oid])
-
-
-def resetmerge(repository: pygit2.Repository, parent: str, cherry: str) -> None:
-    """Reset only files that were touched by a cherry-pick.
-
-    This emulates `git reset --merge HEAD` by performing a hard reset on the
-    files that were updated by the cherry-picked commit, and resetting the index
-    to HEAD.
-    """
-    Repository(repository).resetmerge(parent, cherry)

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -6,7 +6,6 @@ import pygit2
 import pytest
 
 from cutty.util.git import Repository
-from cutty.util.git import resetmerge
 from tests.util.git import createbranches
 from tests.util.git import removefile
 from tests.util.git import updatefile
@@ -211,7 +210,7 @@ def test_resetmerge_restores_files_with_conflicts(
 ) -> None:
     """It restores the conflicting files in the working tree to our version."""
     createconflict(repository, path, ours="a", theirs="b")
-    resetmerge(repository, parent="latest", cherry="update")
+    Repository(repository).resetmerge(parent="latest", cherry="update")
 
     assert path.read_text() == "a"
 
@@ -233,7 +232,7 @@ def test_resetmerge_removes_added_files(
     with pytest.raises(Exception, match=path1.name):
         Repository(repository).cherrypick(update.name, message="")
 
-    resetmerge(repository, parent="latest", cherry="update")
+    Repository(repository).resetmerge(parent="latest", cherry="update")
 
     assert not path2.exists()
 
@@ -257,7 +256,7 @@ def test_resetmerge_keeps_unrelated_additions(
     with pytest.raises(Exception, match=path1.name):
         Repository(repository).cherrypick(update.name, message="")
 
-    resetmerge(repository, parent="latest", cherry="update")
+    Repository(repository).resetmerge(parent="latest", cherry="update")
 
     assert path2.exists()
 
@@ -282,7 +281,7 @@ def test_resetmerge_keeps_unrelated_changes(
     with pytest.raises(Exception, match=path1.name):
         Repository(repository).cherrypick(update.name, message="")
 
-    resetmerge(repository, parent="latest", cherry="update")
+    Repository(repository).resetmerge(parent="latest", cherry="update")
 
     assert path2.read_text() == "c"
 
@@ -307,7 +306,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     with pytest.raises(Exception, match=path1.name):
         Repository(repository).cherrypick(update.name, message="")
 
-    resetmerge(repository, parent="latest", cherry="update")
+    Repository(repository).resetmerge(parent="latest", cherry="update")
 
     assert not path2.exists()
 
@@ -316,6 +315,6 @@ def test_resetmerge_resets_index(repository: pygit2.Repository, path: Path) -> N
     """It resets the index to HEAD, removing conflicts."""
     createconflict(repository, path, ours="a", theirs="b")
 
-    resetmerge(repository, parent="latest", cherry="update")
+    Repository(repository).resetmerge(parent="latest", cherry="update")
 
     assert repository.index.write_tree() == repository.head.peel().tree.id


### PR DESCRIPTION
- :recycle: [util] Move function `resetmerge` to `git.Repository`
- :recycle: [util] Inline function `git.resetmerge`
- :recycle: [services] Remove redundant `git.Repository` roundtrip
