### PR TITLE
:sparkles: [repositories] Improve template name in commit messages

### DIFF
--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -17,8 +17,8 @@ from yarl import URL
 from cutty.repositories.adapters.registry import defaultproviderregistry
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
-from cutty.repositories.domain.providers import RepositoryProvider
-from cutty.repositories.domain.providers import repositoryprovider
+from cutty.repositories.domain.providers import RepositoryProvider2
+from cutty.repositories.domain.providers import repositoryprovider2
 from cutty.repositories.domain.stores import Store
 
 
@@ -152,9 +152,9 @@ def getdefaultproviderstore(
 
 def getdefaultrepositoryprovider(
     path: pathlib.Path, *, timer: Timer = defaulttimer
-) -> RepositoryProvider:
+) -> RepositoryProvider2:
     """Return a repository provider."""
-    return repositoryprovider(
+    return repositoryprovider2(
         defaultproviderregistry,
         getdefaultproviderstore(path, timer=timer),
     )

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -17,8 +17,8 @@ from yarl import URL
 from cutty.repositories.adapters.registry import defaultproviderregistry
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
-from cutty.repositories.domain.providers import RepositoryProvider2
-from cutty.repositories.domain.providers import repositoryprovider2
+from cutty.repositories.domain.providers import RepositoryProvider
+from cutty.repositories.domain.providers import repositoryprovider
 from cutty.repositories.domain.stores import Store
 
 
@@ -152,9 +152,9 @@ def getdefaultproviderstore(
 
 def getdefaultrepositoryprovider(
     path: pathlib.Path, *, timer: Timer = defaulttimer
-) -> RepositoryProvider2:
+) -> RepositoryProvider:
     """Return a repository provider."""
-    return repositoryprovider2(
+    return repositoryprovider(
         defaultproviderregistry,
         getdefaultproviderstore(path, timer=timer),
     )

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -34,7 +34,7 @@ class Repository:
     path: Path
 
 
-class RepositoryProvider2(Protocol):
+class RepositoryProvider(Protocol):
     """The repository provider turns a repository URL into a filesystem path."""
 
     def __call__(
@@ -206,9 +206,9 @@ def _splitprovidername(location: Location) -> tuple[Optional[ProviderName], Loca
     return None, location
 
 
-def repositoryprovider2(
+def repositoryprovider(
     providerregistry: ProviderRegistry, providerstore: ProviderStore
-) -> RepositoryProvider2:
+) -> RepositoryProvider:
     """Return a repository provider."""
 
     def _provide(

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -220,21 +220,22 @@ def _splitprovidername(location: Location) -> tuple[Optional[ProviderName], Loca
 
 def repositoryprovider2(
     providerregistry: ProviderRegistry, providerstore: ProviderStore
-) -> RepositoryProvider:
+) -> RepositoryProvider2:
     """Return a repository provider."""
 
     def _provide(
         location: str,
         revision: Optional[Revision] = None,
         fetchmode: FetchMode = FetchMode.ALWAYS,
-    ) -> Path:
+    ) -> Repository:
         location_ = parselocation(location)
         providername, location_ = _splitprovidername(location_)
         providers = _createproviders(
             providerregistry, providerstore, fetchmode, providername
         )
 
-        return provide(providers, location_, revision)
+        path = provide(providers, location_, revision)
+        return Repository(path)
 
     return _provide
 
@@ -243,4 +244,14 @@ def repositoryprovider(
     providerregistry: ProviderRegistry, providerstore: ProviderStore
 ) -> RepositoryProvider:
     """Return a repository provider."""
-    return repositoryprovider2(providerregistry, providerstore)
+    provider = repositoryprovider2(providerregistry, providerstore)
+
+    def _provide(
+        location: str,
+        revision: Optional[Revision] = None,
+        fetchmode: FetchMode = FetchMode.ALWAYS,
+    ) -> Path:
+        repository = provider(location, revision, fetchmode)
+        return repository.path
+
+    return _provide

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -238,20 +238,3 @@ def repositoryprovider2(
         return Repository(path)
 
     return _provide
-
-
-def repositoryprovider(
-    providerregistry: ProviderRegistry, providerstore: ProviderStore
-) -> RepositoryProvider:
-    """Return a repository provider."""
-    provider = repositoryprovider2(providerregistry, providerstore)
-
-    def _provide(
-        location: str,
-        revision: Optional[Revision] = None,
-        fetchmode: FetchMode = FetchMode.ALWAYS,
-    ) -> Path:
-        repository = provider(location, revision, fetchmode)
-        return repository.path
-
-    return _provide

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -31,6 +31,7 @@ from cutty.repositories.domain.stores import Store
 class Repository:
     """A repository."""
 
+    name: str
     path: Path
 
 
@@ -223,6 +224,6 @@ def repositoryprovider(
         )
 
         path = provide(providers, location_, revision)
-        return Repository(path)
+        return Repository(location_.name, path)
 
     return _provide

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -34,6 +34,18 @@ class Repository:
     path: Path
 
 
+class RepositoryProvider2(Protocol):
+    """The repository provider turns a repository URL into a filesystem path."""
+
+    def __call__(
+        self,
+        location: str,
+        revision: Optional[Revision] = None,
+        fetchmode: FetchMode = FetchMode.ALWAYS,
+    ) -> Repository:
+        """Return the repository located at the given URL."""
+
+
 class RepositoryProvider(Protocol):
     """The repository provider turns a repository URL into a filesystem path."""
 

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -46,18 +46,6 @@ class RepositoryProvider2(Protocol):
         """Return the repository located at the given URL."""
 
 
-class RepositoryProvider(Protocol):
-    """The repository provider turns a repository URL into a filesystem path."""
-
-    def __call__(
-        self,
-        location: str,
-        revision: Optional[Revision] = None,
-        fetchmode: FetchMode = FetchMode.ALWAYS,
-    ) -> Path:
-        """Return a path to the repository located at the given URL."""
-
-
 Provider = Callable[[Location, Optional[Revision]], Optional[Filesystem]]
 
 

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
 from collections.abc import Mapping
+from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Optional
 from typing import Protocol
@@ -24,6 +25,13 @@ from cutty.repositories.domain.matchers import PathMatcher
 from cutty.repositories.domain.mounters import Mounter
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
+
+
+@dataclass
+class Repository:
+    """A repository."""
+
+    path: Path
 
 
 class RepositoryProvider(Protocol):

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -198,7 +198,7 @@ def _splitprovidername(location: Location) -> tuple[Optional[ProviderName], Loca
     return None, location
 
 
-def repositoryprovider(
+def repositoryprovider2(
     providerregistry: ProviderRegistry, providerstore: ProviderStore
 ) -> RepositoryProvider:
     """Return a repository provider."""
@@ -217,3 +217,10 @@ def repositoryprovider(
         return provide(providers, location_, revision)
 
     return _provide
+
+
+def repositoryprovider(
+    providerregistry: ProviderRegistry, providerstore: ProviderStore
+) -> RepositoryProvider:
+    """Return a repository provider."""
+    return repositoryprovider2(providerregistry, providerstore)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -36,9 +36,8 @@ def create(
 ) -> None:
     """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
-    templatedir = getdefaultrepositoryprovider(cachedir)(
-        template, revision=checkout
-    ).path
+    repositoryprovider = getdefaultrepositoryprovider(cachedir)
+    templatedir = repositoryprovider(template, revision=checkout).path
 
     if directory is not None:
         templatedir = templatedir.joinpath(*directory.parts)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -81,7 +81,7 @@ def create(
         else None
     )
 
-    templatename = pathlib.Path(template).name if directory is None else directory.name
+    templatename = templaterepository.name if directory is None else directory.name
     with createcookiecutterstorage(
         outputdir,
         projectdir,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -36,7 +36,9 @@ def create(
 ) -> None:
     """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
-    templatedir = getdefaultrepositoryprovider(cachedir)(template, revision=checkout)
+    templatedir = getdefaultrepositoryprovider(cachedir)(
+        template, revision=checkout
+    ).path
 
     if directory is not None:
         templatedir = templatedir.joinpath(*directory.parts)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -37,7 +37,8 @@ def create(
     """Generate a project from a Cookiecutter template."""
     cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
     repositoryprovider = getdefaultrepositoryprovider(cachedir)
-    templatedir = repositoryprovider(template, revision=checkout).path
+    templaterepository = repositoryprovider(template, revision=checkout)
+    templatedir = templaterepository.path
 
     if directory is not None:
         templatedir = templatedir.joinpath(*directory.parts)

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -298,8 +298,8 @@ def test_repositoryprovider_with_path(
         default=localprovider(match=lambda path: True, mount=defaultmount)
     )
     provider = repositoryprovider2(registry, providerstore)
-    repository2 = provider(str(directory))
-    [entry] = repository2.path.iterdir()
+    repository = provider(str(directory))
+    [entry] = repository.path.iterdir()
 
     assert entry.name == "marker"
 

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -275,7 +275,7 @@ def test_repositoryprovider_none(providerstore: ProviderStore, url: URL) -> None
         provider(str(url))
 
 
-def test_repositoryprovider_happy(
+def test_repositoryprovider_with_url(
     providerstore: ProviderStore, fetcher: Fetcher, url: URL
 ) -> None:
     """It returns a provider that allows traversing repositories."""

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -26,7 +26,7 @@ from cutty.repositories.domain.providers import registerproviderfactories
 from cutty.repositories.domain.providers import registerproviderfactory
 from cutty.repositories.domain.providers import registerproviders
 from cutty.repositories.domain.providers import remoteproviderfactory
-from cutty.repositories.domain.providers import repositoryprovider2
+from cutty.repositories.domain.providers import repositoryprovider
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
 
@@ -270,7 +270,7 @@ def test_registerproviders_override(store: Store) -> None:
 def test_repositoryprovider_none(providerstore: ProviderStore, url: URL) -> None:
     """It raises an exception if the registry is empty."""
     registry = registerproviderfactories()
-    provider = repositoryprovider2(registry, providerstore)
+    provider = repositoryprovider(registry, providerstore)
     with pytest.raises(Exception):
         provider(str(url))
 
@@ -281,7 +281,7 @@ def test_repositoryprovider_happy(
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory(fetch=[fetcher])
     registry = registerproviderfactories(default=providerfactory)
-    provider = repositoryprovider2(registry, providerstore)
+    provider = repositoryprovider(registry, providerstore)
     repository = provider(str(url))
     assert not list(repository.path.iterdir())
 
@@ -297,7 +297,7 @@ def test_repositoryprovider_with_path(
     registry = registerproviders(
         default=localprovider(match=lambda path: True, mount=defaultmount)
     )
-    provider = repositoryprovider2(registry, providerstore)
+    provider = repositoryprovider(registry, providerstore)
     repository = provider(str(directory))
     [entry] = repository.path.iterdir()
 
@@ -313,6 +313,6 @@ def test_repositoryprovider_with_provider_specific_url(
         default=remoteproviderfactory(fetch=[fetcher]),
         null=constproviderfactory(nullprovider),
     )
-    provider = repositoryprovider2(registry, providerstore)
+    provider = repositoryprovider(registry, providerstore)
     with pytest.raises(Exception):
         provider(str(url))

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -316,3 +316,14 @@ def test_repositoryprovider_with_provider_specific_url(
     provider = repositoryprovider(registry, providerstore)
     with pytest.raises(Exception):
         provider(str(url))
+
+
+def test_repositoryprovider_name_from_url(
+    providerstore: ProviderStore, fetcher: Fetcher
+) -> None:
+    """It returns a provider that allows traversing repositories."""
+    providerfactory = remoteproviderfactory(fetch=[fetcher])
+    registry = registerproviderfactories(default=providerfactory)
+    provider = repositoryprovider(registry, providerstore)
+    repository = provider("https://example.com/path/to/example?query#fragment")
+    assert "example" == repository.name

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -290,15 +290,15 @@ def test_repositoryprovider_with_path(
     tmp_path: pathlib.Path, providerstore: ProviderStore, fetcher: Fetcher
 ) -> None:
     """It returns a provider that allows traversing repositories."""
-    repository = tmp_path / "repository"
-    repository.mkdir()
-    (repository / "marker").touch()
+    directory = tmp_path / "repository"
+    directory.mkdir()
+    (directory / "marker").touch()
 
     registry = registerproviders(
         default=localprovider(match=lambda path: True, mount=defaultmount)
     )
     provider = repositoryprovider2(registry, providerstore)
-    repository2 = provider(str(repository))
+    repository2 = provider(str(directory))
     [entry] = repository2.path.iterdir()
 
     assert entry.name == "marker"

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -282,8 +282,8 @@ def test_repositoryprovider_happy(
     providerfactory = remoteproviderfactory(fetch=[fetcher])
     registry = registerproviderfactories(default=providerfactory)
     provider = repositoryprovider2(registry, providerstore)
-    path = provider(str(url)).path
-    assert not list(path.iterdir())
+    repository = provider(str(url))
+    assert not list(repository.path.iterdir())
 
 
 def test_repositoryprovider_with_path(
@@ -298,8 +298,8 @@ def test_repositoryprovider_with_path(
         default=localprovider(match=lambda path: True, mount=defaultmount)
     )
     provider = repositoryprovider2(registry, providerstore)
-    path = provider(str(repository)).path
-    [entry] = path.iterdir()
+    repository2 = provider(str(repository))
+    [entry] = repository2.path.iterdir()
 
     assert entry.name == "marker"
 

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -26,7 +26,7 @@ from cutty.repositories.domain.providers import registerproviderfactories
 from cutty.repositories.domain.providers import registerproviderfactory
 from cutty.repositories.domain.providers import registerproviders
 from cutty.repositories.domain.providers import remoteproviderfactory
-from cutty.repositories.domain.providers import repositoryprovider
+from cutty.repositories.domain.providers import repositoryprovider2
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
 
@@ -270,7 +270,7 @@ def test_registerproviders_override(store: Store) -> None:
 def test_repositoryprovider_none(providerstore: ProviderStore, url: URL) -> None:
     """It raises an exception if the registry is empty."""
     registry = registerproviderfactories()
-    provider = repositoryprovider(registry, providerstore)
+    provider = repositoryprovider2(registry, providerstore)
     with pytest.raises(Exception):
         provider(str(url))
 
@@ -281,8 +281,8 @@ def test_repositoryprovider_happy(
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory(fetch=[fetcher])
     registry = registerproviderfactories(default=providerfactory)
-    provider = repositoryprovider(registry, providerstore)
-    path = provider(str(url))
+    provider = repositoryprovider2(registry, providerstore)
+    path = provider(str(url)).path
     assert not list(path.iterdir())
 
 
@@ -297,8 +297,8 @@ def test_repositoryprovider_with_path(
     registry = registerproviders(
         default=localprovider(match=lambda path: True, mount=defaultmount)
     )
-    provider = repositoryprovider(registry, providerstore)
-    path = provider(str(repository))
+    provider = repositoryprovider2(registry, providerstore)
+    path = provider(str(repository)).path
     [entry] = path.iterdir()
 
     assert entry.name == "marker"
@@ -313,6 +313,6 @@ def test_repositoryprovider_with_provider_specific_url(
         default=remoteproviderfactory(fetch=[fetcher]),
         null=constproviderfactory(nullprovider),
     )
-    provider = repositoryprovider(registry, providerstore)
+    provider = repositoryprovider2(registry, providerstore)
     with pytest.raises(Exception):
         provider(str(url))


### PR DESCRIPTION
- Refactor `cutty.repositories` to provide a `Repository` class with `name` and `path` attributes, instead of just a path
- Improve the way the template name is determined from URLs, where the last part of the URL path portion is used