### PR TITLE
:recycle: Encapsulate branches as `git.Branch` and add `git.Branches.{create,head,branch}`

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -51,6 +51,7 @@ class Branches(MutableMapping[str, pygit2.Commit]):
 
     def branch(self, name: str) -> Branch:
         """Return the branch with the given name."""
+        self[name]
         return Branch(self, name)
 
 
@@ -61,7 +62,6 @@ class Branch:
         """Initialize."""
         self._branches = branches
         self._name = name
-        self.commit  # raise KeyError on creation
 
     @property
     def name(self) -> str:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -52,20 +52,26 @@ class Branches(MutableMapping[str, pygit2.Commit]):
     def branch(self, name: str) -> Branch:
         """Return the branch with the given name."""
         self[name]
-        return Branch(name)
+        return Branch(self, name)
 
 
 class Branch:
     """Branch in a git repository."""
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, branches: Branches, name: str) -> None:
         """Initialize."""
+        self._branches = branches
         self._name = name
 
     @property
     def name(self) -> str:
         """Return the name of the branch."""
         return self._name
+
+    @property
+    def commit(self) -> pygit2.Commit:
+        """Return the commit at the head of branch."""
+        return self._branches[self._name]
 
 
 @dataclass

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -60,7 +60,12 @@ class Branch:
 
     def __init__(self, name: str) -> None:
         """Initialize."""
-        self.name = name
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        """Return the name of the branch."""
+        return self._name
 
 
 @dataclass

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -51,7 +51,6 @@ class Branches(MutableMapping[str, pygit2.Commit]):
 
     def branch(self, name: str) -> Branch:
         """Return the branch with the given name."""
-        self[name]
         return Branch(self, name)
 
 
@@ -62,6 +61,7 @@ class Branch:
         """Initialize."""
         self._branches = branches
         self._name = name
+        self.commit  # raise KeyError on creation
 
     @property
     def name(self) -> str:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -54,9 +54,11 @@ class Branches(MutableMapping[str, pygit2.Commit]):
         self[name]
         return Branch(self, name)
 
-    def create(self, name: str, commit: pygit2.Commit) -> Branch:
+    def create(
+        self, name: str, commit: pygit2.Commit, *, force: bool = False
+    ) -> Branch:
         """Create the branch with the given name and commit."""
-        self._branches.create(name, commit)
+        self._branches.create(name, commit, force=force)
         return Branch(self, name)
 
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -49,6 +49,13 @@ class Branches(MutableMapping[str, pygit2.Commit]):
         """Remove the branch."""
         self._branches.delete(name)
 
+    @property
+    def head(self) -> Branch:
+        """Return the branch referenced by HEAD."""
+        head = self._branches._repository.references["HEAD"]
+        name = head.target.removeprefix("refs/heads/")
+        return Branch(self, name)
+
     def branch(self, name: str) -> Branch:
         """Return the branch with the given name."""
         self[name]

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -54,6 +54,11 @@ class Branches(MutableMapping[str, pygit2.Commit]):
         self[name]
         return Branch(self, name)
 
+    def create(self, name: str, commit: pygit2.Commit) -> Branch:
+        """Create the branch with the given name and commit."""
+        self[name] = commit
+        return Branch(self, name)
+
 
 class Branch:
     """Branch in a git repository."""

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -73,6 +73,11 @@ class Branch:
         """Return the commit at the head of branch."""
         return self._branches[self._name]
 
+    @commit.setter
+    def commit(self, commit: pygit2.Commit) -> None:
+        """Reset the branch to another commit."""
+        self._branches[self._name] = commit
+
 
 @dataclass
 class Repository:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -56,7 +56,7 @@ class Branches(MutableMapping[str, pygit2.Commit]):
 
     def create(self, name: str, commit: pygit2.Commit) -> Branch:
         """Create the branch with the given name and commit."""
-        self[name] = commit
+        self._branches.create(name, commit)
         return Branch(self, name)
 
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -49,6 +49,10 @@ class Branches(MutableMapping[str, pygit2.Commit]):
         """Remove the branch."""
         self._branches.delete(name)
 
+    def branch(self, name: str) -> None:
+        """Return the branch with the given name."""
+        raise KeyError(name)
+
 
 @dataclass
 class Repository:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -62,10 +62,14 @@ class Branches(MutableMapping[str, pygit2.Commit]):
         return Branch(self, name)
 
     def create(
-        self, name: str, commit: pygit2.Commit, *, force: bool = False
+        self, name: str, commit: Optional[pygit2.Commit] = None, *, force: bool = False
     ) -> Branch:
         """Create the branch with the given name and commit."""
