### PR TITLE
:recycle: [repositories] Extract `Provider` class hierarchy

### DIFF
--- a/src/cutty/repositories/adapters/providers/disk.py
+++ b/src/cutty/repositories/adapters/providers/disk.py
@@ -1,10 +1,10 @@
 """Repository provider for a local directory."""
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.repositories.domain.mounters import unversioned_mounter
-from cutty.repositories.domain.providers import localprovider
+from cutty.repositories.domain.providers import LocalProvider
 
 
-diskprovider = localprovider(
+diskprovider = LocalProvider(
     match=lambda path: path.is_dir(),
     mount=unversioned_mounter(DiskFilesystem),
 )

--- a/src/cutty/repositories/adapters/providers/git.py
+++ b/src/cutty/repositories/adapters/providers/git.py
@@ -6,7 +6,7 @@ import pygit2
 
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.repositories.adapters.fetchers.git import gitfetcher
-from cutty.repositories.domain.providers import localprovider
+from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import remoteproviderfactory
 from cutty.repositories.domain.revisions import Revision
 
@@ -54,7 +54,7 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
     return revision
 
 
-localgitprovider = localprovider(match=match, mount=mount, getrevision=getrevision)
+localgitprovider = LocalProvider(match=match, mount=mount, getrevision=getrevision)
 gitproviderfactory = remoteproviderfactory(
     fetch=[gitfetcher], mount=mount, getrevision=getrevision
 )

--- a/src/cutty/repositories/adapters/providers/zip.py
+++ b/src/cutty/repositories/adapters/providers/zip.py
@@ -6,7 +6,7 @@ from cutty.repositories.adapters.fetchers.file import filefetcher
 from cutty.repositories.adapters.fetchers.ftp import ftpfetcher
 from cutty.repositories.adapters.fetchers.http import httpfetcher
 from cutty.repositories.domain.mounters import unversioned_mounter
-from cutty.repositories.domain.providers import localprovider
+from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import remoteproviderfactory
 
 
@@ -16,7 +16,7 @@ def match(path: Path) -> bool:
 
 
 mount = unversioned_mounter(ZipFilesystem)
-localzipprovider = localprovider(match=match, mount=mount)
+localzipprovider = LocalProvider(match=match, mount=mount)
 zipproviderfactory = remoteproviderfactory(
     match=lambda url: url.path.lower().endswith(".zip"),
     fetch=[httpfetcher, ftpfetcher, filefetcher],

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -72,7 +72,7 @@ class UnknownLocationError(CuttyError):
 
 
 def provide(
-    providers: Iterable[Provider], location: Location, revision: Optional[Revision]
+    providers: Iterable[Provider2], location: Location, revision: Optional[Revision]
 ) -> Repository:
     """Provide the repository located at the given URL."""
     for provider in providers:
@@ -82,7 +82,7 @@ def provide(
     raise UnknownLocationError(location)
 
 
-ProviderFactory = Callable[[Store, FetchMode], Provider]
+ProviderFactory = Callable[[Store, FetchMode], Provider2]
 GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]
 
 
@@ -176,7 +176,7 @@ def remoteproviderfactory(
 ) -> ProviderFactory:
     """Remote providers fetch the repository into local storage first."""
 
-    def _remoteproviderfactory(store: Store, fetchmode: FetchMode) -> Provider:
+    def _remoteproviderfactory(store: Store, fetchmode: FetchMode) -> Provider2:
         return RemoteProvider(
             match=match,
             fetch=fetch,
@@ -197,10 +197,10 @@ ProviderRegistry = Mapping[ProviderName, ProviderFactory]
 _emptyproviderregistry: ProviderRegistry = MappingProxyType({})
 
 
-def constproviderfactory(provider: Provider) -> ProviderFactory:
+def constproviderfactory(provider: Provider2) -> ProviderFactory:
     """Create a provider factory that returns the given provider."""
 
-    def _providerfactory(store: Store, fetchmode: FetchMode) -> Provider:
+    def _providerfactory(store: Store, fetchmode: FetchMode) -> Provider2:
         return provider
 
     return _providerfactory
@@ -211,7 +211,7 @@ def _createprovider(
     providerfactory: ProviderFactory,
     providerstore: ProviderStore,
     fetchmode: FetchMode,
-) -> Provider:
+) -> Provider2:
     """Create a provider."""
     store = providerstore(providername)
     return providerfactory(store, fetchmode)
@@ -222,7 +222,7 @@ def _createproviders(
     providerstore: ProviderStore,
     fetchmode: FetchMode,
     providername: Optional[ProviderName],
-) -> Iterator[Provider]:
+) -> Iterator[Provider2]:
     """Create providers."""
     if providername is not None:
         providerfactory = providerregistry[providername]

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -111,12 +111,11 @@ class LocalProvider(Provider):
             return None
 
         filesystem = self.mount(path_, revision)
-        path = Path(filesystem=filesystem)
 
         if self.getrevision is not None:
             revision = self.getrevision(path_, revision)
 
-        return Repository(location.name, path, revision)
+        return Repository(location.name, Path(filesystem=filesystem), revision)
 
 
 def _defaultmount(path: pathlib.Path, revision: Optional[Revision]) -> Filesystem:

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -153,12 +153,13 @@ class RemoteProvider(Provider):
             for fetcher in self.fetch:
                 if path := fetcher(url, self.store, revision, self.fetchmode):
                     filesystem = self.mount(path, revision)
-                    path_ = Path(filesystem=filesystem)
 
                     if self.getrevision is not None:
                         revision = self.getrevision(path, revision)
 
-                    return Repository(location.name, path_, revision)
+                    return Repository(
+                        location.name, Path(filesystem=filesystem), revision
+                    )
 
         return None
 

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -55,6 +55,15 @@ class RepositoryProvider(Protocol):
 Provider = Callable[[Location, Optional[Revision]], Optional[Repository]]
 
 
+class Provider2:
+    """Provider for a specific type of repository."""
+
+    def __call__(
+        self, location: Location, revision: Optional[Revision]
+    ) -> Optional[Repository]:
+        """Return the repository at the given location."""
+
+
 @dataclass
 class UnknownLocationError(CuttyError):
     """The repository location could not be processed by any provider."""

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -151,8 +151,7 @@ class RemoteProvider(Provider):
         url = location if isinstance(location, URL) else asurl(location)
         if self.match is None or self.match(url):
             for fetcher in self.fetch:
-                path = fetcher(url, self.store, revision, self.fetchmode)
-                if path is not None:
+                if path := fetcher(url, self.store, revision, self.fetchmode):
                     filesystem = self.mount(path, revision)
                     path_ = Path(filesystem=filesystem)
 

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -148,19 +148,23 @@ class RemoteProvider(Provider):
     ) -> Optional[Repository]:
         """Return the repository at the given location."""
         url = location if isinstance(location, URL) else asurl(location)
