### PR TITLE
:recycle: [util] Preserve commit message and author in `git.Repository.cherrypick`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -46,7 +46,7 @@ def update(
             directory=directory,
         )
 
-    repository.cherrypick(branch.commit, message=UPDATE_MESSAGE)
+    repository.cherrypick(branch.commit)
     repository.branches[LATEST_BRANCH] = branch.commit
 
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -247,7 +247,7 @@ class Repository:
             }
             raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
 
-        self.commit(message=commit.message)
+        self.commit(message=commit.message, author=commit.author)
         self._repository.state_cleanup()
 
     def createtag(self, name: str, *, message: str) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -252,6 +252,7 @@ class Repository:
             author=commit.author,
             committer=self.default_signature,
         )
+
         self._repository.state_cleanup()
 
     def createtag(self, name: str, *, message: str) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -247,7 +247,11 @@ class Repository:
             }
             raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
 
-        self.commit(message=commit.message, author=commit.author)
+        self.commit(
+            message=commit.message,
+            author=commit.author,
+            committer=self.default_signature,
+        )
         self._repository.state_cleanup()
 
     def createtag(self, name: str, *, message: str) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -234,7 +234,9 @@ class Repository:
         oid = self._repository.TreeBuilder().write()
         self._repository.checkout_tree(self._repository[oid])
 
-    def cherrypick(self, commit: pygit2.Commit, *, message: str) -> None:
+    def cherrypick(
+        self, commit: pygit2.Commit, *, message: Optional[str] = None
+    ) -> None:
         """Cherry-pick the commit onto the current branch."""
         self._repository.cherrypick(commit.id)
 
@@ -246,6 +248,9 @@ class Repository:
                 if side is not None
             }
             raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
+
+        if message is None:
+            message = commit.message
 
         self.commit(message=message)
         self._repository.state_cleanup()

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -234,9 +234,7 @@ class Repository:
         oid = self._repository.TreeBuilder().write()
         self._repository.checkout_tree(self._repository[oid])
 
-    def cherrypick(
-        self, commit: pygit2.Commit, *, message: Optional[str] = None
-    ) -> None:
+    def cherrypick(self, commit: pygit2.Commit) -> None:
         """Cherry-pick the commit onto the current branch."""
         self._repository.cherrypick(commit.id)
 
@@ -249,10 +247,7 @@ class Repository:
             }
             raise RuntimeError(f"Merge conflicts: {', '.join(paths)}")
 
