### PR TITLE
:recycle: [services] Add function `git.Repository.resetcherrypick` to replace `resetmerge`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -73,6 +73,7 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
 
     repository = Repository.open(projectdir)
     repository.resetcherrypick()
+
     repository.branches[LATEST_BRANCH] = repository.branches[UPDATE_BRANCH]
 
 
@@ -83,4 +84,5 @@ def abortupdate(*, projectdir: Optional[Path] = None) -> None:
 
     repository = Repository.open(projectdir)
     repository.resetcherrypick()
+
     repository.branches[UPDATE_BRANCH] = repository.branches[LATEST_BRANCH]

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -72,7 +72,7 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
         projectdir = Path.cwd()
 
     repository = Repository.open(projectdir)
-    repository.resetmerge(parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+    repository.resetcherrypick()
     repository.branches[LATEST_BRANCH] = repository.branches[UPDATE_BRANCH]
 
 
@@ -82,5 +82,5 @@ def abortupdate(*, projectdir: Optional[Path] = None) -> None:
         projectdir = Path.cwd()
 
     repository = Repository.open(projectdir)
-    repository.resetmerge(parent=LATEST_BRANCH, cherry=UPDATE_BRANCH)
+    repository.resetcherrypick()
     repository.branches[UPDATE_BRANCH] = repository.branches[LATEST_BRANCH]

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -295,30 +295,6 @@ class Repository:
             paths=paths,
         )
 