+        if commit is None:
+            commit = self.head.commit
+
         self._branches.create(name, commit, force=force)
+
         return Branch(self, name)
 
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -49,9 +49,18 @@ class Branches(MutableMapping[str, pygit2.Commit]):
         """Remove the branch."""
         self._branches.delete(name)
 
-    def branch(self, name: str) -> None:
+    def branch(self, name: str) -> Branch:
         """Return the branch with the given name."""
-        raise KeyError(name)
+        self[name]
+        return Branch(name)
+
+
+class Branch:
+    """Branch in a git repository."""
+
+    def __init__(self, name: str) -> None:
+        """Initialize."""
+        self.name = name
 
 
 @dataclass

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -139,7 +139,7 @@ def test_branch_commit_get(repository: Repository) -> None:
     """It returns the commit at the head of the branch."""
     main = repository.references["HEAD"].target.removeprefix("refs/heads/")
     branch = repository.branches.branch(main)
-    assert repository.head.peel() == branch.commit
+    assert repository.branches[main] == branch.commit
 
 
 def test_discover_fail(tmp_path: Path) -> None:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -154,6 +154,14 @@ def test_branches_create_existing_branch_force(repository: Repository) -> None:
     assert branches[main] == branch.commit
 
 
+def test_branches_create_default_commit(repository: Repository) -> None:
+    """It creates the branch at the commit referenced by HEAD."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    branches = repository.branches
+    branch = branches.create("branch")
+    assert branches[main] == branch.commit
+
+
 def test_branches_head_name(repository: Repository) -> None:
     """It returns the branch whose name is contained in HEAD."""
     main = repository.references["HEAD"].target.removeprefix("refs/heads/")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -132,7 +132,7 @@ def test_branch_name_set(repository: Repository) -> None:
     main = repository.references["HEAD"].target.removeprefix("refs/heads/")
     branch = repository.branches.branch(main)
     with pytest.raises(AttributeError):
-        branch.name = "teapot"
+        branch.name = "teapot"  # type: ignore[misc]
 
 
 def test_discover_fail(tmp_path: Path) -> None:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -127,6 +127,14 @@ def test_branch_name_get(repository: Repository) -> None:
     assert main == branch.name
 
 
+def test_branch_name_set(repository: Repository) -> None:
+    """It raises AttributeError when the name is set."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    branch = repository.branches.branch(main)
+    with pytest.raises(AttributeError):
+        branch.name = "teapot"
+
+
 def test_discover_fail(tmp_path: Path) -> None:
     """It returns None."""
     assert None is Repository.discover(tmp_path)

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -142,6 +142,17 @@ def test_branch_commit_get(repository: Repository) -> None:
     assert repository.branches[main] == branch.commit
 
 
+def test_branch_commit_set(repository: Repository) -> None:
+    """It resets the branch to the given commit."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    branches = repository.branches
+    branches["branch"] = branches[main]
+    updatefile(repository.path / "file")
+    branch = branches.branch("branch")
+    branch.commit = branches[main]
+    assert branches[main] == branch.commit
+
+
 def test_discover_fail(tmp_path: Path) -> None:
     """It returns None."""
     assert None is Repository.discover(tmp_path)

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -114,6 +114,12 @@ def test_branches_pop(repository: Repository) -> None:
     assert branches[main] == commit
 
 
+def test_branches_branch_fail(repository: Repository) -> None:
+    """It raises KeyError if the branch does not exist."""
+    with pytest.raises(KeyError):
+        repository.branches.branch("branch")
+
+
 def test_discover_fail(tmp_path: Path) -> None:
     """It returns None."""
     assert None is Repository.discover(tmp_path)

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -135,6 +135,13 @@ def test_branch_name_set(repository: Repository) -> None:
         branch.name = "teapot"  # type: ignore[misc]
 
 
+def test_branch_commit_get(repository: Repository) -> None:
+    """It returns the commit at the head of the branch."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    branch = repository.branches.branch(main)
+    assert repository.head.peel() == branch.commit
+
+
 def test_discover_fail(tmp_path: Path) -> None:
     """It returns None."""
     assert None is Repository.discover(tmp_path)

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -144,6 +144,16 @@ def test_branches_create_existing_branch(repository: Repository) -> None:
         branches.create(branch.name, branch.commit)
 
 
