### PR TITLE
Exit with an error message on `CuttyError`

### DIFF
--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -8,9 +8,8 @@ from cutty.entrypoints.cli.update import update
 
 registercommand = main.command()
 
-registercommand(fatal(create))
-registercommand(fatal(update))
-registercommand(fatal(cookiecutter))
+for command in [create, update, cookiecutter]:
+    registercommand(fatal(command))
 
 
 __all__ = ["main"]

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -2,14 +2,15 @@
 from cutty.entrypoints.cli._main import main
 from cutty.entrypoints.cli.cookiecutter import cookiecutter
 from cutty.entrypoints.cli.create import create
+from cutty.entrypoints.cli.errors import fatal
 from cutty.entrypoints.cli.update import update
 
 
 registercommand = main.command()
 
-registercommand(create)
-registercommand(update)
-registercommand(cookiecutter)
+registercommand(fatal(create))
+registercommand(fatal(update))
+registercommand(fatal(cookiecutter))
 
 
 __all__ = ["main"]

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -1,0 +1,11 @@
+"""Error handling for the command-line interface."""
+from typing import NoReturn
+
+from cutty.errors import CuttyError
+from cutty.util.exceptionhandlers import exceptionhandler
+
+
+@exceptionhandler
+def fatal(error: CuttyError) -> NoReturn:
+    """Exit with an error message."""
+    raise SystemExit(f"fatal: {error}")

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -8,7 +8,7 @@ from cutty.util.exceptionhandlers import exceptionhandler
 
 @exceptionhandler
 def _unknownlocation(error: UnknownLocationError) -> NoReturn:
-    raise SystemExit(f"fatal: unknown location {error.location}")
+    raise SystemExit(f"unknown location {error.location}")
 
 
 @exceptionhandler

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -8,7 +8,8 @@ from cutty.util.exceptionhandlers import exceptionhandler
 
 @exceptionhandler
 def _unknownlocation(error: UnknownLocationError) -> NoReturn:
-    raise SystemExit(f"fatal: {error}")
+    [location] = error.args
+    raise SystemExit(f"fatal: unknown location {location}")
 
 
 @exceptionhandler

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -2,7 +2,13 @@
 from typing import NoReturn
 
 from cutty.errors import CuttyError
+from cutty.repositories.domain.providers import UnknownLocationError
 from cutty.util.exceptionhandlers import exceptionhandler
+
+
+@exceptionhandler
+def _unknownlocation(error: UnknownLocationError) -> NoReturn:
+    raise SystemExit(f"fatal: {error}")
 
 
 @exceptionhandler

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -12,6 +12,8 @@ def _unknownlocation(error: UnknownLocationError) -> NoReturn:
 
 
 @exceptionhandler
-def fatal(error: CuttyError) -> NoReturn:
-    """Exit with an error message."""
+def _fatal(error: CuttyError) -> NoReturn:
     raise SystemExit(f"fatal: {error}")
+
+
+fatal = _unknownlocation >> _fatal

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -8,8 +8,7 @@ from cutty.util.exceptionhandlers import exceptionhandler
 
 @exceptionhandler
 def _unknownlocation(error: UnknownLocationError) -> NoReturn:
-    [location] = error.args
-    raise SystemExit(f"fatal: unknown location {location}")
+    raise SystemExit(f"fatal: unknown location {error.location}")
 
 
 @exceptionhandler