-    def resetmerge(self, parent: str, cherry: str) -> None:
-        """Reset only files that were touched by a cherry-pick.
-
-        This emulates `git reset --merge HEAD` by performing a hard reset on the
-        files that were updated by the cherry-picked commit, and resetting the index
-        to HEAD.
-        """
-        self._repository.index.read_tree(self._repository.head.peel().tree)
-        self._repository.index.write()
-
-        parenttree = self.branches[parent].peel(pygit2.Tree)
-        cherrytree = self.branches[cherry].peel(pygit2.Tree)
-        diff = cherrytree.diff_to_tree(parenttree)
-        paths = [
-            file.path
-            for delta in diff.deltas
-            for file in (delta.old_file, delta.new_file)
-        ]
-
-        self._repository.checkout(
-            strategy=pygit2.GIT_CHECKOUT_FORCE | pygit2.GIT_CHECKOUT_REMOVE_UNTRACKED,
-            paths=paths,
-        )
-
     def createtag(self, name: str, *, message: str) -> None:
         """Create a tag at HEAD."""
         self._repository.create_tag(

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -268,16 +268,6 @@ class Repository:
             return reference.peel(pygit2.Commit)
         return None
 
-    def createtag(self, name: str, *, message: str) -> None:
-        """Create a tag at HEAD."""
-        self._repository.create_tag(
-            name,
-            self._repository.head.target,
-            pygit2.GIT_OBJ_COMMIT,
-            self.default_signature,
-            message,
-        )
-
     def resetmerge(self, parent: str, cherry: str) -> None:
         """Reset only files that were touched by a cherry-pick.
 
@@ -300,6 +290,16 @@ class Repository:
         self._repository.checkout(
             strategy=pygit2.GIT_CHECKOUT_FORCE | pygit2.GIT_CHECKOUT_REMOVE_UNTRACKED,
             paths=paths,
+        )
+
+    def createtag(self, name: str, *, message: str) -> None:
+        """Create a tag at HEAD."""
+        self._repository.create_tag(
+            name,
+            self._repository.head.target,
+            pygit2.GIT_OBJ_COMMIT,
+            self.default_signature,
+            message,
         )
 
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -295,6 +295,8 @@ class Repository:
             paths=paths,
         )
 
+        self._repository.state_cleanup()
+
     def createtag(self, name: str, *, message: str) -> None:
         """Create a tag at HEAD."""
         self._repository.create_tag(

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -571,3 +571,11 @@ def test_resetcherrypick_resets_index(repository: Repository, path: Path) -> Non
 
     index = repository._repository.index
     assert index.write_tree() == repository.head.commit.tree.id
+
+
+def test_resetcherrypick_idempotent(repository: Repository, path: Path) -> None:
+    """It is idempotent."""
+    createconflict(repository, path, ours="a", theirs="b")
+
+    repository.resetcherrypick()
+    repository.resetcherrypick()

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -573,6 +573,17 @@ def test_resetcherrypick_resets_index(repository: Repository, path: Path) -> Non
     assert index.write_tree() == repository.head.commit.tree.id
 
 
+def test_resetcherrypick_state_cleanup(repository: Repository, path: Path) -> None:
+    """It removes CHERRY_PICK_HEAD."""
+    createconflict(repository, path, ours="a", theirs="b")
+
+    assert repository.cherrypickhead
+
+    repository.resetcherrypick()
+
+    assert not repository.cherrypickhead
+
+
 def test_resetcherrypick_idempotent(repository: Repository, path: Path) -> None:
     """It is idempotent."""
     createconflict(repository, path, ours="a", theirs="b")

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -457,17 +457,17 @@ def test_cherrypickhead_progress(repository: Repository, path: Path) -> None:
     assert repository.cherrypickhead == repository.branches["update"]
 
 
-def test_resetmerge_restores_files_with_conflicts(
+def test_resetcherrypick_restores_files_with_conflicts(
     repository: Repository, path: Path
 ) -> None:
     """It restores the conflicting files in the working tree to our version."""
     createconflict(repository, path, ours="a", theirs="b")
-    repository.resetmerge(parent="latest", cherry="update")
+    repository.resetcherrypick()
 
     assert path.read_text() == "a"
 
 
-def test_resetmerge_removes_added_files(
+def test_resetcherrypick_removes_added_files(
     repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It removes files added by the cherry-picked commit."""
@@ -484,12 +484,12 @@ def test_resetmerge_removes_added_files(
     with pytest.raises(MergeConflictError, match=path1.name):
         repository.cherrypick(update.commit)
 
-    repository.resetmerge(parent="latest", cherry="update")
+    repository.resetcherrypick()
 
     assert not path2.exists()
 
 
-def test_resetmerge_keeps_unrelated_additions(
+def test_resetcherrypick_keeps_unrelated_additions(
     repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps additions of files that did not change in the update."""
@@ -508,12 +508,12 @@ def test_resetmerge_keeps_unrelated_additions(
     with pytest.raises(MergeConflictError, match=path1.name):
         repository.cherrypick(update.commit)
 
-    repository.resetmerge(parent="latest", cherry="update")
+    repository.resetcherrypick()
 
     assert path2.exists()
 
 
-def test_resetmerge_keeps_unrelated_changes(
+def test_resetcherrypick_keeps_unrelated_changes(
     repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps modifications to files that did not change in the update."""
@@ -533,12 +533,12 @@ def test_resetmerge_keeps_unrelated_changes(
     with pytest.raises(MergeConflictError, match=path1.name):
         repository.cherrypick(update.commit)
 
-    repository.resetmerge(parent="latest", cherry="update")
+    repository.resetcherrypick()
 
     assert path2.read_text() == "c"
 
 
-def test_resetmerge_keeps_unrelated_deletions(
+def test_resetcherrypick_keeps_unrelated_deletions(
     repository: Repository, paths: Iterator[Path]
 ) -> None:
     """It keeps deletions of files that did not change in the update."""
@@ -558,16 +558,16 @@ def test_resetmerge_keeps_unrelated_deletions(
     with pytest.raises(MergeConflictError, match=path1.name):
         repository.cherrypick(update.commit)
 
-    repository.resetmerge(parent="latest", cherry="update")
+    repository.resetcherrypick()
 
     assert not path2.exists()
 
 
-def test_resetmerge_resets_index(repository: Repository, path: Path) -> None:
+def test_resetcherrypick_resets_index(repository: Repository, path: Path) -> None:
     """It resets the index to HEAD, removing conflicts."""
     createconflict(repository, path, ours="a", theirs="b")
 
-    repository.resetmerge(parent="latest", cherry="update")
+    repository.resetcherrypick()
 
     index = repository._repository.index
     assert index.write_tree() == repository.head.commit.tree.id


### PR DESCRIPTION
- :recycle: [util] Slide function definition
- :recycle: [util] Add function `git.Repository.resetcherrypick`
- :recycle: [util] Use `git.Repository.resetcherrypick` instead of `resetmerge`
- :recycle: [services] Use `git.Repository.resetcherrypick` instead of `resetmerge`
- :art: [services] Insert blank lines
- :fire: [util] Remove function `git.Repository.resetmerge`
- :white_check_mark: [util] Add test that `resetcherrypick` is idempotent
- :white_check_mark: [util] Add test that `git.Repository.resetcherrypick` removes `CHERRY_PICK_HEAD`
- :sparkles: [util] Remove `CHERRY_PICK_HEAD` in `git.Repository.resetcherrypick`
