### PR TITLE
:recycle: Change `pygit2.Repository` variables to `git.Repository`

### DIFF
--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -25,23 +25,25 @@ class GitRepositoryObserver(FileStorageObserver):
     def commit(self) -> None:
         """A storage transaction was completed."""
         try:
-            repository = Repository.open(self.project).repository
+            repository = Repository.open(self.project)
         except pygit2.GitError:
-            repository = Repository.init(self.project).repository
+            repository = Repository.init(self.project)
 
-        if UPDATE_BRANCH in repository.branches:
+        if UPDATE_BRANCH in repository.repository.branches:
             # HEAD must point to update branch if it exists.
-            head = repository.references["HEAD"].target
+            head = repository.repository.references["HEAD"].target
             if head != UPDATE_BRANCH_REF:
                 raise RuntimeError(f"unexpected HEAD: {head}")
 
         message = (
             CREATE_MESSAGE
-            if LATEST_BRANCH not in repository.branches
+            if LATEST_BRANCH not in repository.repository.branches
             else UPDATE_MESSAGE
         )
 
-        Repository(repository).commit(message=message)
+        repository.commit(message=message)
 
-        if LATEST_BRANCH not in repository.branches:
-            repository.branches.create(LATEST_BRANCH, repository.head.peel())
+        if LATEST_BRANCH not in repository.repository.branches:
+            repository.repository.branches.create(
+                LATEST_BRANCH, repository.repository.head.peel()
+            )

--- a/src/cutty/filesystems/adapters/git.py
+++ b/src/cutty/filesystems/adapters/git.py
@@ -76,6 +76,6 @@ class GitFilesystem(NodeFilesystem):
 
     def __init__(self, repository: pathlib.Path, ref: str = "HEAD") -> None:
         """Inititalize."""
-        repo = Repository.open(repository).repository
-        tree = repo.revparse_single(ref).peel(pygit2.Tree)
+        repo = Repository.open(repository)
+        tree = repo.repository.revparse_single(ref).peel(pygit2.Tree)
         self.root = GitFilesystemNode(tree)

--- a/src/cutty/repositories/adapters/fetchers/git.py
+++ b/src/cutty/repositories/adapters/fetchers/git.py
@@ -21,8 +21,8 @@ def gitfetcher(
 ) -> None:
     """Fetch a git repository."""
     if destination.exists():
-        repository = Repository.open(destination).repository
-        for remote in repository.remotes:
+        repository = Repository.open(destination)
+        for remote in repository.repository.remotes:
             remote.fetch(prune=pygit2.GIT_FETCH_PRUNE)
     else:
         Repository.clone(str(url), destination)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -93,8 +93,8 @@ class Repository:
             if not checkout:
                 # Emulate `--no-checkout` by checking out an empty tree after the fact.
                 # https://github.com/libgit2/libgit2/issues/5949
-                worktreerepository = Repository.open(path).repository
-                checkoutemptytree(worktreerepository)
+                worktreerepository = Repository.open(path)
+                checkoutemptytree(worktreerepository.repository)
 
             yield path
 

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -27,14 +27,14 @@ def url(tmp_path: pathlib.Path) -> URL:
     path.mkdir()
     (path / "marker").write_text("Lorem")
 