+
         if self.match is None or self.match(url):
             for fetcher in self.fetch:
                 if path := fetcher(url, self.store, revision, self.fetchmode):
-                    filesystem = self.mount(path, revision)
-
-                    if self.getrevision is not None:
-                        revision = self.getrevision(path, revision)
-
-                    return Repository(
-                        location.name, Path(filesystem=filesystem), revision
-                    )
+                    return self._loadrepository(location, revision, path)
 
         return None
+
+    def _loadrepository(
+        self, location: Location, revision: Optional[Revision], path: pathlib.Path
+    ) -> Repository:
+        filesystem = self.mount(path, revision)
+
+        if self.getrevision is not None:
+            revision = self.getrevision(path, revision)
+
+        return Repository(location.name, Path(filesystem=filesystem), revision)
 
 
 def remoteproviderfactory(

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -122,9 +122,6 @@ class LocalProvider(Provider2):
         return Repository(location.name, path, revision)
 
 
-localprovider = LocalProvider
-
-
 def _defaultmount(path: pathlib.Path, revision: Optional[Revision]) -> Filesystem:
     return DiskFilesystem(path)
 

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -84,7 +84,7 @@ GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]
 
 
 class LocalProvider(Provider):
-    """Create a view onto the local filesystem."""
+    """Provide a repository from the local filesystem."""
 
     def __init__(
         self,

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -103,17 +103,17 @@ class LocalProvider(Provider):
     ) -> Optional[Repository]:
         """Return the repository at the given location."""
         try:
-            path_ = location if isinstance(location, pathlib.Path) else aspath(location)
+            path = location if isinstance(location, pathlib.Path) else aspath(location)
         except ValueError:
             return None
 
