### PR TITLE
:recycle: [tests] Change fixture `repository` to return `git.Repository`

### DIFF
--- a/tests/fixtures/git.py
+++ b/tests/fixtures/git.py
@@ -3,7 +3,6 @@ import string
 from collections.abc import Iterator
 from pathlib import Path
 
-import pygit2
 import pytest
 
 from cutty.util.git import Repository
@@ -22,12 +21,6 @@ def repositorypath(tmp_path: Path) -> Path:
 def repository2(repositorypath: Path) -> Repository:
     """Fixture for a repository."""
     return Repository.open(repositorypath)
-
-
-@pytest.fixture
-def repository(repositorypath: Path) -> pygit2.Repository:
-    """Fixture for a repository."""
-    return Repository.open(repositorypath).repository
 
 
 @pytest.fixture

--- a/tests/fixtures/git.py
+++ b/tests/fixtures/git.py
@@ -19,6 +19,12 @@ def repositorypath(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def repository2(repositorypath: Path) -> Repository:
+    """Fixture for a repository."""
+    return Repository.open(repositorypath)
+
+
+@pytest.fixture
 def repository(repositorypath: Path) -> pygit2.Repository:
     """Fixture for a repository."""
     return Repository.open(repositorypath).repository

--- a/tests/fixtures/git.py
+++ b/tests/fixtures/git.py
@@ -18,7 +18,7 @@ def repositorypath(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def repository2(repositorypath: Path) -> Repository:
+def repository(repositorypath: Path) -> Repository:
     """Fixture for a repository."""
     return Repository.open(repositorypath)
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -38,9 +38,10 @@ def createconflict(
 
 
 def test_continueupdate_commits_changes(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
+    repository2: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It commits the changes."""
+    repository = repository2.repository
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
@@ -52,9 +53,10 @@ def test_continueupdate_commits_changes(
 
 
 def test_continueupdate_fastforwards_latest(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
+    repository2: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It updates the latest branch to the tip of the update branch."""
+    repository = repository2.repository
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
@@ -66,9 +68,10 @@ def test_continueupdate_fastforwards_latest(
 
 
 def test_skipupdate_fastforwards_latest(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
+    repository2: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
+    repository = repository2.repository
     createconflict(repository, path, ours="a", theirs="b")
 
     updatehead = repository.branches[UPDATE_BRANCH].peel()
@@ -80,9 +83,10 @@ def test_skipupdate_fastforwards_latest(
 
 
 def test_abortupdate_rewinds_update_branch(
-    repository: pygit2.Repository, repositorypath: Path, path: Path
+    repository2: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
+    repository = repository2.repository
     createconflict(repository, path, ours="a", theirs="b")
 
     branches = repository.branches

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -38,54 +38,54 @@ def createconflict(
 
 
 def test_continueupdate_commits_changes(
-    repository2: Repository, repositorypath: Path, path: Path
+    repository: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It commits the changes."""
-    createconflict(repository2.repository, path, ours="a", theirs="b")
+    createconflict(repository.repository, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
         continueupdate()
 
-    blob = repository2.repository.head.peel().tree / path.name
+    blob = repository.repository.head.peel().tree / path.name
     assert blob.data == b"b"
 
 
 def test_continueupdate_fastforwards_latest(
-    repository2: Repository, repositorypath: Path, path: Path
+    repository: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It updates the latest branch to the tip of the update branch."""
-    createconflict(repository2.repository, path, ours="a", theirs="b")
+    createconflict(repository.repository, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
         continueupdate()
 
-    branches = repository2.repository.branches
+    branches = repository.repository.branches
     assert branches[LATEST_BRANCH].peel() == branches[UPDATE_BRANCH].peel()
 
 
 def test_skipupdate_fastforwards_latest(
-    repository2: Repository, repositorypath: Path, path: Path
+    repository: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
-    createconflict(repository2.repository, path, ours="a", theirs="b")
+    createconflict(repository.repository, path, ours="a", theirs="b")
 
-    updatehead = repository2.repository.branches[UPDATE_BRANCH].peel()
+    updatehead = repository.repository.branches[UPDATE_BRANCH].peel()
 
     with chdir(repositorypath):
         skipupdate()
 
-    assert repository2.repository.branches[LATEST_BRANCH].peel() == updatehead
+    assert repository.repository.branches[LATEST_BRANCH].peel() == updatehead
 
 
 def test_abortupdate_rewinds_update_branch(
-    repository2: Repository, repositorypath: Path, path: Path
+    repository: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
-    createconflict(repository2.repository, path, ours="a", theirs="b")
+    createconflict(repository.repository, path, ours="a", theirs="b")
 
-    branches = repository2.repository.branches
+    branches = repository.repository.branches
     latesthead = branches[LATEST_BRANCH].peel()
 
     with chdir(repositorypath):

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -41,14 +41,13 @@ def test_continueupdate_commits_changes(
     repository2: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It commits the changes."""
-    repository = repository2.repository
-    createconflict(repository, path, ours="a", theirs="b")
+    createconflict(repository2.repository, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
         continueupdate()
 
-    blob = repository.head.peel().tree / path.name
+    blob = repository2.repository.head.peel().tree / path.name
     assert blob.data == b"b"
 
 
@@ -56,14 +55,13 @@ def test_continueupdate_fastforwards_latest(
     repository2: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It updates the latest branch to the tip of the update branch."""
-    repository = repository2.repository
-    createconflict(repository, path, ours="a", theirs="b")
+    createconflict(repository2.repository, path, ours="a", theirs="b")
     resolveconflicts(repositorypath, path, Side.THEIRS)
 
     with chdir(repositorypath):
         continueupdate()
 
-    branches = repository.branches
+    branches = repository2.repository.branches
     assert branches[LATEST_BRANCH].peel() == branches[UPDATE_BRANCH].peel()
 
 
@@ -71,25 +69,23 @@ def test_skipupdate_fastforwards_latest(
     repository2: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
-    repository = repository2.repository
-    createconflict(repository, path, ours="a", theirs="b")
+    createconflict(repository2.repository, path, ours="a", theirs="b")
 
-    updatehead = repository.branches[UPDATE_BRANCH].peel()
+    updatehead = repository2.repository.branches[UPDATE_BRANCH].peel()
 
     with chdir(repositorypath):
         skipupdate()
 
-    assert repository.branches[LATEST_BRANCH].peel() == updatehead
+    assert repository2.repository.branches[LATEST_BRANCH].peel() == updatehead
 
 
 def test_abortupdate_rewinds_update_branch(
     repository2: Repository, repositorypath: Path, path: Path
 ) -> None:
     """It resets the update branch to the tip of the latest branch."""
-    repository = repository2.repository
-    createconflict(repository, path, ours="a", theirs="b")
+    createconflict(repository2.repository, path, ours="a", theirs="b")
 
-    branches = repository.branches
+    branches = repository2.repository.branches
     latesthead = branches[LATEST_BRANCH].peel()
 
     with chdir(repositorypath):

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -30,80 +30,76 @@ def test_commit_on_unborn_branch(tmp_path: Path) -> None:
 
 def test_commit_empty(repository2: Repository) -> None:
     """It does not produce an empty commit (unless the branch is unborn)."""
-    repository = repository2.repository
-    head = repository.head.peel()
+    head = repository2.repository.head.peel()
 
     repository2.commit(message="empty")
 
-    assert head == repository.head.peel()
+    assert head == repository2.repository.head.peel()
 
 
 def test_commit_signature(repository2: Repository, repositorypath: Path) -> None:
     """It uses the provided signature."""
-    repository = repository2.repository
     (repositorypath / "a").touch()
 
     signature = pygit2.Signature("Katherine", "katherine@example.com")
     repository2.commit(message="empty", signature=signature)
 
-    head = repository.head.peel()
+    head = repository2.repository.head.peel()
     assert signature.name == head.author.name and signature.email == head.author.email
 
 
 def test_commit_message_default(repository2: Repository, repositorypath: Path) -> None:
     """It uses an empty message by default."""
-    repository = repository2.repository
     (repositorypath / "a").touch()
 
     repository2.commit()
 
-    head = repository.head.peel()
+    head = repository2.repository.head.peel()
     assert "" == head.message
 
 
 def test_createbranch_target_default(repository2: Repository) -> None:
     """It creates the branch at HEAD by default."""
-    repository = repository2.repository
     repository2.createbranch("branch")
 
-    assert repository.branches["branch"].peel() == repository.head.peel()
+    assert (
+        repository2.repository.branches["branch"].peel()
+        == repository2.repository.head.peel()
+    )
 
 
 def test_createbranch_target_branch(repository2: Repository) -> None:
     """It creates the branch at the head of the given branch."""
-    repository = repository2.repository
-    main = repository.head
+    main = repository2.repository.head
     branch1 = repository2.createbranch("branch1")
 
-    repository.checkout(branch1)
+    repository2.repository.checkout(branch1)
     repository2.commit()
 
-    repository.checkout(main)
+    repository2.repository.checkout(main)
     repository2.createbranch("branch2", target="branch1")
-    branch2 = repository.branches["branch2"]
+    branch2 = repository2.repository.branches["branch2"]
 
     assert branch1.peel() == branch2.peel()
 
 
 def test_createbranch_target_oid(repository2: Repository) -> None:
     """It creates the branch at the commit with the given OID."""
-    repository = repository2.repository
-    main = repository.head
+    main = repository2.repository.head
     oid = main.peel().id
 
     repository2.commit()
 
     repository2.createbranch("branch", target=str(oid))
-    branch = repository.branches["branch"]
+    branch = repository2.repository.branches["branch"]
 
     assert oid == branch.peel().id
 
 
 def test_createbranch_returns_branch(repository2: Repository) -> None:
     """It returns the branch object."""
-    repository = repository2.repository
     branch = repository2.createbranch("branch")
-    assert branch == repository.branches["branch"]
+    assert branch == repository2.repository.branches["branch"]
 
 
 def createconflict(
@@ -161,14 +157,13 @@ def test_createworktree_no_checkout(repository2: Repository, path: Path) -> None
 
 def test_cherrypick_adds_file(repository2: Repository, path: Path) -> None:
     """It cherry-picks the commit onto the current branch."""
-    repository = repository2.repository
-    main = repository.head
+    main = repository2.repository.head
     branch = repository2.createbranch("branch")
 
-    repository.checkout(branch)
+    repository2.repository.checkout(branch)
     updatefile(path)
 
-    repository.checkout(main)
+    repository2.repository.checkout(main)
     assert not path.is_file()
 
     repository2.cherrypick(branch.name, message="")
@@ -177,14 +172,13 @@ def test_cherrypick_adds_file(repository2: Repository, path: Path) -> None:
 
 def test_cherrypick_conflict_edit(repository2: Repository, path: Path) -> None:
     """It raises an exception when both sides modified the file."""
-    repository = repository2.repository
-    main = repository.head
+    main = repository2.repository.head
     branch = repository2.createbranch("branch")
 
-    repository.checkout(branch)
+    repository2.repository.checkout(branch)
     updatefile(path, "a")
 
-    repository.checkout(main)
+    repository2.repository.checkout(main)
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
@@ -193,16 +187,15 @@ def test_cherrypick_conflict_edit(repository2: Repository, path: Path) -> None:
 
 def test_cherrypick_conflict_deletion(repository2: Repository, path: Path) -> None:
     """It raises an exception when one side modified and the other deleted the file."""
-    repository = repository2.repository
     updatefile(path, "a")
 
-    main = repository.head
+    main = repository2.repository.head
     branch = repository2.createbranch("branch")
 
-    repository.checkout(branch)
+    repository2.repository.checkout(branch)
     updatefile(path, "b")
 
-    repository.checkout(main)
+    repository2.repository.checkout(main)
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):
@@ -213,8 +206,7 @@ def test_resetmerge_restores_files_with_conflicts(
     repository2: Repository, path: Path
 ) -> None:
     """It restores the conflicting files in the working tree to our version."""
-    repository = repository2.repository
-    createconflict(repository, path, ours="a", theirs="b")
+    createconflict(repository2.repository, path, ours="a", theirs="b")
     repository2.resetmerge(parent="latest", cherry="update")
 
     assert path.read_text() == "a"
@@ -224,15 +216,14 @@ def test_resetmerge_removes_added_files(
     repository2: Repository, paths: Iterator[Path]
 ) -> None:
     """It removes files added by the cherry-picked commit."""
-    repository = repository2.repository
-    main = repository.head
-    update, _ = createbranches(repository, "update", "latest")
+    main = repository2.repository.head
+    update, _ = createbranches(repository2.repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository.checkout(update)
+    repository2.repository.checkout(update)
     updatefiles({path1: "a", path2: ""})
 
-    repository.checkout(main)
+    repository2.repository.checkout(main)
     updatefile(path1, "b")
 
     with pytest.raises(Exception, match=path1.name):
@@ -247,15 +238,14 @@ def test_resetmerge_keeps_unrelated_additions(
     repository2: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps additions of files that did not change in the update."""
-    repository = repository2.repository
-    main = repository.head
-    update, _ = createbranches(repository, "update", "latest")
+    main = repository2.repository.head
+    update, _ = createbranches(repository2.repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository.checkout(update)
+    repository2.repository.checkout(update)
     updatefile(path1, "a")
 
-    repository.checkout(main)
+    repository2.repository.checkout(main)
     updatefile(path1, "b")
 
     path2.touch()
@@ -272,15 +262,14 @@ def test_resetmerge_keeps_unrelated_changes(
     repository2: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
-    repository = repository2.repository
-    main = repository.head
-    update, _ = createbranches(repository, "update", "latest")
+    main = repository2.repository.head
+    update, _ = createbranches(repository2.repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository.checkout(update)
+    repository2.repository.checkout(update)
     updatefile(path1, "a")
 
-    repository.checkout(main)
+    repository2.repository.checkout(main)
     updatefile(path1, "b")
     updatefile(path2)
 
@@ -298,15 +287,14 @@ def test_resetmerge_keeps_unrelated_deletions(
     repository2: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
-    repository = repository2.repository
-    main = repository.head
-    update, _ = createbranches(repository, "update", "latest")
+    main = repository2.repository.head
+    update, _ = createbranches(repository2.repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository.checkout(update)
+    repository2.repository.checkout(update)
     updatefile(path1, "a")
 
-    repository.checkout(main)
+    repository2.repository.checkout(main)
     updatefile(path1, "b")
     updatefile(path2)
 
@@ -322,9 +310,11 @@ def test_resetmerge_keeps_unrelated_deletions(
 
 def test_resetmerge_resets_index(repository2: Repository, path: Path) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    repository = repository2.repository
-    createconflict(repository, path, ours="a", theirs="b")
+    createconflict(repository2.repository, path, ours="a", theirs="b")
 
     repository2.resetmerge(parent="latest", cherry="update")
 
-    assert repository.index.write_tree() == repository.head.peel().tree.id
+    assert (
+        repository2.repository.index.write_tree()
+        == repository2.repository.head.peel().tree.id
+    )

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -28,78 +28,78 @@ def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     assert not repository.repository.head.peel().parents
 
 
-def test_commit_empty(repository2: Repository) -> None:
+def test_commit_empty(repository: Repository) -> None:
     """It does not produce an empty commit (unless the branch is unborn)."""
-    head = repository2.repository.head.peel()
+    head = repository.repository.head.peel()
 
-    repository2.commit(message="empty")
+    repository.commit(message="empty")
 
-    assert head == repository2.repository.head.peel()
+    assert head == repository.repository.head.peel()
 
 
-def test_commit_signature(repository2: Repository, repositorypath: Path) -> None:
+def test_commit_signature(repository: Repository, repositorypath: Path) -> None:
     """It uses the provided signature."""
     (repositorypath / "a").touch()
 
     signature = pygit2.Signature("Katherine", "katherine@example.com")
-    repository2.commit(message="empty", signature=signature)
+    repository.commit(message="empty", signature=signature)
 
-    head = repository2.repository.head.peel()
+    head = repository.repository.head.peel()
     assert signature.name == head.author.name and signature.email == head.author.email
 
 
-def test_commit_message_default(repository2: Repository, repositorypath: Path) -> None:
+def test_commit_message_default(repository: Repository, repositorypath: Path) -> None:
     """It uses an empty message by default."""
     (repositorypath / "a").touch()
 
-    repository2.commit()
+    repository.commit()
 
-    head = repository2.repository.head.peel()
+    head = repository.repository.head.peel()
     assert "" == head.message
 
 
-def test_createbranch_target_default(repository2: Repository) -> None:
+def test_createbranch_target_default(repository: Repository) -> None:
     """It creates the branch at HEAD by default."""
-    repository2.createbranch("branch")
+    repository.createbranch("branch")
 
     assert (
-        repository2.repository.branches["branch"].peel()
-        == repository2.repository.head.peel()
+        repository.repository.branches["branch"].peel()
+        == repository.repository.head.peel()
     )
 
 
-def test_createbranch_target_branch(repository2: Repository) -> None:
+def test_createbranch_target_branch(repository: Repository) -> None:
     """It creates the branch at the head of the given branch."""
-    main = repository2.repository.head
-    branch1 = repository2.createbranch("branch1")
+    main = repository.repository.head
+    branch1 = repository.createbranch("branch1")
 
-    repository2.repository.checkout(branch1)
-    repository2.commit()
+    repository.repository.checkout(branch1)
+    repository.commit()
 
-    repository2.repository.checkout(main)
-    repository2.createbranch("branch2", target="branch1")
-    branch2 = repository2.repository.branches["branch2"]
+    repository.repository.checkout(main)
+    repository.createbranch("branch2", target="branch1")
+    branch2 = repository.repository.branches["branch2"]
 
     assert branch1.peel() == branch2.peel()
 
 
-def test_createbranch_target_oid(repository2: Repository) -> None:
+def test_createbranch_target_oid(repository: Repository) -> None:
     """It creates the branch at the commit with the given OID."""
-    main = repository2.repository.head
+    main = repository.repository.head
     oid = main.peel().id
 
-    repository2.commit()
+    repository.commit()
 
-    repository2.createbranch("branch", target=str(oid))
-    branch = repository2.repository.branches["branch"]
+    repository.createbranch("branch", target=str(oid))
+    branch = repository.repository.branches["branch"]
 
     assert oid == branch.peel().id
 
 
-def test_createbranch_returns_branch(repository2: Repository) -> None:
+def test_createbranch_returns_branch(repository: Repository) -> None:
     """It returns the branch object."""
-    branch = repository2.createbranch("branch")
-    assert branch == repository2.repository.branches["branch"]
+    branch = repository.createbranch("branch")
+    assert branch == repository.repository.branches["branch"]
 
 
 def createconflict(
@@ -119,202 +119,202 @@ def createconflict(
         Repository(repository).cherrypick(update.name, message="")
 
 
-def test_createworktree_creates_worktree(repository2: Repository) -> None:
+def test_createworktree_creates_worktree(repository: Repository) -> None:
     """It creates a worktree."""
-    repository2.createbranch("branch")
+    repository.createbranch("branch")
 
-    with repository2.createworktree("branch") as worktree:
+    with repository.createworktree("branch") as worktree:
         assert (worktree / ".git").is_file()
 
 
-def test_createworktree_removes_worktree_on_exit(repository2: Repository) -> None:
+def test_createworktree_removes_worktree_on_exit(repository: Repository) -> None:
     """It removes the worktree on exit."""
-    repository2.createbranch("branch")
+    repository.createbranch("branch")
 
-    with repository2.createworktree("branch") as worktree:
+    with repository.createworktree("branch") as worktree:
         pass
 
     assert not worktree.is_dir()
 
 
-def test_createworktree_does_checkout(repository2: Repository, path: Path) -> None:
+def test_createworktree_does_checkout(repository: Repository, path: Path) -> None:
     """It checks out a working tree."""
     updatefile(path)
-    repository2.createbranch("branch")
+    repository.createbranch("branch")
 
-    with repository2.createworktree("branch") as worktree:
+    with repository.createworktree("branch") as worktree:
         assert (worktree / path.name).is_file()
 
 
-def test_createworktree_no_checkout(repository2: Repository, path: Path) -> None:
+def test_createworktree_no_checkout(repository: Repository, path: Path) -> None:
     """It creates a worktree without checking out the files."""
     updatefile(path)
-    repository2.createbranch("branch")
+    repository.createbranch("branch")
 
-    with repository2.createworktree("branch", checkout=False) as worktree:
+    with repository.createworktree("branch", checkout=False) as worktree:
         assert not (worktree / path.name).is_file()
 
 
-def test_cherrypick_adds_file(repository2: Repository, path: Path) -> None:
+def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:
     """It cherry-picks the commit onto the current branch."""
-    main = repository2.repository.head
-    branch = repository2.createbranch("branch")
+    main = repository.repository.head
+    branch = repository.createbranch("branch")
 
-    repository2.repository.checkout(branch)
+    repository.repository.checkout(branch)
     updatefile(path)
 
-    repository2.repository.checkout(main)
+    repository.repository.checkout(main)
     assert not path.is_file()
 
-    repository2.cherrypick(branch.name, message="")
+    repository.cherrypick(branch.name, message="")
     assert path.is_file()
 
 
-def test_cherrypick_conflict_edit(repository2: Repository, path: Path) -> None:
+def test_cherrypick_conflict_edit(repository: Repository, path: Path) -> None:
     """It raises an exception when both sides modified the file."""
-    main = repository2.repository.head
-    branch = repository2.createbranch("branch")
+    main = repository.repository.head
+    branch = repository.createbranch("branch")
 
-    repository2.repository.checkout(branch)
+    repository.repository.checkout(branch)
     updatefile(path, "a")
 
-    repository2.repository.checkout(main)
+    repository.repository.checkout(main)
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
-        repository2.cherrypick(branch.name, message="")
+        repository.cherrypick(branch.name, message="")
 
 
-def test_cherrypick_conflict_deletion(repository2: Repository, path: Path) -> None:
+def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> None:
     """It raises an exception when one side modified and the other deleted the file."""
     updatefile(path, "a")
 
-    main = repository2.repository.head
-    branch = repository2.createbranch("branch")
+    main = repository.repository.head
+    branch = repository.createbranch("branch")
 
-    repository2.repository.checkout(branch)
+    repository.repository.checkout(branch)
     updatefile(path, "b")
 
-    repository2.repository.checkout(main)
+    repository.repository.checkout(main)
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):
-        repository2.cherrypick(branch.name, message="")
+        repository.cherrypick(branch.name, message="")
 
 
 def test_resetmerge_restores_files_with_conflicts(
-    repository2: Repository, path: Path
+    repository: Repository, path: Path
 ) -> None:
     """It restores the conflicting files in the working tree to our version."""
-    createconflict(repository2.repository, path, ours="a", theirs="b")
-    repository2.resetmerge(parent="latest", cherry="update")
+    createconflict(repository.repository, path, ours="a", theirs="b")
+    repository.resetmerge(parent="latest", cherry="update")
 
     assert path.read_text() == "a"
 
 
 def test_resetmerge_removes_added_files(
-    repository2: Repository, paths: Iterator[Path]
+    repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It removes files added by the cherry-picked commit."""
-    main = repository2.repository.head
-    update, _ = createbranches(repository2.repository, "update", "latest")
+    main = repository.repository.head
+    update, _ = createbranches(repository.repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository2.repository.checkout(update)
+    repository.repository.checkout(update)
     updatefiles({path1: "a", path2: ""})
 
-    repository2.repository.checkout(main)
+    repository.repository.checkout(main)
     updatefile(path1, "b")
 
     with pytest.raises(Exception, match=path1.name):
-        repository2.cherrypick(update.name, message="")
+        repository.cherrypick(update.name, message="")
 
-    repository2.resetmerge(parent="latest", cherry="update")
+    repository.resetmerge(parent="latest", cherry="update")
 
     assert not path2.exists()
 
 
 def test_resetmerge_keeps_unrelated_additions(
-    repository2: Repository, paths: Iterator[Path]
+    repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps additions of files that did not change in the update."""
-    main = repository2.repository.head
-    update, _ = createbranches(repository2.repository, "update", "latest")
+    main = repository.repository.head
+    update, _ = createbranches(repository.repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository2.repository.checkout(update)
+    repository.repository.checkout(update)
     updatefile(path1, "a")
 
-    repository2.repository.checkout(main)
+    repository.repository.checkout(main)
     updatefile(path1, "b")
 
     path2.touch()
 
     with pytest.raises(Exception, match=path1.name):
-        repository2.cherrypick(update.name, message="")
+        repository.cherrypick(update.name, message="")
 
-    repository2.resetmerge(parent="latest", cherry="update")
+    repository.resetmerge(parent="latest", cherry="update")
 
     assert path2.exists()
 
 
 def test_resetmerge_keeps_unrelated_changes(
-    repository2: Repository, paths: Iterator[Path]
+    repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
-    main = repository2.repository.head
-    update, _ = createbranches(repository2.repository, "update", "latest")
+    main = repository.repository.head
+    update, _ = createbranches(repository.repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository2.repository.checkout(update)
+    repository.repository.checkout(update)
     updatefile(path1, "a")
 
-    repository2.repository.checkout(main)
+    repository.repository.checkout(main)
     updatefile(path1, "b")
     updatefile(path2)
 
     path2.write_text("c")
 
     with pytest.raises(Exception, match=path1.name):
-        repository2.cherrypick(update.name, message="")
+        repository.cherrypick(update.name, message="")
 
-    repository2.resetmerge(parent="latest", cherry="update")
+    repository.resetmerge(parent="latest", cherry="update")
 
     assert path2.read_text() == "c"
 
 
 def test_resetmerge_keeps_unrelated_deletions(
-    repository2: Repository, paths: Iterator[Path]
+    repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
-    main = repository2.repository.head
-    update, _ = createbranches(repository2.repository, "update", "latest")
+    main = repository.repository.head
+    update, _ = createbranches(repository.repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository2.repository.checkout(update)
+    repository.repository.checkout(update)
     updatefile(path1, "a")
 
-    repository2.repository.checkout(main)
+    repository.repository.checkout(main)
     updatefile(path1, "b")
     updatefile(path2)
 
     path2.unlink()
 
     with pytest.raises(Exception, match=path1.name):
-        repository2.cherrypick(update.name, message="")
+        repository.cherrypick(update.name, message="")
 
-    repository2.resetmerge(parent="latest", cherry="update")
+    repository.resetmerge(parent="latest", cherry="update")
 
     assert not path2.exists()
 
 
-def test_resetmerge_resets_index(repository2: Repository, path: Path) -> None:
+def test_resetmerge_resets_index(repository: Repository, path: Path) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    createconflict(repository2.repository, path, ours="a", theirs="b")
+    createconflict(repository.repository, path, ours="a", theirs="b")
 
-    repository2.resetmerge(parent="latest", cherry="update")
+    repository.resetmerge(parent="latest", cherry="update")
 
     assert (
-        repository2.repository.index.write_tree()
-        == repository2.repository.head.peel().tree.id
+        repository.repository.index.write_tree()
+        == repository.repository.head.peel().tree.id
     )


### PR DESCRIPTION
- :recycle: [tests] Add `repository2` fixture for `git.Repository`
- :recycle: [services] Use `repository2` fixture in tests
- :recycle: [util] Use `repository2` fixture in tests
- :recycle: [util] Inline variable `repository`
- :recycle: [services] Inline variable `repository`
- :recycle: [tests] Remove fixture `repository`
- :recycle: [tests] Rename fixture to `repository`
