### PR TITLE
:recycle: [util] Change `git.Repository.worktree` to use `git.Branch`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -34,7 +34,9 @@ def update(
     repository = Repository.open(projectdir)
     repository.branches[UPDATE_BRANCH] = repository.branches[LATEST_BRANCH]
 
-    with repository.createworktree(UPDATE_BRANCH, checkout=False) as worktree:
+    with repository.worktree(
+        repository.branches.branch(UPDATE_BRANCH), checkout=False
+    ) as worktree:
         create(
             projectconfig.template,
             outputdir=worktree,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -33,10 +33,9 @@ def update(
 
     repository = Repository.open(projectdir)
     repository.branches[UPDATE_BRANCH] = repository.branches[LATEST_BRANCH]
+    branch = repository.branches.branch(UPDATE_BRANCH)
 
-    with repository.worktree(
-        repository.branches.branch(UPDATE_BRANCH), checkout=False
-    ) as worktree:
+    with repository.worktree(branch, checkout=False) as worktree:
         create(
             projectconfig.template,
             outputdir=worktree,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -46,8 +46,8 @@ def update(
             directory=directory,
         )
 
-    repository.cherrypick(repository.branches[UPDATE_BRANCH], message=UPDATE_MESSAGE)
-    repository.branches[LATEST_BRANCH] = repository.branches[UPDATE_BRANCH]
+    repository.cherrypick(branch.commit, message=UPDATE_MESSAGE)
+    repository.branches[LATEST_BRANCH] = branch.commit
 
 
 def continueupdate(*, projectdir: Optional[Path] = None) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -234,12 +234,6 @@ class Repository:
         # https://github.com/libgit2/libgit2/issues/5280
         worktree.prune(True)
 
-    @contextmanager
-    def createworktree(self, branch: str, *, checkout: bool = True) -> Iterator[Path]:
-        """Create a worktree for the branch in the repository."""
-        with self.worktree(self.branches.branch(branch), checkout=checkout) as path:
-            yield path
-
     def _checkoutemptytree(self) -> None:
         """Check out an empty tree from the repository."""
         oid = self._repository.TreeBuilder().write()

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -214,13 +214,13 @@ class Repository:
         )
 
     @contextmanager
-    def worktree(self, branch: str, *, checkout: bool = True) -> Iterator[Path]:
+    def worktree(self, branch: Branch, *, checkout: bool = True) -> Iterator[Path]:
         """Create a worktree for the branch in the repository."""
         with tempfile.TemporaryDirectory() as directory:
-            name = hashlib.blake2b(branch.encode(), digest_size=32).hexdigest()
+            name = hashlib.blake2b(branch.name.encode(), digest_size=32).hexdigest()
             path = Path(directory) / name
             worktree = self._repository.add_worktree(
-                name, path, self._repository.branches[branch]
+                name, path, self._repository.branches[branch.name]
             )
 
             if not checkout:
@@ -237,7 +237,7 @@ class Repository:
     @contextmanager
     def createworktree(self, branch: str, *, checkout: bool = True) -> Iterator[Path]:
         """Create a worktree for the branch in the repository."""
-        with self.worktree(branch, checkout=checkout) as path:
+        with self.worktree(self.branches.branch(branch), checkout=checkout) as path:
             yield path
 
     def _checkoutemptytree(self) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -214,7 +214,7 @@ class Repository:
         )
 
     @contextmanager
-    def createworktree(self, branch: str, *, checkout: bool = True) -> Iterator[Path]:
+    def worktree(self, branch: str, *, checkout: bool = True) -> Iterator[Path]:
         """Create a worktree for the branch in the repository."""
         with tempfile.TemporaryDirectory() as directory:
             name = hashlib.blake2b(branch.encode(), digest_size=32).hexdigest()
@@ -233,6 +233,12 @@ class Repository:
         # Prune with `force=True` because libgit2 thinks `worktree.path` still exists.
         # https://github.com/libgit2/libgit2/issues/5280
         worktree.prune(True)
+
+    @contextmanager
+    def createworktree(self, branch: str, *, checkout: bool = True) -> Iterator[Path]:
+        """Create a worktree for the branch in the repository."""
+        with self.worktree(branch, checkout=checkout) as path:
+            yield path
 
     def _checkoutemptytree(self) -> None:
         """Check out an empty tree from the repository."""

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -307,39 +307,39 @@ def createconflict(
         repository.cherrypick(update.commit, message="")
 
 
-def test_createworktree_creates_worktree(repository: Repository) -> None:
+def test_worktree_creates_worktree(repository: Repository) -> None:
     """It creates a worktree."""
-    repository.branches.create("branch")
+    branch = repository.branches.create("branch")
 
-    with repository.createworktree("branch") as worktree:
+    with repository.worktree(branch) as worktree:
         assert (worktree / ".git").is_file()
 
 
-def test_createworktree_removes_worktree_on_exit(repository: Repository) -> None:
+def test_worktree_removes_worktree_on_exit(repository: Repository) -> None:
     """It removes the worktree on exit."""
-    repository.branches.create("branch")
+    branch = repository.branches.create("branch")
 
-    with repository.createworktree("branch") as worktree:
+    with repository.worktree(branch) as worktree:
         pass
 
     assert not worktree.is_dir()
 
 
-def test_createworktree_does_checkout(repository: Repository, path: Path) -> None:
+def test_worktree_does_checkout(repository: Repository, path: Path) -> None:
     """It checks out a working tree."""
     updatefile(path)
-    repository.branches.create("branch")
+    branch = repository.branches.create("branch")
 
-    with repository.createworktree("branch") as worktree:
+    with repository.worktree(branch) as worktree:
         assert (worktree / path.name).is_file()
 
 
-def test_createworktree_no_checkout(repository: Repository, path: Path) -> None:
+def test_worktree_no_checkout(repository: Repository, path: Path) -> None:
     """It creates a worktree without checking out the files."""
     updatefile(path)
-    repository.branches.create("branch")
+    branch = repository.branches.create("branch")
 
-    with repository.createworktree("branch", checkout=False) as worktree:
+    with repository.worktree(branch, checkout=False) as worktree:
         assert not (worktree / path.name).is_file()
 
 


### PR DESCRIPTION
- :recycle: [util] Extract function `git.Repository.worktree`
- :recycle: [util] Change type of `git.Repository.worktree` parameter `branch` to `git.Branch`
- :recycle: [util] Use `git.Repository.worktree` in tests
- :recycle: [services] Use `git.Repository.worktree` with `git.Branch`
- :fire: [util] Remove `git.Repository.createworktree`
- :recycle: [services] Extract variable `branch`
- :recycle: [services] Replace inline code with `git.Branch.commit`