-        if not self.match(path_):
+        if not self.match(path):
             return None
 
-        filesystem = self.mount(path_, revision)
+        filesystem = self.mount(path, revision)
 
         if self.getrevision is not None:
-            revision = self.getrevision(path_, revision)
+            revision = self.getrevision(path, revision)
 
         return Repository(location.name, Path(filesystem=filesystem), revision)
 

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -130,10 +130,10 @@ class LocalProvider(BaseProvider):
         except ValueError:
             return None
 
-        if not self.match(path):
-            return None
+        if self.match(path):
+            return self._loadrepository(location, revision, path)
 
-        return self._loadrepository(location, revision, path)
+        return None
 
 
 def _defaultmount(path: pathlib.Path, revision: Optional[Revision]) -> Filesystem:

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -110,6 +110,11 @@ class LocalProvider(Provider):
         if not self.match(path):
             return None
 
+        return self._loadrepository(location, revision, path)
+
+    def _loadrepository(
+        self, location: Location, revision: Optional[Revision], path: pathlib.Path
+    ) -> Repository:
         filesystem = self.mount(path, revision)
 
         if self.getrevision is not None:

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -52,9 +52,6 @@ class RepositoryProvider(Protocol):
         """Return the repository located at the given URL."""
 
 
-Provider = Callable[[Location, Optional[Revision]], Optional[Repository]]
-
-
 class Provider2:
     """Provider for a specific type of repository."""
 

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -49,7 +49,7 @@ nullprovider = Provider()
 
 
 def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider:
-    """Provider that matches every URL with a filesystem."""
+    """Provider that matches every URL with a repository."""
 
     @provider
     def _provider(

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -44,12 +44,8 @@ def provider(function: ProviderFunction) -> Provider:
     return _Provider()
 
 
-@provider
-def nullprovider(
-    location: Location, revision: Optional[Revision]
-) -> Optional[Repository]:
-    """Provider that matches no location."""
-    return None
+nullprovider = Provider()
+"""Provider that matches no location."""
 
 
 def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider:

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -1,6 +1,7 @@
 """Unit tests for cutty.repositories.domain.providers."""
 import json
 import pathlib
+from collections.abc import Callable
 from typing import Any
 from typing import Optional
 
@@ -19,7 +20,6 @@ from cutty.repositories.domain.mounters import unversioned_mounter
 from cutty.repositories.domain.providers import constproviderfactory
 from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import provide
-from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import Provider2
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import remoteproviderfactory
@@ -27,6 +27,9 @@ from cutty.repositories.domain.providers import Repository
 from cutty.repositories.domain.providers import repositoryprovider
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
+
+
+Provider = Callable[[Location, Optional[Revision]], Optional[Repository]]
 
 
 def provider2(function: Provider) -> Provider2:

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -20,6 +20,7 @@ from cutty.repositories.domain.providers import constproviderfactory
 from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import provide
 from cutty.repositories.domain.providers import Provider
+from cutty.repositories.domain.providers import Provider2
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import remoteproviderfactory
 from cutty.repositories.domain.providers import Repository
@@ -28,6 +29,19 @@ from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
 
 
+def provider2(function: Provider) -> Provider2:
+    """Decorator to create a provider from a function."""
+
+    class _Provider(Provider2):
+        def __call__(
+            self, location: Location, revision: Optional[Revision]
+        ) -> Optional[Repository]:
+            return function(location, revision)
+
+    return _Provider()
+
+
+@provider2
 def nullprovider(
     location: Location, revision: Optional[Revision]
 ) -> Optional[Repository]:
@@ -38,6 +52,7 @@ def nullprovider(
 def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider:
     """Provider that matches every URL with a filesystem."""
 
+    @provider2
     def _provider(
         location: Location, revision: Optional[Revision]
     ) -> Optional[Repository]:

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -20,7 +20,7 @@ from cutty.repositories.domain.mounters import unversioned_mounter
 from cutty.repositories.domain.providers import constproviderfactory
 from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import provide
-from cutty.repositories.domain.providers import Provider2
+from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import remoteproviderfactory
 from cutty.repositories.domain.providers import Repository
@@ -32,10 +32,10 @@ from cutty.repositories.domain.stores import Store
 ProviderFunction = Callable[[Location, Optional[Revision]], Optional[Repository]]
 
 
-def provider2(function: ProviderFunction) -> Provider2:
+def provider2(function: ProviderFunction) -> Provider:
     """Decorator to create a provider from a function."""
 
-    class _Provider(Provider2):
+    class _Provider(Provider):
         def __call__(
             self, location: Location, revision: Optional[Revision]
         ) -> Optional[Repository]:
@@ -52,7 +52,7 @@ def nullprovider(
     return None
 
 
-def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider2:
+def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider:
     """Provider that matches every URL with a filesystem."""
 
     @provider2
@@ -76,7 +76,7 @@ def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider2:
         [nullprovider, nullprovider],
     ],
 )
-def test_provide_fail(providers: list[Provider2]) -> None:
+def test_provide_fail(providers: list[Provider]) -> None:
     """It raises an exception."""
     with pytest.raises(Exception):
         provide(providers, URL(), None)
@@ -91,7 +91,7 @@ def test_provide_fail(providers: list[Provider2]) -> None:
         [dictprovider({}), dictprovider({"marker": ""})],
     ],
 )
