### PR TITLE
:recycle: Hide delegate `git.Repository.repository` to encapsulate pygit2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ module = [
     "binaryornot.*",
     "jinja2_time",
     "pyftpdlib.*",
-    "pygit2",
+    "pygit2.*",
 ]
 ignore_missing_imports = true
 

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -29,7 +29,7 @@ class GitRepositoryObserver(FileStorageObserver):
         except pygit2.GitError:
             repository = Repository.init(self.project)
 
-        if UPDATE_BRANCH in repository.repository.branches:
+        if UPDATE_BRANCH in repository.branches:
             # HEAD must point to update branch if it exists.
             head = repository.repository.references["HEAD"].target
             if head != UPDATE_BRANCH_REF:
@@ -37,11 +37,11 @@ class GitRepositoryObserver(FileStorageObserver):
 
         message = (
             CREATE_MESSAGE
-            if LATEST_BRANCH not in repository.repository.branches
+            if LATEST_BRANCH not in repository.branches
             else UPDATE_MESSAGE
         )
 
         repository.commit(message=message)
 
-        if LATEST_BRANCH not in repository.repository.branches:
-            repository.repository.branches.create(LATEST_BRANCH, repository.head.peel())
+        if LATEST_BRANCH not in repository.branches:
+            repository.branches.create(LATEST_BRANCH, repository.head.peel())

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -31,7 +31,7 @@ class GitRepositoryObserver(FileStorageObserver):
 
         if UPDATE_BRANCH in repository.branches:
             # HEAD must point to update branch if it exists.
-            head = repository.repository.references["HEAD"].target
+            head = repository.references["HEAD"].target
             if head != UPDATE_BRANCH_REF:
                 raise RuntimeError(f"unexpected HEAD: {head}")
 

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -44,6 +44,4 @@ class GitRepositoryObserver(FileStorageObserver):
         repository.commit(message=message)
 
         if LATEST_BRANCH not in repository.repository.branches:
-            repository.repository.branches.create(
-                LATEST_BRANCH, repository.repository.head.peel()
-            )
+            repository.repository.branches.create(LATEST_BRANCH, repository.head.peel())

--- a/src/cutty/filesystems/adapters/git.py
+++ b/src/cutty/filesystems/adapters/git.py
@@ -8,7 +8,6 @@ from cutty.filesystems.domain.filesystem import Access
 from cutty.filesystems.domain.nodefs import FilesystemNode
 from cutty.filesystems.domain.nodefs import NodeFilesystem
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.util.git import Repository
 
 
 class GitFilesystemNode(FilesystemNode):
@@ -76,6 +75,6 @@ class GitFilesystem(NodeFilesystem):
 
     def __init__(self, repository: pathlib.Path, ref: str = "HEAD") -> None:
         """Inititalize."""
-        repo = Repository.open(repository)
-        tree = repo.repository.revparse_single(ref).peel(pygit2.Tree)
+        repo = pygit2.Repository(repository)
+        tree = repo.revparse_single(ref).peel(pygit2.Tree)
         self.root = GitFilesystemNode(tree)