--- a/src/cutty/errors.py
+++ b/src/cutty/errors.py
@@ -1,0 +1,5 @@
+"""Cutty errors."""
+
+
+class CuttyError(Exception):
+    """The base class for all cutty exceptions."""

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -11,6 +11,7 @@ from typing import Protocol
 
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.filesystems.domain.path import Path
@@ -62,7 +63,7 @@ def provide(
         if repository := provider(location, revision):
             return repository
 
-    raise RuntimeError(f"unknown location {location}")
+    raise CuttyError(f"unknown location {location}")
 
 
 ProviderFactory = Callable[[Store, FetchMode], Provider]

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -67,7 +67,7 @@ def provide(
         if repository := provider(location, revision):
             return repository
 
-    raise UnknownLocationError(f"unknown location {location}")
+    raise UnknownLocationError(location)
 
 
 ProviderFactory = Callable[[Store, FetchMode], Provider]

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -55,6 +55,10 @@ class RepositoryProvider(Protocol):
 Provider = Callable[[Location, Optional[Revision]], Optional[Repository]]
 
 
+class UnknownLocationError(CuttyError):
+    """The repository location could not be processed by any provider."""
+
+
 def provide(
     providers: Iterable[Provider], location: Location, revision: Optional[Revision]
 ) -> Repository:
@@ -63,7 +67,7 @@ def provide(
         if repository := provider(location, revision):
             return repository
 
-    raise CuttyError(f"unknown location {location}")
+    raise UnknownLocationError(f"unknown location {location}")
 
 
 ProviderFactory = Callable[[Store, FetchMode], Provider]

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -55,8 +55,11 @@ class RepositoryProvider(Protocol):
 Provider = Callable[[Location, Optional[Revision]], Optional[Repository]]
 
 
+@dataclass
 class UnknownLocationError(CuttyError):
     """The repository location could not be processed by any provider."""
+
+    location: Location
 
 
 def provide(

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -59,8 +59,7 @@ def provide(
 ) -> Repository:
     """Provide the repository located at the given URL."""
     for provider in providers:
-        repository = provider(location, revision)
-        if repository is not None:
+        if repository := provider(location, revision):
             return repository
 
     raise RuntimeError(f"unknown location {location}")

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -95,5 +95,5 @@ def test_commit_message_revision(runcutty: RunCutty, template: Path) -> None:
 
 def test_unknown_location(runcutty: RunCutty) -> None:
     """It prints an error message."""
-    with pytest.raises(Exception, match="fatal: unknown location"):
+    with pytest.raises(Exception, match="unknown location"):
         runcutty("create", "invalid://location")

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -91,3 +91,9 @@ def test_commit_message_revision(runcutty: RunCutty, template: Path) -> None:
     repository = Repository.open(Path("example"))
 
     assert str(revision)[:7] in repository.head.commit.message
+
+
+def test_unknown_location(runcutty: RunCutty) -> None:
+    """It prints an error message."""
+    with pytest.raises(Exception, match="fatal: unknown location"):
+        runcutty("create", "invalid://location")

--- a/tests/unit/entrypoints/__init__.py
+++ b/tests/unit/entrypoints/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for cutty.entrypoints."""

--- a/tests/unit/entrypoints/cli/__init__.py
+++ b/tests/unit/entrypoints/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for cutty.entrypoints.cli."""

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -1,0 +1,12 @@
+"""Unit tests for cutty.entrypoints.cli.errors."""
+import pytest
+
+from cutty.entrypoints.cli.errors import fatal
+from cutty.errors import CuttyError
+
+
+def test_fatal() -> None:
+    """It raises SystemExit with the exception message."""
+    with pytest.raises(SystemExit, match="fatal: Boom"):
+        with fatal:
+            raise CuttyError("Boom")


### PR DESCRIPTION
- :recycle: [repositories] Simplify `provide` using walrus operator
- :recycle: [errors] Add exception `CuttyError`
- :recycle: [repositories] Raise `CuttyError` instead of `RuntimeError`
- :tada: [entrypoints] Add package tests.unit.entrypoints.cli
- :white_check_mark: [errors] Add test for `fatal` error handler
- :recycle: [errors] Add `fatal` error handler
- :white_check_mark: [functional] Add test for CLI error messages
- :sparkles: [entrypoints] Exit with an error message on `CuttyError`
- :recycle: [entrypoints] Roll loop around command registration
- :recycle: [repositories] Add specialized exception for unknown locations
- :recycle: [entrypoints] Add handler for UnknownLocationError
- :recycle: [entrypoints] Compose error handlers
- :recycle: [entrypoints] Move UnknownLocationError message to handler
- :recycle: [repositories] Add attribute `UnknownLocationError.location`
- :children_crossing: [entrypoints] Omit "fatal:" prefix for unknown location errors