-def test_provide_pass(providers: list[Provider2]) -> None:
+def test_provide_pass(providers: list[Provider]) -> None:
     """It returns a path to the filesystem."""
     repository = provide(providers, URL(), None)
     assert repository.path.is_dir()

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -29,10 +29,10 @@ from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
 
 
-Provider = Callable[[Location, Optional[Revision]], Optional[Repository]]
+ProviderFunction = Callable[[Location, Optional[Revision]], Optional[Repository]]
 
 
-def provider2(function: Provider) -> Provider2:
+def provider2(function: ProviderFunction) -> Provider2:
     """Decorator to create a provider from a function."""
 
     class _Provider(Provider2):

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -49,7 +49,7 @@ def nullprovider(
     return None
 
 
-def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider:
+def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider2:
     """Provider that matches every URL with a filesystem."""
 
     @provider2
@@ -73,7 +73,7 @@ def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider:
         [nullprovider, nullprovider],
     ],
 )
-def test_provide_fail(providers: list[Provider]) -> None:
+def test_provide_fail(providers: list[Provider2]) -> None:
     """It raises an exception."""
     with pytest.raises(Exception):
         provide(providers, URL(), None)
@@ -88,7 +88,7 @@ def test_provide_fail(providers: list[Provider]) -> None:
         [dictprovider({}), dictprovider({"marker": ""})],
     ],
 )
-def test_provide_pass(providers: list[Provider]) -> None:
+def test_provide_pass(providers: list[Provider2]) -> None:
     """It returns a path to the filesystem."""
     repository = provide(providers, URL(), None)
     assert repository.path.is_dir()