+def test_branches_create_existing_branch_force(repository: Repository) -> None:
+    """It updates the branch head if the branch already exists."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    branches = repository.branches
+    branch = branches.create("branch", branches[main])
+    updatefile(repository.path / "file")
+    branches.create(branch.name, branches[main], force=True)
+    assert branches[main] == branch.commit
+
+
 def test_branch_name_get(repository: Repository) -> None:
     """It returns the name of the branch."""
     main = repository.references["HEAD"].target.removeprefix("refs/heads/")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -154,6 +154,12 @@ def test_branches_create_existing_branch_force(repository: Repository) -> None:
     assert branches[main] == branch.commit
 
 
+def test_branches_head_name(repository: Repository) -> None:
+    """It returns the branch whose name is contained in HEAD."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    assert main == repository.branches.head.name
+
+
 def test_branch_name_get(repository: Repository) -> None:
     """It returns the name of the branch."""
     main = repository.references["HEAD"].target.removeprefix("refs/heads/")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -135,6 +135,15 @@ def test_branches_create_new_branch_commit(repository: Repository) -> None:
     assert branches[main] == branch.commit
 
 
+def test_branches_create_existing_branch(repository: Repository) -> None:
+    """It raises an exception if the branch already exists."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    branches = repository.branches
+    branch = branches.create("branch", branches[main])
+    with pytest.raises(pygit2.AlreadyExistsError):
+        branches.create(branch.name, branch.commit)
+
+
 def test_branch_name_get(repository: Repository) -> None:
     """It returns the name of the branch."""
     main = repository.references["HEAD"].target.removeprefix("refs/heads/")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -120,6 +120,21 @@ def test_branches_branch_fail(repository: Repository) -> None:
         repository.branches.branch("branch")
 
 
+def test_branches_create_new_branch_name(repository: Repository) -> None:
+    """It creates the branch with the given name."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    branch = repository.branches.create("branch", repository.branches[main])
+    assert "branch" == branch.name
+
+
+def test_branches_create_new_branch_commit(repository: Repository) -> None:
+    """It creates the branch at the given commit."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    branches = repository.branches
+    branch = branches.create("branch", branches[main])
+    assert branches[main] == branch.commit
+
+
 def test_branch_name_get(repository: Repository) -> None:
     """It returns the name of the branch."""
     main = repository.references["HEAD"].target.removeprefix("refs/heads/")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -120,6 +120,13 @@ def test_branches_branch_fail(repository: Repository) -> None:
         repository.branches.branch("branch")
 
 
+def test_branch_name_get(repository: Repository) -> None:
+    """It returns the name of the branch."""
+    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
+    branch = repository.branches.branch(main)
+    assert main == branch.name
+
+
 def test_discover_fail(tmp_path: Path) -> None:
     """It returns None."""
     assert None is Repository.discover(tmp_path)


### PR DESCRIPTION
- :white_check_mark: [util] Add test for `git.Branches.branch` with unknown branch
- :sparkles: [util] Add `git.Branches.branch`
- :white_check_mark: [util] Add test for `git.Branch.name`
- :sparkles: [util] Add `git.Branch.name`
- :white_check_mark: [util] Add test for immutability of `git.Branch.name`
- :sparkles: [util] Make `git.Branch.name` immutable
- :label: [util] Ignore mypy error about read-only property in immutability test
- :white_check_mark: [util] Add test for `git.Branch.commit`
- :sparkles: [util] Add `git.Branch.commit`
- :recycle: [util] Move validation from `git.Branches.branch` to `git.Branch.__init__`
- :recycle: [util] Replace `pygit2` function by `git.Branches.__getitem__` in test
- :white_check_mark: [util] Add test for `git.Branch.commit` setter
- :sparkles: [util] Add `git.Branch.commit` setter
- :rewind: [util] Revert "Move validation from `git.Branches.branch` to `git.Branch.__init__`"
- :white_check_mark: [util] Add tests for `git.Branches.create`
- :sparkles: [util] Add `git.Branches.create`
- :white_check_mark: [util] Add test for `git.Branches.create` with existing branch
- :sparkles: [util] Refuse to create an existing branch in `git.Branches.create`
- :white_check_mark: [util] Add test for `git.Branches.create` with `force`
- :sparkles: [util] Add `force` parameter to `git.Branches.create`
- :white_check_mark: [util] Add test for `git.Branches.head`
- :sparkles: [util] Add `git.Branches.head`
- :white_check_mark: [util] Add test for `git.Branches.create` without commit
- :sparkles: [util] Use HEAD by default in `git.Branches.create`
