### PR TITLE
:sparkles: [repositories] Use original URL when scheme contains unknown provider

### DIFF
--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -181,12 +181,14 @@ def _createproviders(
             )
 
 
-def _splitprovidername(location: Location) -> tuple[Optional[ProviderName], Location]:
+def _splitprovidername(
+    location: Location, providerregistry: ProviderRegistry
+) -> tuple[Optional[ProviderName], Location]:
     """Split off the provider name from the URL scheme, if any."""
     if isinstance(location, URL):
         providername, _, scheme = location.scheme.rpartition("+")
 
-        if providername:
+        if providername and providername in providerregistry:
             return providername, location.with_scheme(scheme)
 
     return None, location
@@ -204,7 +206,7 @@ def repositoryprovider(
         directory: Optional[PurePath] = None,
     ) -> Repository:
         location_ = parselocation(location)
-        providername, location_ = _splitprovidername(location_)
+        providername, location_ = _splitprovidername(location_, providerregistry)
         providers = _createproviders(
             providerregistry, providerstore, fetchmode, providername
         )

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -303,6 +303,26 @@ def test_repositoryprovider_with_provider_specific_url(
         provider(str(url))
 
 
+def test_repositoryprovider_unknown_provider_in_url_scheme(
+    providerstore: ProviderStore, url: URL
+) -> None:
+    """It invokes providers with the original scheme."""
+    repositorypath = Path(filesystem=DictFilesystem({}))
+    repository = Repository("example", repositorypath, None)
+
+    def fakeprovider(
+        location: Location, revision: Optional[Revision]
+    ) -> Optional[Repository]:
+        """Fake provider."""
+        return repository
+
+    registry = {"default": constproviderfactory(fakeprovider)}
+    provider = repositoryprovider(registry, providerstore)
+    url = url.with_scheme(f"invalid+{url.scheme}")
+
+    assert repository == provider(str(url))
+
+
 def test_repositoryprovider_name_from_url(
     providerstore: ProviderStore, fetcher: Fetcher
 ) -> None:


### PR DESCRIPTION
- :white_check_mark: [repositories] Add test with unknown provider in URL scheme
- :sparkles: [repositories] Use original URL when scheme contains unknown provider