@@ -325,6 +325,7 @@ def test_repositoryprovider_unknown_provider_in_url_scheme(
     repositorypath = Path(filesystem=DictFilesystem({}))
     repository = Repository("example", repositorypath, None)
 
+    @provider2
     def fakeprovider(
         location: Location, revision: Optional[Revision]
     ) -> Optional[Repository]:

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -32,7 +32,7 @@ from cutty.repositories.domain.stores import Store
 ProviderFunction = Callable[[Location, Optional[Revision]], Optional[Repository]]
 
 
-def provider2(function: ProviderFunction) -> Provider:
+def provider(function: ProviderFunction) -> Provider:
     """Decorator to create a provider from a function."""
 
     class _Provider(Provider):
@@ -44,7 +44,7 @@ def provider2(function: ProviderFunction) -> Provider:
     return _Provider()
 
 
-@provider2
+@provider
 def nullprovider(
     location: Location, revision: Optional[Revision]
 ) -> Optional[Repository]:
@@ -55,7 +55,7 @@ def nullprovider(
 def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider:
     """Provider that matches every URL with a filesystem."""
 
-    @provider2
+    @provider
     def _provider(
         location: Location, revision: Optional[Revision]
     ) -> Optional[Repository]:
@@ -328,7 +328,7 @@ def test_repositoryprovider_unknown_provider_in_url_scheme(
     repositorypath = Path(filesystem=DictFilesystem({}))
     repository = Repository("example", repositorypath, None)
 
-    @provider2
+    @provider
     def fakeprovider(
         location: Location, revision: Optional[Revision]
     ) -> Optional[Repository]:
@@ -336,10 +336,10 @@ def test_repositoryprovider_unknown_provider_in_url_scheme(
         return repository
 
     registry = {"default": constproviderfactory(fakeprovider)}
-    provider = repositoryprovider(registry, providerstore)
+    provider_ = repositoryprovider(registry, providerstore)
     url = url.with_scheme(f"invalid+{url.scheme}")
 
-    assert repository == provider(str(url))
+    assert repository == provider_(str(url))
 
 
 def test_repositoryprovider_name_from_url(

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -17,7 +17,7 @@ from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.locations import Location
 from cutty.repositories.domain.mounters import unversioned_mounter
 from cutty.repositories.domain.providers import constproviderfactory
-from cutty.repositories.domain.providers import localprovider
+from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import provide
 from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import ProviderStore
@@ -85,7 +85,7 @@ defaultmount = unversioned_mounter(DiskFilesystem)
 
 def test_localprovider_not_local(url: URL) -> None:
     """It returns None if the location is not local."""
-    provider = localprovider(match=lambda path: True, mount=defaultmount)
+    provider = LocalProvider(match=lambda path: True, mount=defaultmount)
 
     assert provider(url, None) is None
 
@@ -93,7 +93,7 @@ def test_localprovider_not_local(url: URL) -> None:
 def test_localprovider_not_matching(tmp_path: pathlib.Path) -> None:
     """It returns None if the provider does not match."""
     url = asurl(tmp_path)
-    provider = localprovider(match=lambda path: False, mount=defaultmount)
+    provider = LocalProvider(match=lambda path: False, mount=defaultmount)
 
     assert provider(url, None) is None
 
@@ -105,7 +105,7 @@ def test_localprovider_path(tmp_path: pathlib.Path) -> None:
     (repository / "marker").touch()
 
     url = asurl(repository)
-    provider = localprovider(match=lambda path: True, mount=defaultmount)
+    provider = LocalProvider(match=lambda path: True, mount=defaultmount)
     repository2 = provider(url, None)
 
     assert repository2 is not None
@@ -116,7 +116,7 @@ def test_localprovider_path(tmp_path: pathlib.Path) -> None:
 def test_localprovider_revision(tmp_path: pathlib.Path) -> None:
     """It raises an exception if the mounter does not support revisions."""
     url = asurl(tmp_path)
-    provider = localprovider(match=lambda path: True, mount=defaultmount)
+    provider = LocalProvider(match=lambda path: True, mount=defaultmount)
 
     with pytest.raises(Exception):
         provider(url, "v1.0.0")
@@ -131,7 +131,7 @@ def test_localprovider_repository_revision(tmp_path: pathlib.Path) -> None:
         """Return the contents of the VERSION file."""
         return (path / "VERSION").read_text().strip()
 
-    provider = localprovider(
+    provider = LocalProvider(
         match=lambda _: True, mount=defaultmount, getrevision=getrevision
     )
 
@@ -279,7 +279,7 @@ def test_repositoryprovider_with_path(
     (directory / "marker").touch()
 
     providerfactory = constproviderfactory(
-        localprovider(match=lambda path: True, mount=defaultmount)
+        LocalProvider(match=lambda path: True, mount=defaultmount)
     )
 
     provider = repositoryprovider({"default": providerfactory}, providerstore)


### PR DESCRIPTION
- :recycle: [repositories] Add class Provider2
- :recycle: [repositories] Replace `localprovider` function with `LocalProvider` class
- :recycle: [repositories] Inline `localprovider` alias
- :recycle: [repositories] Extract class `RemoteProvider` from `remoteproviderfactory`
- :recycle: [repositories] Make `nullprovider` and `dictprovider` `Provider2` instances
- :recycle: [repositories] Replace `Provider` with `Provider2`
- :recycle: [repositories] Move `Provider` type alias to tests
- :recycle: [repositories] Rename `Provider` to `ProviderFunction`
- :recycle: [repositories] Rename `Provider2` to `Provider`
- :recycle: [repositories] Rename function `provider2` to `provider`
- :recycle: [repositories] Remove redundant subclass in `nullprovider` definition
- :bulb: [repositories] Update obsolete docstring for `dictprovider`
