### PR TITLE
:recycle: [filesystems] Refactor tests for `GitFilesystem`

### DIFF
--- a/tests/unit/filesystems/adapters/test_git.py
+++ b/tests/unit/filesystems/adapters/test_git.py
@@ -29,7 +29,7 @@ def filesystem(tmp_path: Path) -> GitFilesystem:
         builder.insert(name, tree.write(), pygit2.GIT_FILEMODE_TREE)
 
     signature = pygit2.Signature("you", "you@example.com")
-    repository = pygit2.init_repository(tmp_path)
+    repository = pygit2.init_repository(tmp_path / "repository")
 
     root = repository.TreeBuilder()
     root_dir = repository.TreeBuilder()
@@ -52,7 +52,7 @@ def filesystem(tmp_path: Path) -> GitFilesystem:
         [],
     )
 
-    return GitFilesystem(tmp_path)
+    return GitFilesystem(tmp_path / "repository")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- :recycle: [filesystems] Do not create repository in `tmp_path` fixture
- :recycle: [filesystems] Add utility class `TreeBuilder` for git tests
- :recycle: [filesystems] Simplify git tests using `git.Repository`
