### PR TITLE
:recycle: [services] Use `CHERRY_PICK_HEAD` in `cutty update --continue`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
-from cutty.filestorage.adapters.observers.git import UPDATE_MESSAGE
 from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
@@ -56,7 +55,14 @@ def continueupdate(*, projectdir: Optional[Path] = None) -> None:
         projectdir = Path.cwd()
 
     repository = Repository.open(projectdir)
-    repository.commit(message=UPDATE_MESSAGE)
+
+    if commit := repository.cherrypickhead:
+        repository.commit(
+            message=commit.message,
+            author=commit.author,
+            committer=repository.default_signature,
+        )
+
     repository.branches[LATEST_BRANCH] = repository.branches[UPDATE_BRANCH]
 
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -70,6 +70,21 @@ def test_continueupdate_fastforwards_latest(repository: Repository, path: Path) 
     assert repository.branches[LATEST_BRANCH] == repository.branches[UPDATE_BRANCH]
 
 
+def test_continueupdate_works_after_commit(repository: Repository, path: Path) -> None:
+    """It updates the latest branch even if the cherry-pick is no longer in progress."""
+    createconflict(repository, path, ours="a", theirs="b")
+    resolveconflicts(repository.path, path, Side.THEIRS)
+
+    # The user invokes `git cherry-pick --continue` before `cutty update --continue`.
+    repository.commit()
+    repository._repository.state_cleanup()
+
+    with chdir(repository.path):
+        continueupdate()
+
+    assert repository.branches[LATEST_BRANCH] == repository.branches[UPDATE_BRANCH]
+
+
 def test_skipupdate_fastforwards_latest(repository: Repository, path: Path) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
     createconflict(repository, path, ours="a", theirs="b")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -48,6 +48,17 @@ def test_continueupdate_commits_changes(repository: Repository, path: Path) -> N
     assert blob.data == b"b"
 
 
+def test_continueupdate_preserves_metainfo(repository: Repository, path: Path) -> None:
+    """It preserves the original commit message."""
+    createconflict(repository, path, ours="a", theirs="b")
+    resolveconflicts(repository.path, path, Side.THEIRS)
+
+    with chdir(repository.path):
+        continueupdate()
+
+    assert repository.branches[UPDATE_BRANCH].message == repository.head.commit.message
+
+
 def test_continueupdate_fastforwards_latest(repository: Repository, path: Path) -> None:
     """It updates the latest branch to the tip of the update branch."""
     createconflict(repository, path, ours="a", theirs="b")


### PR DESCRIPTION
- :white_check_mark: [services] Add test that `continueupdate` preserves commit metainfo
- :sparkles: [services] Use CHERRY_PICK_HEAD in `cutty update --continue`
- :white_check_mark: [services] Add test for `cutty update --continue` after `git cherry-pick --continue`