-        if message is None:
-            message = commit.message
-
-        self.commit(message=message)
+        self.commit(message=commit.message)
         self._repository.state_cleanup()
 
     def createtag(self, name: str, *, message: str) -> None:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -33,7 +33,7 @@ def createconflict(
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick(update.commit, message="")
+        repository.cherrypick(update.commit)
 
 
 def test_continueupdate_commits_changes(repository: Repository, path: Path) -> None:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -359,6 +359,21 @@ def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:
     assert path.is_file()
 
 
+def test_cherrypick_message(repository: Repository, path: Path) -> None:
+    """It uses the original commit message."""
+    main = repository.head
+    branch = repository.branches.create("branch")
+
+    repository.checkout(branch)
+    updatefile(path)
+    message = repository.head.commit.message
+
+    repository.checkout(main)
+
+    repository.cherrypick(branch.commit)
+    assert message == repository.head.commit.message
+
+
 def test_cherrypick_conflict_edit(repository: Repository, path: Path) -> None:
     """It raises an exception when both sides modified the file."""
     main = repository.head

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -305,7 +305,7 @@ def createconflict(
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick(update.commit, message="")
+        repository.cherrypick(update.commit)
 
 
 def test_worktree_creates_worktree(repository: Repository) -> None:
@@ -355,7 +355,7 @@ def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:
     repository.checkout(main)
     assert not path.is_file()
 
-    repository.cherrypick(branch.commit, message="")
+    repository.cherrypick(branch.commit)
     assert path.is_file()
 
 
@@ -386,7 +386,7 @@ def test_cherrypick_conflict_edit(repository: Repository, path: Path) -> None:
     updatefile(path, "b")
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick(branch.commit, message="")
+        repository.cherrypick(branch.commit)
 
 
 def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> None:
@@ -403,7 +403,7 @@ def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> Non
     removefile(path)
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick(branch.commit, message="")
+        repository.cherrypick(branch.commit)
 
 
 def test_resetmerge_restores_files_with_conflicts(
@@ -431,7 +431,7 @@ def test_resetmerge_removes_added_files(
     updatefile(path1, "b")
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick(update.commit, message="")
+        repository.cherrypick(update.commit)
 
     repository.resetmerge(parent="latest", cherry="update")
 
@@ -455,7 +455,7 @@ def test_resetmerge_keeps_unrelated_additions(
     path2.touch()
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick(update.commit, message="")
+        repository.cherrypick(update.commit)
 
     repository.resetmerge(parent="latest", cherry="update")
 
@@ -480,7 +480,7 @@ def test_resetmerge_keeps_unrelated_changes(
     path2.write_text("c")
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick(update.commit, message="")
+        repository.cherrypick(update.commit)
 
     repository.resetmerge(parent="latest", cherry="update")
 
@@ -505,7 +505,7 @@ def test_resetmerge_keeps_unrelated_deletions(
     path2.unlink()
 
     with pytest.raises(Exception, match=path1.name):
-        repository.cherrypick(update.commit, message="")
+        repository.cherrypick(update.commit)
 
     repository.resetmerge(parent="latest", cherry="update")
 

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -374,6 +374,22 @@ def test_cherrypick_message(repository: Repository, path: Path) -> None:
     assert message == repository.head.commit.message
 
 
+def test_cherrypick_author(repository: Repository) -> None:
+    """It uses the original commit author."""
+    main = repository.head
+    branch = repository.branches.create("branch")
+    author = pygit2.Signature("author", "author@example.com")
+
+    repository.checkout(branch)
+    (repository.path / "a").touch()
+    repository.commit(author=author)
+
+    repository.checkout(main)
+
+    repository.cherrypick(branch.commit)
+    assert author.email == repository.head.commit.author.email
+
+
 def test_cherrypick_conflict_edit(repository: Repository, path: Path) -> None:
     """It raises an exception when both sides modified the file."""
     main = repository.head

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -369,8 +369,8 @@ def test_cherrypick_message(repository: Repository, path: Path) -> None:
     message = repository.head.commit.message
 
     repository.checkout(main)
-
     repository.cherrypick(branch.commit)
+
     assert message == repository.head.commit.message
 
 
@@ -385,8 +385,8 @@ def test_cherrypick_author(repository: Repository) -> None:
     repository.commit(author=author)
 
     repository.checkout(main)
-
     repository.cherrypick(branch.commit)
+
     assert author.email == repository.head.commit.author.email
 
 


### PR DESCRIPTION
- :white_check_mark: [util] Add test that `git.Repository.cherrypick` preserves commit message
- :sparkles: [util] Preserve commit message in `git.Repository.cherrypick`
- :recycle: [services] Omit `message` argument for `git.Repository.cherrypick`
- :recycle: [services] Omit `message` argument for `git.Repository.cherrypick` in tests
- :recycle: [util] Omit `message` argument for `git.Repository.cherrypick` in tests
- :recycle: [util] Remove parameter `message` from `git.Repository.cherrypick`
- :white_check_mark: [util] Add test that `git.Repository.cherrypick` preserves commit author
- :sparkles: [util] Preserve commit author in `git.Repository.cherrypick`
- :white_check_mark: [util] Add test that `git.Repository.cherrypick` creates committer signature
- :sparkles: [util] Create committer signature in `git.Repository.cherrypick`
- :art: [util] Add blank line
- :art: [util] Slide blank lines
