### PR TITLE
:recycle: [util] Remove attribute `git.Repository.head`

### DIFF
--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -31,8 +31,8 @@ class GitRepositoryObserver(FileStorageObserver):
 
         if UPDATE_BRANCH in repository.branches:
             # HEAD must point to update branch if it exists.
-            head = repository.references["HEAD"].target
-            if head != UPDATE_BRANCH_REF:
+            head = repository.branches.head.name
+            if head != UPDATE_BRANCH:
                 raise RuntimeError(f"unexpected HEAD: {head}")
 
         message = (

--- a/src/cutty/filestorage/adapters/observers/git.py
+++ b/src/cutty/filestorage/adapters/observers/git.py
@@ -43,4 +43,4 @@ class GitRepositoryObserver(FileStorageObserver):
 
         repository.commit(message=message)
 
-        repository.branches.setdefault(LATEST_BRANCH, repository.head.peel())
+        repository.branches.setdefault(LATEST_BRANCH, repository.branches.head.commit)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -157,11 +157,6 @@ class Repository:
         return self._repository.index
 
     @property
-    def head(self) -> pygit2.Reference:
-        """Return the repository head."""
-        return self._repository.head
-
-    @property
     def references(self) -> pygit2.repository.References:
         """Return the repository references."""
         return self._repository.references

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -197,21 +197,22 @@ class Repository:
 
         If there are no changes relative to the parent, this is a noop.
         """
-        self.index.add_all()
+        repository = self._repository
+        index = repository.index
 
-        tree = self.index.write_tree()
-        if not self._repository.head_is_unborn and tree == self.head.peel().tree.id:
+        index.add_all()
+
+        tree = index.write_tree()
+        if not repository.head_is_unborn and tree == repository.head.peel().tree.id:
             return
 
-        self.index.write()
+        index.write()
 
         if signature is None:
             signature = self.default_signature
 
-        parents = [] if self._repository.head_is_unborn else [self.head.target]
-        self._repository.create_commit(
-            "HEAD", signature, signature, message, tree, parents
-        )
+        parents = [] if repository.head_is_unborn else [repository.head.target]
+        repository.create_commit("HEAD", signature, signature, message, tree, parents)
 
     @contextmanager
     def worktree(self, branch: Branch, *, checkout: bool = True) -> Iterator[Path]:
@@ -259,7 +260,7 @@ class Repository:
         """Create a tag at HEAD."""
         self._repository.create_tag(
             name,
-            self.head.target,
+            self._repository.head.target,
             pygit2.GIT_OBJ_COMMIT,
             self.default_signature,
             message,

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -161,10 +161,6 @@ class Repository:
         """Return the repository head."""
         return self._repository.head
 
-    def set_head(self, target: str) -> None:
-        """Update the repository head."""
-        self._repository.set_head(target)
-
     @property
     def references(self) -> pygit2.repository.References:
         """Return the repository references."""

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -70,7 +70,7 @@ def test_extra_context_invalid(runcutty: RunCutty, template: Path) -> None:
 
 def test_checkout(runcutty: RunCutty, template: Path) -> None:
     """It uses the specified revision of the template."""
-    initial = Repository.open(template).head.target
+    initial = Repository.open(template).branches.head.commit.id
 
     updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -104,12 +104,13 @@ def test_remove(runcutty: RunCutty, templateproject: Path, project: Path) -> Non
 
 def test_noop(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does nothing if the generated project did not change."""
-    oldhead = Repository.open(project).head.target
+    repository = Repository.open(project)
+    oldhead = repository.branches.head.commit
 
     with chdir(project):
         runcutty("update")
 
-    assert oldhead == Repository.open(project).head.target
+    assert oldhead == repository.branches.head.commit
 
 
 def test_new_variables(runcutty: RunCutty, template: Path, project: Path) -> None:
@@ -288,7 +289,7 @@ def test_checkout(
     """It uses the specified revision of the template."""
     updatefile(templateproject / "LICENSE", "a")
 
-    revision = Repository.open(template).head.target
+    revision = Repository.open(template).branches.head.commit.id
 
     updatefile(templateproject / "LICENSE", "b")
 

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -7,14 +7,13 @@ import pytest
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.adapters.observers.git import GitRepositoryObserver
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
-from cutty.filestorage.adapters.observers.git import LATEST_BRANCH_REF
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
-from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH_REF
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.util.git import Repository
+from tests.util.git import createbranches
 
 
 @pytest.fixture
@@ -125,8 +124,7 @@ def test_branch(storage: FileStorage, file: RegularFile, project: pathlib.Path) 
         storage.add(file)
 
     repository = Repository.open(project)
-    reference = repository.references[LATEST_BRANCH_REF]
-    assert repository.branches.head.commit == reference.peel()
+    assert repository.branches.head.commit == repository.branches[LATEST_BRANCH]
 
 
 def test_branch_not_checked_out(
@@ -137,7 +135,7 @@ def test_branch_not_checked_out(
         storage.add(file)
 
     repository = Repository.open(project)
-    assert repository.references["HEAD"].target != LATEST_BRANCH_REF
+    assert repository.branches.head.name != LATEST_BRANCH
 
 
 def test_existing_branch(
@@ -147,8 +145,8 @@ def test_existing_branch(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.branches[UPDATE_BRANCH] = repository.branches.head.commit
-    repository.set_head(UPDATE_BRANCH_REF)
+    branch = repository.branches.create(UPDATE_BRANCH)
+    repository.checkout(branch)
 
     with storage:
         storage.add(file)
@@ -163,7 +161,7 @@ def test_existing_branch_not_head(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.branches[UPDATE_BRANCH] = repository.branches.head.commit
+    repository.branches.create(UPDATE_BRANCH)
 
     with pytest.raises(Exception):
         with storage:
@@ -179,15 +177,13 @@ def test_existing_branch_commit_message(
     repository = Repository.init(project)
     repository.commit()
 
-    branches = repository.branches
-    branches[LATEST_BRANCH] = branches[UPDATE_BRANCH] = repository.branches.head.commit
-    repository.set_head(UPDATE_BRANCH_REF)
+    update, _ = createbranches(repository, UPDATE_BRANCH, LATEST_BRANCH)
+    repository.checkout(update)
 
     with storage:
         storage.add(file)
 
-    commit = repository.branches.head.commit
-    assert "initial" not in commit.message.lower()
+    assert "initial" not in repository.branches.head.commit.message.lower()
 
 
 def test_existing_branch_no_changes(
@@ -197,11 +193,11 @@ def test_existing_branch_no_changes(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.branches[UPDATE_BRANCH] = repository.branches.head.commit
-    repository.set_head(UPDATE_BRANCH_REF)
-    oldhead = repository.head.target
+    branch = repository.branches.create(UPDATE_BRANCH)
+    repository.checkout(branch)
+    oldhead = repository.branches.head.commit
 
     with storage:
         pass
 
-    assert oldhead == repository.head.target
+    assert oldhead == repository.branches.head.commit

--- a/tests/unit/filestorage/adapters/observers/test_git.py
+++ b/tests/unit/filestorage/adapters/observers/test_git.py
@@ -54,7 +54,7 @@ def test_commit(storage: FileStorage, file: RegularFile, project: pathlib.Path) 
         storage.add(file)
 
     repository = Repository.open(project)
-    repository.head  # does not raise
+    repository.branches.head.commit  # does not raise
 
 
 def test_index(storage: FileStorage, file: RegularFile, project: pathlib.Path) -> None:
@@ -68,7 +68,7 @@ def test_index(storage: FileStorage, file: RegularFile, project: pathlib.Path) -
 
 def tree(repository: Repository) -> pygit2.Tree:
     """Return the tree at the HEAD of the repository."""
-    return repository.head.peel().tree
+    return repository.branches.head.commit.tree
 
 
 def test_hook_edits(
@@ -126,7 +126,7 @@ def test_branch(storage: FileStorage, file: RegularFile, project: pathlib.Path) 
 
     repository = Repository.open(project)
     reference = repository.references[LATEST_BRANCH_REF]
-    assert repository.head.peel() == reference.peel()
+    assert repository.branches.head.commit == reference.peel()
 
 
 def test_branch_not_checked_out(
@@ -147,7 +147,7 @@ def test_existing_branch(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.branches[UPDATE_BRANCH] = repository.head.peel()
+    repository.branches[UPDATE_BRANCH] = repository.branches.head.commit
     repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
@@ -163,7 +163,7 @@ def test_existing_branch_not_head(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.branches[UPDATE_BRANCH] = repository.head.peel()
+    repository.branches[UPDATE_BRANCH] = repository.branches.head.commit
 
     with pytest.raises(Exception):
         with storage:
@@ -180,14 +180,14 @@ def test_existing_branch_commit_message(
     repository.commit()
 
     branches = repository.branches
-    branches[LATEST_BRANCH] = branches[UPDATE_BRANCH] = repository.head.peel()
+    branches[LATEST_BRANCH] = branches[UPDATE_BRANCH] = repository.branches.head.commit
     repository.set_head(UPDATE_BRANCH_REF)
 
     with storage:
         storage.add(file)
 
-    commit_ = repository.head.peel()
-    assert "initial" not in commit_.message.lower()
+    commit = repository.branches.head.commit
+    assert "initial" not in commit.message.lower()
 
 
 def test_existing_branch_no_changes(
@@ -197,7 +197,7 @@ def test_existing_branch_no_changes(
     repository = Repository.init(project)
     repository.commit()
 
-    repository.branches[UPDATE_BRANCH] = repository.head.peel()
+    repository.branches[UPDATE_BRANCH] = repository.branches.head.commit
     repository.set_head(UPDATE_BRANCH_REF)
     oldhead = repository.head.target
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -44,7 +44,7 @@ def test_continueupdate_commits_changes(repository: Repository, path: Path) -> N
     with chdir(repository.path):
         continueupdate()
 
-    blob = repository.head.peel().tree / path.name
+    blob = repository.branches.head.commit.tree / path.name
     assert blob.data == b"b"
 
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -63,7 +63,7 @@ def test_branches_getitem_fail(repository: Repository) -> None:
 def test_branches_getitem_pass(repository: Repository) -> None:
     """It returns the commit at the head of the branch."""
     main = repository.references["HEAD"].target.removeprefix("refs/heads/")
-    assert repository.head.peel() == repository.branches[main]
+    assert repository.branches.head.commit == repository.branches[main]
 
 
 def test_branches_setitem_new(repository: Repository) -> None:
@@ -218,16 +218,16 @@ def test_commit_on_unborn_branch(tmp_path: Path) -> None:
     repository = Repository.init(tmp_path / "repository")
     repository.commit(message="initial")
 
-    assert not repository.head.peel().parents
+    assert not repository.branches.head.commit.parents
 
 
 def test_commit_empty(repository: Repository) -> None:
     """It does not produce an empty commit (unless the branch is unborn)."""
-    head = repository.head.peel()
+    head = repository.branches.head.commit
 
     repository.commit(message="empty")
 
-    assert head == repository.head.peel()
+    assert head == repository.branches.head.commit
 
 
 def test_commit_signature(repository: Repository) -> None:
@@ -237,7 +237,7 @@ def test_commit_signature(repository: Repository) -> None:
     signature = pygit2.Signature("Katherine", "katherine@example.com")
     repository.commit(message="empty", signature=signature)
 
-    head = repository.head.peel()
+    head = repository.branches.head.commit
     assert signature.name == head.author.name and signature.email == head.author.email
 
 
@@ -247,7 +247,7 @@ def test_commit_message_default(repository: Repository) -> None:
 
     repository.commit()
 
-    head = repository.head.peel()
+    head = repository.branches.head.commit
     assert "" == head.message
 
 
@@ -255,7 +255,7 @@ def test_createbranch_target_default(repository: Repository) -> None:
     """It creates the branch at HEAD by default."""
     repository.branches.create("branch")
 
-    assert repository.branches["branch"] == repository.head.peel()
+    assert repository.branches["branch"] == repository.branches.head.commit
 
 
 def test_createbranch_target_branch(repository: Repository) -> None:
@@ -502,4 +502,4 @@ def test_resetmerge_resets_index(repository: Repository, path: Path) -> None:
 
     repository.resetmerge(parent="latest", cherry="update")
 
-    assert repository.index.write_tree() == repository.head.peel().tree.id
+    assert repository.index.write_tree() == repository.branches.head.commit.tree.id


### PR DESCRIPTION
- :recycle: [util] Replace `git.Repository.head` with `pygit2.Repository.head`
- :recycle: [filestorage] Replace `git.Repository.head` with `git.Branches.head`
- :recycle: [filestorage] Replace `git.Repository.references` with `git.Branches.head`
- :recycle: [util] Replace `git.Repository.head` with `git.Branches.head` in tests
- :recycle: [filestorage] Replace `git.Repository.head` with `git.Branches.head` in tests
- :recycle: [filestorage] Replace `git.Repository.references` with `git.Repository.branches`
- :fire: [util] Remove function `git.Repository.set_head`
- :recycle: [services] Replace `git.Repository.head` with `git.Branches.head` in tests
- :recycle: [functional] Replace `git.Repository.head` with `git.Branches.head`
- :fire: [util] Remove function `git.Repository.head`
