### PR TITLE
:sparkles: [util] Replace parameter `signature` with `author` and `committer` in `git.Repository.commit`

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -178,7 +178,11 @@ class Repository:
         return self._repository.default_signature  # pragma: no cover
 
     def commit(
-        self, *, message: str = "", signature: Optional[pygit2.Signature] = None
+        self,
+        *,
+        message: str = "",
+        author: Optional[pygit2.Signature] = None,
+        committer: Optional[pygit2.Signature] = None,
     ) -> None:
         """Commit all changes in the repository.
 
@@ -195,11 +199,14 @@ class Repository:
 
         index.write()
 
-        if signature is None:
-            signature = self.default_signature
+        if author is None:
+            author = self.default_signature
+
+        if committer is None:
+            committer = author
 
         parents = [] if repository.head_is_unborn else [repository.head.target]
-        repository.create_commit("HEAD", signature, signature, message, tree, parents)
+        repository.create_commit("HEAD", author, committer, message, tree, parents)
 
     @contextmanager
     def worktree(self, branch: Branch, *, checkout: bool = True) -> Iterator[Path]:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -256,15 +256,29 @@ def test_commit_empty(repository: Repository) -> None:
     assert head == repository.head.commit
 
 
-def test_commit_signature(repository: Repository) -> None:
+def test_commit_author(repository: Repository) -> None:
+    """It uses the provided author."""
+    (repository.path / "a").touch()
+
+    author = pygit2.Signature("Katherine", "katherine@example.com")
+    repository.commit(message="empty", author=author)
+
+    head = repository.head.commit
+    assert author.name == head.author.name and author.email == head.author.email
+
+
+def test_commit_committer(repository: Repository) -> None:
     """It uses the provided signature."""
     (repository.path / "a").touch()
 
-    signature = pygit2.Signature("Katherine", "katherine@example.com")
-    repository.commit(message="empty", signature=signature)
+    committer = pygit2.Signature("Katherine", "katherine@example.com")
+    repository.commit(message="empty", committer=committer)
 
     head = repository.head.commit
-    assert signature.name == head.author.name and signature.email == head.author.email
+    assert (
+        committer.name == head.committer.name
+        and committer.email == head.committer.email
+    )
 
 
 def test_commit_message_default(repository: Repository) -> None:


### PR DESCRIPTION
- :white_check_mark: [util] Add tests for `git.Repository.commit` with `author` and `committer`
- :sparkles: [util] Replace parameter `signature` with `author` and `committer` in `git.Repository.commit`
