### PR TITLE
:recycle: [services] Remove `CHERRY_PICK_HEAD` when running `cutty update --continue`

### DIFF
--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -62,7 +62,6 @@ def continueupdate(*, projectdir: Optional[Path] = None) -> None:
             author=commit.author,
             committer=repository.default_signature,
         )
-        repository._repository.state_cleanup()
 
     repository.branches[LATEST_BRANCH] = repository.branches[UPDATE_BRANCH]
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -62,6 +62,7 @@ def continueupdate(*, projectdir: Optional[Path] = None) -> None:
             author=commit.author,
             committer=repository.default_signature,
         )
+        repository._repository.state_cleanup()
 
     repository.branches[LATEST_BRANCH] = repository.branches[UPDATE_BRANCH]
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -211,6 +211,7 @@ class Repository:
 
         parents = [] if repository.head_is_unborn else [repository.head.target]
         repository.create_commit("HEAD", author, committer, message, tree, parents)
+        repository.state_cleanup()
 
     @contextmanager
     def worktree(self, branch: Branch, *, checkout: bool = True) -> Iterator[Path]:

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -85,6 +85,17 @@ def test_continueupdate_works_after_commit(repository: Repository, path: Path) -
     assert repository.branches[LATEST_BRANCH] == repository.branches[UPDATE_BRANCH]
 
 
+def test_continueupdate_state_cleanup(repository: Repository, path: Path) -> None:
+    """It removes CHERRY_PICK_HEAD."""
+    createconflict(repository, path, ours="a", theirs="b")
+    resolveconflicts(repository.path, path, Side.THEIRS)
+
+    with chdir(repository.path):
+        continueupdate()
+
+    assert repository.cherrypickhead is None
+
+
 def test_skipupdate_fastforwards_latest(repository: Repository, path: Path) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
     createconflict(repository, path, ours="a", theirs="b")

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -77,7 +77,6 @@ def test_continueupdate_works_after_commit(repository: Repository, path: Path) -
 
     # The user invokes `git cherry-pick --continue` before `cutty update --continue`.
     repository.commit()
-    repository._repository.state_cleanup()
 
     with chdir(repository.path):
         continueupdate()


### PR DESCRIPTION
- :white_check_mark: [services] Add test that `cutty update --continue` removes `CHERRY_PICK_HEAD`
- :sparkles: [services] Remove `CHERRY_PICK_HEAD` when running `cutty update --continue`
- :recycle: [util] Perform state cleanup in `git.Repository.commit`
