### PR TITLE
:recycle: Move `default_signature` and `checkoutemptytree` to `git.Repository`

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -128,8 +128,7 @@ class Repository:
             if not checkout:
                 # Emulate `--no-checkout` by checking out an empty tree after the fact.
                 # https://github.com/libgit2/libgit2/issues/5949
-                worktreerepository = Repository.open(path)
-                worktreerepository._checkoutemptytree()
+                Repository.open(path)._checkoutemptytree()
 
             yield path
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -92,6 +92,16 @@ class Repository:
         """Check out the given reference."""
         self._repository.checkout(reference)
 
+    @property
+    def default_signature(self) -> pygit2.Signature:
+        """Return the default signature."""
+        with contextlib.suppress(KeyError):
+            return pygit2.Signature(
+                os.environ["GIT_AUTHOR_NAME"],
+                os.environ["GIT_AUTHOR_EMAIL"],
+            )
+        return self._repository.default_signature  # pragma: no cover
+
     def commit(
         self, *, message: str = "", signature: Optional[pygit2.Signature] = None
     ) -> None:
@@ -108,7 +118,7 @@ class Repository:
         self.index.write()
 
         if signature is None:
-            signature = default_signature(self._repository)
+            signature = self.default_signature
 
         parents = [] if self._repository.head_is_unborn else [self.head.target]
         self._repository.create_commit(
@@ -160,9 +170,12 @@ class Repository:
 
     def createtag(self, name: str, *, message: str) -> None:
         """Create a tag at HEAD."""
-        signature = default_signature(self._repository)
         self._repository.create_tag(
-            name, self.head.target, pygit2.GIT_OBJ_COMMIT, signature, message
+            name,
+            self.head.target,
+            pygit2.GIT_OBJ_COMMIT,
+            self.default_signature,
+            message,
         )
 
     def createbranch(
@@ -221,13 +234,3 @@ def _fix_repository_head(repository: pygit2.Repository) -> pygit2.Reference:
             break
 
     return head.resolve()
-
-
-def default_signature(repository: pygit2.Repository) -> pygit2.Signature:
-    """Return the default signature."""
-    with contextlib.suppress(KeyError):
-        return pygit2.Signature(
-            os.environ["GIT_AUTHOR_NAME"],
-            os.environ["GIT_AUTHOR_EMAIL"],
-        )
-    return repository.default_signature  # pragma: no cover

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -129,13 +129,18 @@ class Repository:
                 # Emulate `--no-checkout` by checking out an empty tree after the fact.
                 # https://github.com/libgit2/libgit2/issues/5949
                 worktreerepository = Repository.open(path)
-                checkoutemptytree(worktreerepository._repository)
+                worktreerepository._checkoutemptytree()
 
             yield path
 
         # Prune with `force=True` because libgit2 thinks `worktree.path` still exists.
         # https://github.com/libgit2/libgit2/issues/5280
         worktree.prune(True)
+
+    def _checkoutemptytree(self) -> None:
+        """Check out an empty tree from the repository."""
+        oid = self._repository.TreeBuilder().write()
+        self._repository.checkout_tree(self._repository[oid])
 
     def cherrypick(self, reference: str, *, message: str) -> None:
         """Cherry-pick the commit onto the current branch."""
@@ -227,9 +232,3 @@ def default_signature(repository: pygit2.Repository) -> pygit2.Signature:
             os.environ["GIT_AUTHOR_EMAIL"],
         )
     return repository.default_signature  # pragma: no cover
-
-
-def checkoutemptytree(repository: pygit2.Repository) -> None:
-    """Check out an empty tree from the repository."""
-    oid = repository.TreeBuilder().write()
-    repository.checkout_tree(repository[oid])


### PR DESCRIPTION
- :recycle: [util] Move function `checkoutemptytree` to `git.Repository._checkoutemptytree`
- :recycle: [util] Inline variable `worktreerepository`
- :recycle: [util] Move function `default_signature` to `git.Repository`
