### PR TITLE
:recycle: [util] Change `git.Repository.cherrypick` to use `pygit2.Commit`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
-from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH_REF
 from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
@@ -46,7 +45,7 @@ def update(
             directory=directory,
         )
 
-    repository.cherrypick(UPDATE_BRANCH_REF, message=UPDATE_MESSAGE)
+    repository.cherrypick2(repository.branches[UPDATE_BRANCH], message=UPDATE_MESSAGE)
     repository.branches[LATEST_BRANCH] = repository.branches[UPDATE_BRANCH]
 
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -45,7 +45,7 @@ def update(
             directory=directory,
         )
 
-    repository.cherrypick2(repository.branches[UPDATE_BRANCH], message=UPDATE_MESSAGE)
+    repository.cherrypick(repository.branches[UPDATE_BRANCH], message=UPDATE_MESSAGE)
     repository.branches[LATEST_BRANCH] = repository.branches[UPDATE_BRANCH]
 
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -257,20 +257,8 @@ class Repository:
 
     def cherrypick(self, reference: str, *, message: str) -> None:
         """Cherry-pick the commit onto the current branch."""
-        oid = self._repository.references[reference].resolve().target
-        self._repository.cherrypick(oid)
-
-        if self._repository.index.conflicts:
-            paths = {
-                side.path
-                for _, ours, theirs in self._repository.index.conflicts
-                for side in (ours, theirs)
-                if side is not None
-            }
-            raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
-
-        self.commit(message=message)
-        self._repository.state_cleanup()
+        commit = self._repository.references[reference].peel()
+        self.cherrypick2(commit, message=message)
 
     def createtag(self, name: str, *, message: str) -> None:
         """Create a tag at HEAD."""

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -239,7 +239,7 @@ class Repository:
         oid = self._repository.TreeBuilder().write()
         self._repository.checkout_tree(self._repository[oid])
 
-    def cherrypick2(self, commit: pygit2.Commit, *, message: str) -> None:
+    def cherrypick(self, commit: pygit2.Commit, *, message: str) -> None:
         """Cherry-pick the commit onto the current branch."""
         self._repository.cherrypick(commit.id)
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -255,11 +255,6 @@ class Repository:
         self.commit(message=message)
         self._repository.state_cleanup()
 
-    def cherrypick(self, reference: str, *, message: str) -> None:
-        """Cherry-pick the commit onto the current branch."""
-        commit = self._repository.references[reference].peel()
-        self.cherrypick2(commit, message=message)
-
     def createtag(self, name: str, *, message: str) -> None:
         """Create a tag at HEAD."""
         self._repository.create_tag(

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -33,8 +33,7 @@ def createconflict(
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        refname = f"refs/heads/{update.name}"
-        repository.cherrypick(refname, message="")
+        repository.cherrypick2(update.commit, message="")
 
 
 def test_continueupdate_commits_changes(repository: Repository, path: Path) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -33,7 +33,7 @@ def createconflict(
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick2(update.commit, message="")
+        repository.cherrypick(update.commit, message="")
 
 
 def test_continueupdate_commits_changes(repository: Repository, path: Path) -> None:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -304,7 +304,7 @@ def createconflict(
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick2(update.commit, message="")
+        repository.cherrypick(update.commit, message="")
 
 
 def test_createworktree_creates_worktree(repository: Repository) -> None:
@@ -354,7 +354,7 @@ def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:
     repository.checkout(main)
     assert not path.is_file()
 
-    repository.cherrypick2(branch.commit, message="")
+    repository.cherrypick(branch.commit, message="")
     assert path.is_file()
 
 
@@ -370,7 +370,7 @@ def test_cherrypick_conflict_edit(repository: Repository, path: Path) -> None:
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick2(branch.commit, message="")
+        repository.cherrypick(branch.commit, message="")
 
 
 def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> None:
@@ -387,7 +387,7 @@ def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> Non
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick2(branch.commit, message="")
+        repository.cherrypick(branch.commit, message="")
 
 
 def test_resetmerge_restores_files_with_conflicts(
@@ -415,7 +415,7 @@ def test_resetmerge_removes_added_files(
     updatefile(path1, "b")
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick2(update.commit, message="")
+        repository.cherrypick(update.commit, message="")
 
     repository.resetmerge(parent="latest", cherry="update")
 
@@ -439,7 +439,7 @@ def test_resetmerge_keeps_unrelated_additions(
     path2.touch()
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick2(update.commit, message="")
+        repository.cherrypick(update.commit, message="")
 
     repository.resetmerge(parent="latest", cherry="update")
 
@@ -464,7 +464,7 @@ def test_resetmerge_keeps_unrelated_changes(
     path2.write_text("c")
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick2(update.commit, message="")
+        repository.cherrypick(update.commit, message="")
 
     repository.resetmerge(parent="latest", cherry="update")
 
@@ -489,7 +489,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     path2.unlink()
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick2(update.commit, message="")
+        repository.cherrypick(update.commit, message="")
 
     repository.resetmerge(parent="latest", cherry="update")
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -304,8 +304,7 @@ def createconflict(
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        refname = f"refs/heads/{update.name}"
-        repository.cherrypick(refname, message="")
+        repository.cherrypick2(update.commit, message="")
 
 
 def test_createworktree_creates_worktree(repository: Repository) -> None:
@@ -355,8 +354,7 @@ def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:
     repository.checkout(main)
     assert not path.is_file()
 
-    refname = f"refs/heads/{branch.name}"
-    repository.cherrypick(refname, message="")
+    repository.cherrypick2(branch.commit, message="")
     assert path.is_file()
 
 
@@ -372,7 +370,7 @@ def test_cherrypick_conflict_edit(repository: Repository, path: Path) -> None:
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick(branch.name, message="")
+        repository.cherrypick2(branch.commit, message="")
 
 
 def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> None:
@@ -389,8 +387,7 @@ def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> Non
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):
-        refname = f"refs/heads/{branch.name}"
-        repository.cherrypick(refname, message="")
+        repository.cherrypick2(branch.commit, message="")
 
 
 def test_resetmerge_restores_files_with_conflicts(
@@ -418,7 +415,7 @@ def test_resetmerge_removes_added_files(
     updatefile(path1, "b")
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick(update.name, message="")
+        repository.cherrypick2(update.commit, message="")
 
     repository.resetmerge(parent="latest", cherry="update")
 
@@ -442,7 +439,7 @@ def test_resetmerge_keeps_unrelated_additions(
     path2.touch()
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick(update.name, message="")
+        repository.cherrypick2(update.commit, message="")
 
     repository.resetmerge(parent="latest", cherry="update")
 
@@ -467,7 +464,7 @@ def test_resetmerge_keeps_unrelated_changes(
     path2.write_text("c")
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick(update.name, message="")
+        repository.cherrypick2(update.commit, message="")
 
     repository.resetmerge(parent="latest", cherry="update")
 
@@ -492,7 +489,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     path2.unlink()
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick(update.name, message="")
+        repository.cherrypick2(update.commit, message="")
 
     repository.resetmerge(parent="latest", cherry="update")
 


### PR DESCRIPTION
- :recycle: [util] Add function `git.Repository.cherrypick2` taking `pygit2.Commit`
- :recycle: [util] Replace inline code with `cherrypick2`
- :recycle: [services] Replace inline code with `cherrypick2`
- :recycle: [services] Replace inline code with `cherrypick2` in tests
- :recycle: [util] Replace inline code with `cherrypick2` in tests
- :recycle: [util] Remove function `git.Repository.cherrypick`
- :recycle: [util] Rename function to `git.Repository.cherrypick`