--- a/src/cutty/repositories/adapters/fetchers/git.py
+++ b/src/cutty/repositories/adapters/fetchers/git.py
@@ -22,7 +22,7 @@ def gitfetcher(
     """Fetch a git repository."""
     if destination.exists():
         repository = Repository.open(destination)
-        for remote in repository.repository.remotes:
+        for remote in repository.remotes:
             remote.fetch(prune=pygit2.GIT_FETCH_PRUNE)
     else:
         Repository.clone(str(url), destination)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -73,6 +73,11 @@ class Repository:
         self.repository.set_head(target)
 
     @property
+    def references(self) -> pygit2.References:
+        """Return the repository references."""
+        return self.repository.references
+
+    @property
     def branches(self) -> pygit2.Branches:
         """Return the repository branches."""
         return self.repository.branches

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -63,6 +63,11 @@ class Repository:
         """Return the repository index."""
         return self.repository.index
 
+    @property
+    def head(self) -> pygit2.Reference:
+        """Return the repository head."""
+        return self.repository.head
+
     def commit(
         self, *, message: str = "", signature: Optional[pygit2.Signature] = None
     ) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -19,7 +19,7 @@ from cutty.compat.contextlib import contextmanager
 class Repository:
     """Git repository."""
 
-    repository: pygit2.Repository
+    _repository: pygit2.Repository
 
     @classmethod
     def open(cls, path: Path) -> Repository:
@@ -61,35 +61,35 @@ class Repository:
     @property
     def index(self) -> pygit2.Index:
         """Return the repository index."""
-        return self.repository.index
+        return self._repository.index
 
     @property
     def head(self) -> pygit2.Reference:
         """Return the repository head."""
-        return self.repository.head
+        return self._repository.head
 
     def set_head(self, target: str) -> None:
         """Update the repository head."""
-        self.repository.set_head(target)
+        self._repository.set_head(target)
 
     @property
     def references(self) -> pygit2.References:
         """Return the repository references."""
-        return self.repository.references
+        return self._repository.references
 
     @property
     def branches(self) -> pygit2.Branches:
         """Return the repository branches."""
-        return self.repository.branches
+        return self._repository.branches
 
     @property
     def remotes(self) -> pygit2.remote.RemoteCollection:
         """Return the repository remotes."""
-        return self.repository.remotes
+        return self._repository.remotes
 
     def checkout(self, reference: pygit2.Reference) -> None:
         """Check out the given reference."""
-        self.repository.checkout(reference)
+        self._repository.checkout(reference)
 
     def commit(
         self, *, message: str = "", signature: Optional[pygit2.Signature] = None
@@ -101,16 +101,16 @@ class Repository:
         self.index.add_all()
 
         tree = self.index.write_tree()
-        if not self.repository.head_is_unborn and tree == self.head.peel().tree.id:
+        if not self._repository.head_is_unborn and tree == self.head.peel().tree.id:
             return
 
         self.index.write()
 
         if signature is None:
-            signature = default_signature(self.repository)
+            signature = default_signature(self._repository)
 
-        parents = [] if self.repository.head_is_unborn else [self.head.target]
-        self.repository.create_commit(
+        parents = [] if self._repository.head_is_unborn else [self.head.target]
+        self._repository.create_commit(
             "HEAD", signature, signature, message, tree, parents
         )
 
@@ -120,15 +120,15 @@ class Repository:
         with tempfile.TemporaryDirectory() as directory:
             name = hashlib.blake2b(branch.encode(), digest_size=32).hexdigest()
             path = Path(directory) / name
-            worktree = self.repository.add_worktree(
-                name, path, self.repository.branches[branch]
+            worktree = self._repository.add_worktree(
+                name, path, self._repository.branches[branch]
             )
 
             if not checkout:
                 # Emulate `--no-checkout` by checking out an empty tree after the fact.
                 # https://github.com/libgit2/libgit2/issues/5949
                 worktreerepository = Repository.open(path)
-                checkoutemptytree(worktreerepository.repository)
+                checkoutemptytree(worktreerepository._repository)
 
             yield path
 
@@ -138,25 +138,25 @@ class Repository:
 
     def cherrypick(self, reference: str, *, message: str) -> None:
         """Cherry-pick the commit onto the current branch."""
-        oid = self.repository.references[reference].resolve().target
-        self.repository.cherrypick(oid)
+        oid = self._repository.references[reference].resolve().target
+        self._repository.cherrypick(oid)
 
-        if self.repository.index.conflicts:
+        if self._repository.index.conflicts:
             paths = {
                 side.path
-                for _, ours, theirs in self.repository.index.conflicts
+                for _, ours, theirs in self._repository.index.conflicts
                 for side in (ours, theirs)
                 if side is not None
             }
             raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
 
         self.commit(message=message)
-        self.repository.state_cleanup()
+        self._repository.state_cleanup()
 
     def createtag(self, name: str, *, message: str) -> None:
         """Create a tag at HEAD."""
-        signature = default_signature(self.repository)
-        self.repository.create_tag(
+        signature = default_signature(self._repository)
+        self._repository.create_tag(
             name, self.head.target, pygit2.GIT_OBJ_COMMIT, signature, message
         )
 
@@ -164,13 +164,13 @@ class Repository:
         self, branch: str, *, target: str = "HEAD", force: bool = False
     ) -> pygit2.Branch:
         """Create a branch pointing to the given target."""
-        commit = self.repository.revparse_single(target)
-        return self.repository.branches.create(branch, commit, force=force)
+        commit = self._repository.revparse_single(target)
+        return self._repository.branches.create(branch, commit, force=force)
 
     def updatebranch(self, branch: str, *, target: str) -> None:
         """Update a branch to the given target, another branch."""
-        commit = self.repository.branches[target].peel()
-        self.repository.branches[branch].set_target(commit.id)
+        commit = self._repository.branches[target].peel()
+        self._repository.branches[branch].set_target(commit.id)
 
     def resetmerge(self, parent: str, cherry: str) -> None:
         """Reset only files that were touched by a cherry-pick.
@@ -179,11 +179,11 @@ class Repository:
         files that were updated by the cherry-picked commit, and resetting the index
         to HEAD.
         """
-        self.repository.index.read_tree(self.repository.head.peel().tree)
-        self.repository.index.write()
+        self._repository.index.read_tree(self._repository.head.peel().tree)
+        self._repository.index.write()
 
-        parenttree = self.repository.branches[parent].peel(pygit2.Tree)
-        cherrytree = self.repository.branches[cherry].peel(pygit2.Tree)
+        parenttree = self._repository.branches[parent].peel(pygit2.Tree)
+        cherrytree = self._repository.branches[cherry].peel(pygit2.Tree)
         diff = cherrytree.diff_to_tree(parenttree)
         paths = [
             file.path
@@ -191,7 +191,7 @@ class Repository:
             for file in (delta.old_file, delta.new_file)
         ]
 
-        self.repository.checkout(
+        self._repository.checkout(
             strategy=pygit2.GIT_CHECKOUT_FORCE | pygit2.GIT_CHECKOUT_REMOVE_UNTRACKED,
             paths=paths,
         )

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -98,20 +98,21 @@ class Repository:
 
         If there are no changes relative to the parent, this is a noop.
         """
-        repository = self.repository
-        repository.index.add_all()
+        self.index.add_all()
 
-        tree = repository.index.write_tree()
-        if not repository.head_is_unborn and tree == repository.head.peel().tree.id:
+        tree = self.index.write_tree()
+        if not self.repository.head_is_unborn and tree == self.head.peel().tree.id:
             return
 
-        repository.index.write()
+        self.index.write()
 
         if signature is None:
-            signature = default_signature(repository)
+            signature = default_signature(self.repository)
 
-        parents = [] if repository.head_is_unborn else [repository.head.target]
-        repository.create_commit("HEAD", signature, signature, message, tree, parents)
+        parents = [] if self.repository.head_is_unborn else [self.head.target]
+        self.repository.create_commit(
+            "HEAD", signature, signature, message, tree, parents
+        )
 
     @contextmanager
     def createworktree(self, branch: str, *, checkout: bool = True) -> Iterator[Path]:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-import pygit2
+import pygit2.remote
 
 from cutty.compat.contextlib import contextmanager
 
@@ -81,6 +81,11 @@ class Repository:
     def branches(self) -> pygit2.Branches:
         """Return the repository branches."""
         return self.repository.branches
+
+    @property
+    def remotes(self) -> pygit2.remote.RemoteCollection:
+        """Return the repository remotes."""
+        return self.repository.remotes
 
     def commit(
         self, *, message: str = "", signature: Optional[pygit2.Signature] = None

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -68,6 +68,10 @@ class Repository:
         """Return the repository head."""
         return self.repository.head
 
+    def set_head(self, target: str) -> None:
+        """Update the repository head."""
+        self.repository.set_head(target)
+
     def commit(
         self, *, message: str = "", signature: Optional[pygit2.Signature] = None
     ) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -74,7 +74,7 @@ class Repository:
         self._repository.set_head(target)
 
     @property
-    def references(self) -> pygit2.References:
+    def references(self) -> pygit2.repository.References:
         """Return the repository references."""
         return self._repository.references
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -72,6 +72,11 @@ class Repository:
         """Update the repository head."""
         self.repository.set_head(target)
 
+    @property
+    def branches(self) -> pygit2.Branches:
+        """Return the repository branches."""
+        return self.repository.branches
+
     def commit(
         self, *, message: str = "", signature: Optional[pygit2.Signature] = None
     ) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -58,6 +58,11 @@ class Repository:
 
         _fix_repository_head(repository)
 
+    @property
+    def index(self) -> pygit2.Index:
+        """Return the repository index."""
+        return self.repository.index
+
     def commit(
         self, *, message: str = "", signature: Optional[pygit2.Signature] = None
     ) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Optional
 
 import pygit2.remote
+import pygit2.repository
 
 from cutty.compat.contextlib import contextmanager
 
@@ -78,7 +79,7 @@ class Repository:
         return self._repository.references
 
     @property
-    def branches(self) -> pygit2.Branches:
+    def branches(self) -> pygit2.repository.Branches:
         """Return the repository branches."""
         return self._repository.branches
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -87,6 +87,10 @@ class Repository:
         """Return the repository remotes."""
         return self.repository.remotes
 
+    def checkout(self, reference: pygit2.Reference) -> None:
+        """Check out the given reference."""
+        self.repository.checkout(reference)
+
     def commit(
         self, *, message: str = "", signature: Optional[pygit2.Signature] = None
     ) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -153,6 +153,13 @@ class Repository:
         self.commit(message=message)
         self.repository.state_cleanup()
 
+    def createtag(self, name: str, *, message: str) -> None:
+        """Create a tag at HEAD."""
+        signature = default_signature(self.repository)
+        self.repository.create_tag(
+            name, self.head.target, pygit2.GIT_OBJ_COMMIT, signature, message
+        )
+
     def createbranch(
         self, branch: str, *, target: str = "HEAD", force: bool = False
     ) -> pygit2.Branch:

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -70,7 +70,7 @@ def test_extra_context_invalid(runcutty: RunCutty, template: Path) -> None:
 
 def test_checkout(runcutty: RunCutty, template: Path) -> None:
     """It uses the specified revision of the template."""
-    initial = Repository.open(template).repository.head.target
+    initial = Repository.open(template).head.target
 
     updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -104,12 +104,12 @@ def test_remove(runcutty: RunCutty, templateproject: Path, project: Path) -> Non
 
 def test_noop(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does nothing if the generated project did not change."""
-    oldhead = Repository.open(project).repository.head.target
+    oldhead = Repository.open(project).head.target
 
     with chdir(project):
         runcutty("update")
 
-    assert oldhead == Repository.open(project).repository.head.target
+    assert oldhead == Repository.open(project).head.target
 
 
 def test_new_variables(runcutty: RunCutty, template: Path, project: Path) -> None:
@@ -288,7 +288,7 @@ def test_checkout(
     """It uses the specified revision of the template."""
     updatefile(templateproject / "LICENSE", "a")
 
-    revision = Repository.open(template).repository.head.target
+    revision = Repository.open(template).head.target
 
     updatefile(templateproject / "LICENSE", "b")
 

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -45,7 +45,7 @@ def test_repository(
     with storage:
         storage.add(file)
 
-    Repository.open(project).repository  # does not raise
+    Repository.open(project)  # does not raise
 
 
 def test_commit(storage: FileStorage, file: RegularFile, project: pathlib.Path) -> None:

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -63,7 +63,7 @@ def test_index(storage: FileStorage, file: RegularFile, project: pathlib.Path) -
         storage.add(file)
 
     repository = Repository.open(project)
-    assert file.path.name in repository.repository.index
+    assert file.path.name in repository.index
 
 
 def tree(repository: Repository) -> pygit2.Tree:

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -125,7 +125,7 @@ def test_branch(storage: FileStorage, file: RegularFile, project: pathlib.Path) 
         storage.add(file)
 
     repository = Repository.open(project)
-    reference = repository.repository.references[LATEST_BRANCH_REF]
+    reference = repository.references[LATEST_BRANCH_REF]
     assert repository.head.peel() == reference.peel()
 
 
@@ -137,7 +137,7 @@ def test_branch_not_checked_out(
         storage.add(file)
 
     repository = Repository.open(project)
-    assert repository.repository.references["HEAD"].target != LATEST_BRANCH_REF
+    assert repository.references["HEAD"].target != LATEST_BRANCH_REF
 
 
 def test_existing_branch(

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -148,7 +148,7 @@ def test_existing_branch(
     repository.commit()
 
     repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
-    repository.repository.set_head(UPDATE_BRANCH_REF)
+    repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
         storage.add(file)
@@ -181,7 +181,7 @@ def test_existing_branch_commit_message(
 
     repository.repository.branches.create(LATEST_BRANCH, repository.head.peel())
     repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
-    repository.repository.set_head(UPDATE_BRANCH_REF)
+    repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
         storage.add(file)
@@ -198,7 +198,7 @@ def test_existing_branch_no_changes(
     repository.commit()
 
     repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
-    repository.repository.set_head(UPDATE_BRANCH_REF)
+    repository.set_head(UPDATE_BRANCH_REF)
     oldhead = repository.head.target
 
     with storage:

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -54,7 +54,7 @@ def test_commit(storage: FileStorage, file: RegularFile, project: pathlib.Path) 
         storage.add(file)
 
     repository = Repository.open(project)
-    repository.repository.head  # does not raise
+    repository.head  # does not raise
 
 
 def test_index(storage: FileStorage, file: RegularFile, project: pathlib.Path) -> None:
@@ -68,7 +68,7 @@ def test_index(storage: FileStorage, file: RegularFile, project: pathlib.Path) -
 
 def tree(repository: Repository) -> pygit2.Tree:
     """Return the tree at the HEAD of the repository."""
-    return repository.repository.head.peel().tree
+    return repository.head.peel().tree
 
 
 def test_hook_edits(
@@ -126,7 +126,7 @@ def test_branch(storage: FileStorage, file: RegularFile, project: pathlib.Path) 
 
     repository = Repository.open(project)
     reference = repository.repository.references[LATEST_BRANCH_REF]
-    assert repository.repository.head.peel() == reference.peel()
+    assert repository.head.peel() == reference.peel()
 
 
 def test_branch_not_checked_out(
@@ -147,9 +147,7 @@ def test_existing_branch(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.repository.branches.create(
-        UPDATE_BRANCH, repository.repository.head.peel()
-    )
+    repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
@@ -165,9 +163,7 @@ def test_existing_branch_not_head(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.repository.branches.create(
-        UPDATE_BRANCH, repository.repository.head.peel()
-    )
+    repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
 
     with pytest.raises(Exception):
         with storage:
@@ -183,18 +179,14 @@ def test_existing_branch_commit_message(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.repository.branches.create(
-        LATEST_BRANCH, repository.repository.head.peel()
-    )
-    repository.repository.branches.create(
-        UPDATE_BRANCH, repository.repository.head.peel()
-    )
+    repository.repository.branches.create(LATEST_BRANCH, repository.head.peel())
+    repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
         storage.add(file)
 
-    commit_ = repository.repository.head.peel()
+    commit_ = repository.head.peel()
     assert "initial" not in commit_.message.lower()
 
 
@@ -205,13 +197,11 @@ def test_existing_branch_no_changes(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.repository.branches.create(
-        UPDATE_BRANCH, repository.repository.head.peel()
-    )
+    repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.repository.set_head(UPDATE_BRANCH_REF)
-    oldhead = repository.repository.head.target
+    oldhead = repository.head.target
 
     with storage:
         pass
 
-    assert oldhead == repository.repository.head.target
+    assert oldhead == repository.head.target

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -147,7 +147,7 @@ def test_existing_branch(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
@@ -163,7 +163,7 @@ def test_existing_branch_not_head(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    repository.branches.create(UPDATE_BRANCH, repository.head.peel())
 
     with pytest.raises(Exception):
         with storage:
@@ -179,8 +179,8 @@ def test_existing_branch_commit_message(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.repository.branches.create(LATEST_BRANCH, repository.head.peel())
-    repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    repository.branches.create(LATEST_BRANCH, repository.head.peel())
+    repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
@@ -197,7 +197,7 @@ def test_existing_branch_no_changes(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.repository.branches.create(UPDATE_BRANCH, repository.head.peel())
+    repository.branches.create(UPDATE_BRANCH, repository.head.peel())
     repository.set_head(UPDATE_BRANCH_REF)
     oldhead = repository.head.target
 

--- a/tests/unit/filesystems/adapters/test_git.py
+++ b/tests/unit/filesystems/adapters/test_git.py
@@ -7,7 +7,6 @@ import pytest
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.filesystems.domain.filesystem import Access
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.util.git import Repository
 
 
 @pytest.fixture
@@ -30,7 +29,7 @@ def filesystem(tmp_path: Path) -> GitFilesystem:
         builder.insert(name, tree.write(), pygit2.GIT_FILEMODE_TREE)
 
     signature = pygit2.Signature("you", "you@example.com")
-    repository = Repository.init(tmp_path).repository
+    repository = pygit2.init_repository(tmp_path)
 
     root = repository.TreeBuilder()
     root_dir = repository.TreeBuilder()

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -28,13 +28,13 @@ def url(tmp_path: pathlib.Path) -> URL:
     (path / "marker").write_text("Lorem")
 
     repository = Repository.init(path)
-    repository.repository.index.add("marker")
+    repository.index.add("marker")
     repository.repository.create_commit(
         "HEAD",
         signature,
         signature,
         "Initial",
-        repository.repository.index.write_tree(),
+        repository.index.write_tree(),
         [],
     )
 
@@ -65,14 +65,14 @@ def test_gitfetcher_update(url: URL, store: Store) -> None:
     # Remove the marker file.
     repository = Repository.open(aspath(url))
     tree = repository.repository.head.peel(pygit2.Tree)
-    repository.repository.index.read_tree(tree)
-    repository.repository.index.remove("marker")
+    repository.index.read_tree(tree)
+    repository.index.remove("marker")
     repository.repository.create_commit(
         "HEAD",
         signature,
         signature,
         "Remove the marker file",
-        repository.repository.index.write_tree(),
+        repository.index.write_tree(),
         [repository.repository.head.target],
     )
 
@@ -142,7 +142,7 @@ def test_broken_head_after_clone_unexpected_branch(
         signature,
         signature,
         "Initial",
-        repository.repository.index.write_tree(),
+        repository.index.write_tree(),
         [],
     )
 

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -125,7 +125,7 @@ def test_broken_head_after_clone(
     destination = gitfetcher(url, store, None, FetchMode.ALWAYS)
     assert destination is not None
     repository = Repository.open(destination)
-    head = repository.repository.references["HEAD"]
+    head = repository.references["HEAD"]
     assert head.target != f"refs/heads/{custom_default_branch}"
 
 

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -114,17 +114,8 @@ def test_broken_head_after_clone_unexpected_branch(
 ) -> None:
     """It crashes if the default branch is not master or main."""
     path = tmp_path / "repository"
-    path.mkdir()
-
     repository = Repository.init(path, head="refs/heads/whoops")
-    repository.repository.create_commit(
-        "HEAD",
-        signature,
-        signature,
-        "Initial",
-        repository.index.write_tree(),
-        [],
-    )
+    repository.commit()
 
     with pytest.raises(KeyError):
         gitfetcher(asurl(path), store, None, FetchMode.ALWAYS)

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -64,7 +64,7 @@ def test_gitfetcher_update(url: URL, store: Store) -> None:
 
     # Remove the marker file.
     repository = Repository.open(aspath(url))
-    tree = repository.repository.head.peel(pygit2.Tree)
+    tree = repository.head.peel(pygit2.Tree)
     repository.index.read_tree(tree)
     repository.index.remove("marker")
     repository.repository.create_commit(
@@ -73,7 +73,7 @@ def test_gitfetcher_update(url: URL, store: Store) -> None:
         signature,
         "Remove the marker file",
         repository.index.write_tree(),
-        [repository.repository.head.target],
+        [repository.head.target],
     )
 
     # Second fetch.

--- a/tests/unit/repositories/adapters/providers/test_git.py
+++ b/tests/unit/repositories/adapters/providers/test_git.py
@@ -26,13 +26,13 @@ def url(tmp_path: pathlib.Path) -> URL:
     (path / "marker").write_text("Lorem")
 
     repository = Repository.init(path)
-    repository.repository.index.add("marker")
+    repository.index.add("marker")
     repository.repository.create_commit(
         "HEAD",
         signature,
         signature,
         "Initial",
-        repository.repository.index.write_tree(),
+        repository.index.write_tree(),
         [],
     )
 
@@ -45,13 +45,13 @@ def url(tmp_path: pathlib.Path) -> URL:
     )
 
     (path / "marker").write_text("Ipsum")
-    repository.repository.index.add("marker")
+    repository.index.add("marker")
     repository.repository.create_commit(
         "HEAD",
         signature,
         signature,
         "Update marker",
-        repository.repository.index.write_tree(),
+        repository.index.write_tree(),
         [repository.repository.head.target],
     )
 

--- a/tests/unit/repositories/adapters/providers/test_git.py
+++ b/tests/unit/repositories/adapters/providers/test_git.py
@@ -13,6 +13,7 @@ from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.stores import Store
 from cutty.util.git import Repository
+from tests.util.git import updatefile
 
 
 signature = pygit2.Signature("you", "you@example.com")
@@ -22,19 +23,8 @@ signature = pygit2.Signature("you", "you@example.com")
 def url(tmp_path: pathlib.Path) -> URL:
     """Fixture for a repository."""
     path = tmp_path / "repository"
-    path.mkdir()
-    (path / "marker").write_text("Lorem")
-
     repository = Repository.init(path)
-    repository.index.add("marker")
-    repository.repository.create_commit(
-        "HEAD",
-        signature,
-        signature,
-        "Initial",
-        repository.index.write_tree(),
-        [],
-    )
+    updatefile(path / "marker", "Lorem")
 
     repository.repository.create_tag(
         "v1.0",
@@ -44,16 +34,7 @@ def url(tmp_path: pathlib.Path) -> URL:
         "Release v1.0",
     )
 
-    (path / "marker").write_text("Ipsum")
-    repository.index.add("marker")
-    repository.repository.create_commit(
-        "HEAD",
-        signature,
-        signature,
-        "Update marker",
-        repository.index.write_tree(),
-        [repository.head.target],
-    )
+    updatefile(path / "marker", "Ipsum")
 
     return asurl(path)
 

--- a/tests/unit/repositories/adapters/providers/test_git.py
+++ b/tests/unit/repositories/adapters/providers/test_git.py
@@ -38,7 +38,7 @@ def url(tmp_path: pathlib.Path) -> URL:
 
     repository.repository.create_tag(
         "v1.0",
-        repository.repository.head.target,
+        repository.head.target,
         pygit2.GIT_OBJ_COMMIT,
         signature,
         "Release v1.0",
@@ -52,7 +52,7 @@ def url(tmp_path: pathlib.Path) -> URL:
         signature,
         "Update marker",
         repository.index.write_tree(),
-        [repository.repository.head.target],
+        [repository.head.target],
     )
 
     return asurl(path)

--- a/tests/unit/repositories/adapters/providers/test_git.py
+++ b/tests/unit/repositories/adapters/providers/test_git.py
@@ -26,14 +26,7 @@ def url(tmp_path: pathlib.Path) -> URL:
     repository = Repository.init(path)
     updatefile(path / "marker", "Lorem")
 
-    repository.repository.create_tag(
-        "v1.0",
-        repository.head.target,
-        pygit2.GIT_OBJ_COMMIT,
-        signature,
-        "Release v1.0",
-    )
-
+    repository.createtag("v1.0", message="Release v1.0")
     updatefile(path / "marker", "Ipsum")
 
     return asurl(path)

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -23,7 +23,7 @@ def createconflict(
     repository: Repository, path: Path, *, ours: str, theirs: str
 ) -> None:
     """Create an update conflict."""
-    main = repository.repository.head
+    main = repository.head
     update, _ = createbranches(repository, UPDATE_BRANCH, LATEST_BRANCH)
 
     repository.repository.checkout(update)
@@ -46,7 +46,7 @@ def test_continueupdate_commits_changes(
     with chdir(repositorypath):
         continueupdate()
 
-    blob = repository.repository.head.peel().tree / path.name
+    blob = repository.head.peel().tree / path.name
     assert blob.data == b"b"
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -60,7 +60,7 @@ def test_continueupdate_fastforwards_latest(
     with chdir(repositorypath):
         continueupdate()
 
-    branches = repository.repository.branches
+    branches = repository.branches
     assert branches[LATEST_BRANCH].peel() == branches[UPDATE_BRANCH].peel()
 
 
@@ -70,12 +70,12 @@ def test_skipupdate_fastforwards_latest(
     """It fast-forwards the latest branch to the tip of the update branch."""
     createconflict(repository, path, ours="a", theirs="b")
 
-    updatehead = repository.repository.branches[UPDATE_BRANCH].peel()
+    updatehead = repository.branches[UPDATE_BRANCH].peel()
 
     with chdir(repositorypath):
         skipupdate()
 
-    assert repository.repository.branches[LATEST_BRANCH].peel() == updatehead
+    assert repository.branches[LATEST_BRANCH].peel() == updatehead
 
 
 def test_abortupdate_rewinds_update_branch(
@@ -84,7 +84,7 @@ def test_abortupdate_rewinds_update_branch(
     """It resets the update branch to the tip of the latest branch."""
     createconflict(repository, path, ours="a", theirs="b")
 
-    branches = repository.repository.branches
+    branches = repository.branches
     latesthead = branches[LATEST_BRANCH].peel()
 
     with chdir(repositorypath):

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -26,10 +26,10 @@ def createconflict(
     main = repository.head
     update, _ = createbranches(repository, UPDATE_BRANCH, LATEST_BRANCH)
 
-    repository.repository.checkout(update)
+    repository.checkout(update)
     updatefile(path, theirs)
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -70,10 +70,10 @@ def test_createbranch_target_branch(repository: Repository) -> None:
     main = repository.head
     branch1 = repository.createbranch("branch1")
 
-    repository.repository.checkout(branch1)
+    repository.checkout(branch1)
     repository.commit()
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     repository.createbranch("branch2", target="branch1")
     branch2 = repository.branches["branch2"]
 
@@ -106,10 +106,10 @@ def createconflict(
     main = repository.head
     update, _ = createbranches(repository, "update", "latest")
 
-    repository.repository.checkout(update)
+    repository.checkout(update)
     updatefile(path, theirs)
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
@@ -157,10 +157,10 @@ def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:
     main = repository.head
     branch = repository.createbranch("branch")
 
-    repository.repository.checkout(branch)
+    repository.checkout(branch)
     updatefile(path)
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     assert not path.is_file()
 
     repository.cherrypick(branch.name, message="")
@@ -172,10 +172,10 @@ def test_cherrypick_conflict_edit(repository: Repository, path: Path) -> None:
     main = repository.head
     branch = repository.createbranch("branch")
 
-    repository.repository.checkout(branch)
+    repository.checkout(branch)
     updatefile(path, "a")
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
@@ -189,10 +189,10 @@ def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> Non
     main = repository.head
     branch = repository.createbranch("branch")
 
-    repository.repository.checkout(branch)
+    repository.checkout(branch)
     updatefile(path, "b")
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):
@@ -217,10 +217,10 @@ def test_resetmerge_removes_added_files(
     update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository.repository.checkout(update)
+    repository.checkout(update)
     updatefiles({path1: "a", path2: ""})
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     updatefile(path1, "b")
 
     with pytest.raises(Exception, match=path1.name):
@@ -239,10 +239,10 @@ def test_resetmerge_keeps_unrelated_additions(
     update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository.repository.checkout(update)
+    repository.checkout(update)
     updatefile(path1, "a")
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     updatefile(path1, "b")
 
     path2.touch()
@@ -263,10 +263,10 @@ def test_resetmerge_keeps_unrelated_changes(
     update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository.repository.checkout(update)
+    repository.checkout(update)
     updatefile(path1, "a")
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     updatefile(path1, "b")
     updatefile(path2)
 
@@ -288,10 +288,10 @@ def test_resetmerge_keeps_unrelated_deletions(
     update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
-    repository.repository.checkout(update)
+    repository.checkout(update)
     updatefile(path1, "a")
 
-    repository.repository.checkout(main)
+    repository.checkout(main)
     updatefile(path1, "b")
     updatefile(path2)
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -62,7 +62,7 @@ def test_createbranch_target_default(repository: Repository) -> None:
     """It creates the branch at HEAD by default."""
     repository.createbranch("branch")
 
-    assert repository.repository.branches["branch"].peel() == repository.head.peel()
+    assert repository.branches["branch"].peel() == repository.head.peel()
 
 
 def test_createbranch_target_branch(repository: Repository) -> None:
@@ -75,7 +75,7 @@ def test_createbranch_target_branch(repository: Repository) -> None:
 
     repository.repository.checkout(main)
     repository.createbranch("branch2", target="branch1")
-    branch2 = repository.repository.branches["branch2"]
+    branch2 = repository.branches["branch2"]
 
     assert branch1.peel() == branch2.peel()
 
@@ -88,7 +88,7 @@ def test_createbranch_target_oid(repository: Repository) -> None:
     repository.commit()
 
     repository.createbranch("branch", target=str(oid))
-    branch = repository.repository.branches["branch"]
+    branch = repository.branches["branch"]
 
     assert oid == branch.peel().id
 
@@ -96,7 +96,7 @@ def test_createbranch_target_oid(repository: Repository) -> None:
 def test_createbranch_returns_branch(repository: Repository) -> None:
     """It returns the branch object."""
     branch = repository.createbranch("branch")
-    assert branch == repository.repository.branches["branch"]
+    assert branch == repository.branches["branch"]
 
 
 def createconflict(

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -314,7 +314,4 @@ def test_resetmerge_resets_index(repository: Repository, path: Path) -> None:
 
     repository.resetmerge(parent="latest", cherry="update")
 
-    assert (
-        repository.repository.index.write_tree()
-        == repository.repository.head.peel().tree.id
-    )
+    assert repository.index.write_tree() == repository.repository.head.peel().tree.id

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -25,16 +25,16 @@ def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     repository = Repository.init(tmp_path / "repository")
     repository.commit(message="initial")
 
-    assert not repository.repository.head.peel().parents
+    assert not repository.head.peel().parents
 
 
 def test_commit_empty(repository: Repository) -> None:
     """It does not produce an empty commit (unless the branch is unborn)."""
-    head = repository.repository.head.peel()
+    head = repository.head.peel()
 
     repository.commit(message="empty")
 
-    assert head == repository.repository.head.peel()
+    assert head == repository.head.peel()
 
 
 def test_commit_signature(repository: Repository, repositorypath: Path) -> None:
@@ -44,7 +44,7 @@ def test_commit_signature(repository: Repository, repositorypath: Path) -> None:
     signature = pygit2.Signature("Katherine", "katherine@example.com")
     repository.commit(message="empty", signature=signature)
 
-    head = repository.repository.head.peel()
+    head = repository.head.peel()
     assert signature.name == head.author.name and signature.email == head.author.email
 
 
@@ -54,7 +54,7 @@ def test_commit_message_default(repository: Repository, repositorypath: Path) ->
 
     repository.commit()
 
-    head = repository.repository.head.peel()
+    head = repository.head.peel()
     assert "" == head.message
 
 
@@ -62,15 +62,12 @@ def test_createbranch_target_default(repository: Repository) -> None:
     """It creates the branch at HEAD by default."""
     repository.createbranch("branch")
 
-    assert (
-        repository.repository.branches["branch"].peel()
-        == repository.repository.head.peel()
-    )
+    assert repository.repository.branches["branch"].peel() == repository.head.peel()
 
 
 def test_createbranch_target_branch(repository: Repository) -> None:
     """It creates the branch at the head of the given branch."""
-    main = repository.repository.head
+    main = repository.head
     branch1 = repository.createbranch("branch1")
 
     repository.repository.checkout(branch1)
@@ -85,7 +82,7 @@ def test_createbranch_target_branch(repository: Repository) -> None:
 
 def test_createbranch_target_oid(repository: Repository) -> None:
     """It creates the branch at the commit with the given OID."""
-    main = repository.repository.head
+    main = repository.head
     oid = main.peel().id
 
     repository.commit()
@@ -106,7 +103,7 @@ def createconflict(
     repository: Repository, path: Path, *, ours: str, theirs: str
 ) -> None:
     """Create an update conflict."""
-    main = repository.repository.head
+    main = repository.head
     update, _ = createbranches(repository, "update", "latest")
 
     repository.repository.checkout(update)
@@ -157,7 +154,7 @@ def test_createworktree_no_checkout(repository: Repository, path: Path) -> None:
 
 def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:
     """It cherry-picks the commit onto the current branch."""
-    main = repository.repository.head
+    main = repository.head
     branch = repository.createbranch("branch")
 
     repository.repository.checkout(branch)
@@ -172,7 +169,7 @@ def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:
 
 def test_cherrypick_conflict_edit(repository: Repository, path: Path) -> None:
     """It raises an exception when both sides modified the file."""
-    main = repository.repository.head
+    main = repository.head
     branch = repository.createbranch("branch")
 
     repository.repository.checkout(branch)
@@ -189,7 +186,7 @@ def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> Non
     """It raises an exception when one side modified and the other deleted the file."""
     updatefile(path, "a")
 
-    main = repository.repository.head
+    main = repository.head
     branch = repository.createbranch("branch")
 
     repository.repository.checkout(branch)
@@ -216,7 +213,7 @@ def test_resetmerge_removes_added_files(
     repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It removes files added by the cherry-picked commit."""
-    main = repository.repository.head
+    main = repository.head
     update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
@@ -238,7 +235,7 @@ def test_resetmerge_keeps_unrelated_additions(
     repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps additions of files that did not change in the update."""
-    main = repository.repository.head
+    main = repository.head
     update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
@@ -262,7 +259,7 @@ def test_resetmerge_keeps_unrelated_changes(
     repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
-    main = repository.repository.head
+    main = repository.head
     update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
@@ -287,7 +284,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
-    main = repository.repository.head
+    main = repository.head
     update, _ = createbranches(repository, "update", "latest")
     path1, path2 = next(paths), next(paths)
 
@@ -314,4 +311,4 @@ def test_resetmerge_resets_index(repository: Repository, path: Path) -> None:
 
     repository.resetmerge(parent="latest", cherry="update")
 
-    assert repository.index.write_tree() == repository.repository.head.peel().tree.id
+    assert repository.index.write_tree() == repository.head.peel().tree.id

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -15,12 +15,13 @@ def createbranches(repository: Repository, *names: str) -> tuple[pygit2.Branch, 
 
 def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) -> None:
     """Move all files in the repository to the given subdirectory."""
-    repository = Repository.open(repositorypath)
-    builder = repository.repository.TreeBuilder()
-    builder.insert(directory, repository.head.peel().tree.id, pygit2.GIT_FILEMODE_TREE)
-    tree = repository.repository[builder.write()]
-    repository.repository.checkout_tree(tree)
+    subdirectory = repositorypath / directory
+    for path in repositorypath.iterdir():
+        if path.name != ".git":
+            subdirectory.mkdir(exist_ok=True)
+            path.rename(subdirectory / path.name)
 
+    repository = Repository.open(repositorypath)
     repository.commit(message=f"Move files to subdirectory {directory}")
 
 

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -92,11 +92,11 @@ def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
     """Resolve the conflicts."""
     repository = Repository.open(repositorypath)
     pathstr = str(path.relative_to(repositorypath))
-    ancestor, ours, theirs = repository.repository.index.conflicts[pathstr]
+    ancestor, ours, theirs = repository.index.conflicts[pathstr]
     resolution = (ancestor, ours, theirs)[side.value]
 
-    del repository.repository.index.conflicts[pathstr]
+    del repository.index.conflicts[pathstr]
 
-    repository.repository.index.add(resolution)
-    repository.repository.index.write()
+    repository.index.add(resolution)
+    repository.index.write()
     repository.repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[pathstr])

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -88,8 +88,8 @@ class Side(enum.Enum):
 
 
 def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
-    """Resolve the conflicts."""
-    repository = Repository.open(repositorypath)
+    """Resolve conflicts in the given file."""
+    repository = pygit2.Repository(repositorypath)
     pathstr = str(path.relative_to(repositorypath))
     ancestor, ours, theirs = repository.index.conflicts[pathstr]
     resolution = (ancestor, ours, theirs)[side.value]
@@ -98,4 +98,4 @@ def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
 
     repository.index.add(resolution)
     repository.index.write()
-    repository.repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[pathstr])
+    repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[pathstr])

--- a/tests/util/git.py
+++ b/tests/util/git.py
@@ -17,9 +17,7 @@ def move_repository_files_to_subdirectory(repositorypath: Path, directory: str) 
     """Move all files in the repository to the given subdirectory."""
     repository = Repository.open(repositorypath)
     builder = repository.repository.TreeBuilder()
-    builder.insert(
-        directory, repository.repository.head.peel().tree.id, pygit2.GIT_FILEMODE_TREE
-    )
+    builder.insert(directory, repository.head.peel().tree.id, pygit2.GIT_FILEMODE_TREE)
     tree = repository.repository[builder.write()]
     repository.repository.checkout_tree(tree)
 


### PR DESCRIPTION
- :recycle: [util] Add property `git.Repository.index`
- :recycle: [tests] Replace inline code with `git.Repository.index`
- :recycle: [util] Add property `git.Repository.head`
- :recycle: Replace inline code with `git.Repository.head`
- :recycle: [util] Add `git.Repository.set_head`
- :recycle: [filestorage] Replace inline code with `git.Repository.set_head`
- :recycle: Replace inline code with `git.Repository.branches`
- :recycle: [util] Add `git.Repository.references`
- :recycle: Replace inline code with `git.Repository.references`
- :recycle: [util] Add `git.Repository.remotes`
- :wrench: [mypy] Ignore missing imports for pygit2.*
- :recycle: [repositories] Replace inline code with `git.Repository.remotes`
- :recycle: [util] Add `git.Repository.checkout`
- :recycle: Replace inline code with `git.Repository.checkout`
- :recycle: [repositories] Replace inline code with `updatefile` and `removefile`
- :recycle: [repositories] Replace inline code with `git.Repository.commit`
- :recycle: [util] Inline variable `repository` in `git.Repository.commit`
- :recycle: [util] Extract function `git.Repository.createtag`
- :recycle: [filesystems] Depend on pygit2 directly instead of `git.Repository`
- :recycle: [util] Substitute algorithm of `move_repository_files_to_subdirectory`
- :recycle: [tests] Depend on pygit2 directly in `resolveconflicts`
- :recycle: [tests] Hide delegate `Repository.repository`
- :recycle: [util] Rename attribute to `git.Repository._repository`