-    repository = Repository.init(path).repository
-    repository.index.add("marker")
-    repository.create_commit(
+    repository = Repository.init(path)
+    repository.repository.index.add("marker")
+    repository.repository.create_commit(
         "HEAD",
         signature,
         signature,
         "Initial",
-        repository.index.write_tree(),
+        repository.repository.index.write_tree(),
         [],
     )
 
@@ -63,17 +63,17 @@ def test_gitfetcher_update(url: URL, store: Store) -> None:
     gitfetcher(url, store, None, FetchMode.ALWAYS)
 
     # Remove the marker file.
-    repository = Repository.open(aspath(url)).repository
-    tree = repository.head.peel(pygit2.Tree)
-    repository.index.read_tree(tree)
-    repository.index.remove("marker")
-    repository.create_commit(
+    repository = Repository.open(aspath(url))
+    tree = repository.repository.head.peel(pygit2.Tree)
+    repository.repository.index.read_tree(tree)
+    repository.repository.index.remove("marker")
+    repository.repository.create_commit(
         "HEAD",
         signature,
         signature,
         "Remove the marker file",
-        repository.index.write_tree(),
-        [repository.head.target],
+        repository.repository.index.write_tree(),
+        [repository.repository.head.target],
     )
 
     # Second fetch.
@@ -124,8 +124,8 @@ def test_broken_head_after_clone(
     """It works around a bug in libgit2 resulting in a broken HEAD reference."""
     destination = gitfetcher(url, store, None, FetchMode.ALWAYS)
     assert destination is not None
-    repository = Repository.open(destination).repository
-    head = repository.references["HEAD"]
+    repository = Repository.open(destination)
+    head = repository.repository.references["HEAD"]
     assert head.target != f"refs/heads/{custom_default_branch}"
 
 
@@ -136,13 +136,13 @@ def test_broken_head_after_clone_unexpected_branch(
     path = tmp_path / "repository"
     path.mkdir()
 
-    repository = Repository.init(path, head="refs/heads/whoops").repository
-    repository.create_commit(
+    repository = Repository.init(path, head="refs/heads/whoops")
+    repository.repository.create_commit(
         "HEAD",
         signature,
         signature,
         "Initial",
-        repository.index.write_tree(),
+        repository.repository.index.write_tree(),
         [],
     )
 

--- a/tests/unit/repositories/adapters/providers/test_git.py
+++ b/tests/unit/repositories/adapters/providers/test_git.py
@@ -25,34 +25,34 @@ def url(tmp_path: pathlib.Path) -> URL:
     path.mkdir()
     (path / "marker").write_text("Lorem")
 
-    repository = Repository.init(path).repository
-    repository.index.add("marker")
-    repository.create_commit(
+    repository = Repository.init(path)
+    repository.repository.index.add("marker")
+    repository.repository.create_commit(
         "HEAD",
         signature,
         signature,
         "Initial",
-        repository.index.write_tree(),
+        repository.repository.index.write_tree(),
         [],
     )
 
-    repository.create_tag(
+    repository.repository.create_tag(
         "v1.0",
-        repository.head.target,
+        repository.repository.head.target,
         pygit2.GIT_OBJ_COMMIT,
         signature,
         "Release v1.0",
     )
 
     (path / "marker").write_text("Ipsum")
-    repository.index.add("marker")
-    repository.create_commit(
+    repository.repository.index.add("marker")
+    repository.repository.create_commit(
         "HEAD",
         signature,
         signature,
         "Update marker",
-        repository.index.write_tree(),
-        [repository.head.target],
+        repository.repository.index.write_tree(),
+        [repository.repository.head.target],
     )
 
     return asurl(path)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -25,7 +25,7 @@ def createconflict(
 ) -> None:
     """Create an update conflict."""
     main = repository.head
-    update, _ = createbranches(repository, UPDATE_BRANCH, LATEST_BRANCH)
+    update, _ = createbranches(Repository(repository), UPDATE_BRANCH, LATEST_BRANCH)
 
     repository.checkout(update)
     updatefile(path, theirs)

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -107,7 +107,7 @@ def createconflict(
 ) -> None:
     """Create an update conflict."""
     main = repository.head
-    update, _ = createbranches(repository, "update", "latest")
+    update, _ = createbranches(Repository(repository), "update", "latest")
 
     repository.checkout(update)
     updatefile(path, theirs)
@@ -217,7 +217,7 @@ def test_resetmerge_removes_added_files(
 ) -> None:
     """It removes files added by the cherry-picked commit."""
     main = repository.repository.head
-    update, _ = createbranches(repository.repository, "update", "latest")
+    update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
     repository.repository.checkout(update)
@@ -239,7 +239,7 @@ def test_resetmerge_keeps_unrelated_additions(
 ) -> None:
     """It keeps additions of files that did not change in the update."""
     main = repository.repository.head
-    update, _ = createbranches(repository.repository, "update", "latest")
+    update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
     repository.repository.checkout(update)
@@ -263,7 +263,7 @@ def test_resetmerge_keeps_unrelated_changes(
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
     main = repository.repository.head
-    update, _ = createbranches(repository.repository, "update", "latest")
+    update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
     repository.repository.checkout(update)
@@ -288,7 +288,7 @@ def test_resetmerge_keeps_unrelated_deletions(
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
     main = repository.repository.head
-    update, _ = createbranches(repository.repository, "update", "latest")
+    update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
     repository.repository.checkout(update)

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -103,20 +103,20 @@ def test_createbranch_returns_branch(repository: Repository) -> None:
 
 
 def createconflict(
-    repository: pygit2.Repository, path: Path, *, ours: str, theirs: str
+    repository: Repository, path: Path, *, ours: str, theirs: str
 ) -> None:
     """Create an update conflict."""
-    main = repository.head
-    update, _ = createbranches(Repository(repository), "update", "latest")
+    main = repository.repository.head
+    update, _ = createbranches(repository, "update", "latest")
 
-    repository.checkout(update)
+    repository.repository.checkout(update)
     updatefile(path, theirs)
 
-    repository.checkout(main)
+    repository.repository.checkout(main)
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        Repository(repository).cherrypick(update.name, message="")
+        repository.cherrypick(update.name, message="")
 
 
 def test_createworktree_creates_worktree(repository: Repository) -> None:
@@ -206,7 +206,7 @@ def test_resetmerge_restores_files_with_conflicts(
     repository: Repository, path: Path
 ) -> None:
     """It restores the conflicting files in the working tree to our version."""
-    createconflict(repository.repository, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
     repository.resetmerge(parent="latest", cherry="update")
 
     assert path.read_text() == "a"
@@ -310,7 +310,7 @@ def test_resetmerge_keeps_unrelated_deletions(
 
 def test_resetmerge_resets_index(repository: Repository, path: Path) -> None:
     """It resets the index to HEAD, removing conflicts."""
-    createconflict(repository.repository, path, ours="a", theirs="b")
+    createconflict(repository, path, ours="a", theirs="b")
 
     repository.resetmerge(parent="latest", cherry="update")
 

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -15,13 +15,15 @@ def createbranches(repository: Repository, *names: str) -> tuple[pygit2.Branch, 
 
 def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) -> None:
     """Move all files in the repository to the given subdirectory."""
-    repository = Repository.open(repositorypath).repository
-    builder = repository.TreeBuilder()
-    builder.insert(directory, repository.head.peel().tree.id, pygit2.GIT_FILEMODE_TREE)
-    tree = repository[builder.write()]
-    repository.checkout_tree(tree)
+    repository = Repository.open(repositorypath)
+    builder = repository.repository.TreeBuilder()
+    builder.insert(
+        directory, repository.repository.head.peel().tree.id, pygit2.GIT_FILEMODE_TREE
+    )
+    tree = repository.repository[builder.write()]
+    repository.repository.checkout_tree(tree)
 
-    Repository(repository).commit(message=f"Move files to subdirectory {directory}")
+    repository.commit(message=f"Move files to subdirectory {directory}")
 
 
 def locaterepository(path: Path) -> Repository:
@@ -88,13 +90,13 @@ class Side(enum.Enum):
 
 def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
     """Resolve the conflicts."""
-    repository = Repository.open(repositorypath).repository
+    repository = Repository.open(repositorypath)
     pathstr = str(path.relative_to(repositorypath))
-    ancestor, ours, theirs = repository.index.conflicts[pathstr]
+    ancestor, ours, theirs = repository.repository.index.conflicts[pathstr]
     resolution = (ancestor, ours, theirs)[side.value]
 
-    del repository.index.conflicts[pathstr]
+    del repository.repository.index.conflicts[pathstr]
 
-    repository.index.add(resolution)
-    repository.index.write()
-    repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[pathstr])
+    repository.repository.index.add(resolution)
+    repository.repository.index.write()
+    repository.repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[pathstr])

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -8,12 +8,9 @@ import pygit2
 from cutty.util.git import Repository
 
 
-def createbranches(
-    repository: pygit2.Repository, *names: str
-) -> tuple[pygit2.Branch, ...]:
+def createbranches(repository: Repository, *names: str) -> tuple[pygit2.Branch, ...]:
     """Create branches at HEAD."""
-    repository2 = Repository(repository)
-    return tuple(repository2.createbranch(name) for name in names)
+    return tuple(repository.createbranch(name) for name in names)
 
 
 def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) -> None:


### PR DESCRIPTION
- :recycle: [tests] Change function `createbranches` to operate on `git.Repository`
- :recycle: [services] Change function `createconflict` to operate on `git.Repository`
- :recycle: [util] Change function `createconflict` to operate on `git.Repository`
- :recycle: [filestorage] Change variable to `git.Repository` in tests
- :recycle: [filestorage] Change variable to `git.Repository`
- :recycle: [tests] Change variable to `git.Repository`
- :recycle: [filesystems] Change variable to `git.Repository`
- :recycle: [util] Change variable to `git.Repository`
- :recycle: [repositories] Change variables to `git.Repository`
