### PR TITLE
:fire: [util] Remove attribute `git.Repository.references`

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -152,11 +152,6 @@ class Repository:
             remote.fetch(prune=pygit2.GIT_FETCH_PRUNE)
 
     @property
-    def references(self) -> pygit2.repository.References:
-        """Return the repository references."""
-        return self._repository.references
-
-    @property
     def branches(self) -> Branches:
         """Return the repository branches."""
         return Branches(self._repository.branches)

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -105,8 +105,7 @@ def test_broken_head_after_clone(
     destination = gitfetcher(url, store, None, FetchMode.ALWAYS)
     assert destination is not None
     repository = Repository.open(destination)
-    head = repository.references["HEAD"]
-    assert head.target != f"refs/heads/{custom_default_branch}"
+    assert repository.branches.head.name != custom_default_branch
 
 
 def test_broken_head_after_clone_unexpected_branch(

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -185,8 +185,9 @@ def test_branches_create_default_commit(repository: Repository) -> None:
 
 def test_branches_head_name(repository: Repository) -> None:
     """It returns the branch whose name is contained in HEAD."""
-    main = repository.references["HEAD"].target.removeprefix("refs/heads/")
-    assert main == repository.branches.head.name
+    head = repository._repository.references["HEAD"]
+    name = head.target.removeprefix("refs/heads/")
+    assert name == repository.branches.head.name
 
 
 def test_branch_name_get(repository: Repository) -> None:


### PR DESCRIPTION
- :recycle: [util] Replace `git.Repository.references` by `pygit2.Repository.references` in tests
- :recycle: [repositories] Replace `git.Repository.references` by `git.Branches.head` in tests
- :fire: [util] Remove attribute `git.Repository.references`
