### PR TITLE
:sparkles: [util] Improve error handling in `git.Repository.head` when HEAD is detached

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -154,8 +154,12 @@ class Repository:
     @property
     def head(self) -> Branch:
         """Return the branch referenced by HEAD."""
-        head = self._repository.references["HEAD"]
-        name = head.target.removeprefix("refs/heads/")
+        head = self._repository.references["HEAD"].target
+
+        if isinstance(head, pygit2.Oid):
+            raise ValueError("HEAD is detached")
+
+        name = head.removeprefix("refs/heads/")
         return Branch(self.branches, name)
 
     def checkout(self, branch: Branch) -> None:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -183,7 +183,7 @@ def test_branches_create_default_commit(repository: Repository) -> None:
     assert branch.commit == repository.head.commit
 
 
-def test_branches_head_name(repository: Repository) -> None:
+def test_head_name(repository: Repository) -> None:
     """It returns the branch whose name is contained in HEAD."""
     head = repository._repository.references["HEAD"]
     name = head.target.removeprefix("refs/heads/")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -190,6 +190,13 @@ def test_branches_head_name(repository: Repository) -> None:
     assert name == repository.head.name
 
 
+def test_head_detached(repository: Repository) -> None:
+    """It raises an exception if the HEAD is detached."""
+    repository._repository.set_head(repository.head.commit.id)
+    with pytest.raises(ValueError):
+        repository.head
+
+
 def test_branch_name_get(repository: Repository) -> None:
     """It returns the name of the branch."""
     branch = repository.branch(repository.head.name)


### PR DESCRIPTION
- :white_check_mark: [util] Add test for `git.Repository.head` with detached HEAD
- :recycle: [util] Rename test
- :sparkles: [util] Improve error handling in `git.Repository.head` when HEAD is detached
