### PR TITLE
:recycle: [repositories] Extract class `ProviderRegistry`

### DIFF
--- a/src/cutty/repositories/adapters/registry.py
+++ b/src/cutty/repositories/adapters/registry.py
@@ -10,7 +10,7 @@ from cutty.repositories.adapters.providers.zip import zipproviderfactory
 from cutty.repositories.domain.providers import constproviderfactory as factory
 
 
-defaultproviderregistry = {
+defaultproviderfactories = {
     "localzip": factory(localzipprovider),
     "localgit": factory(localgitprovider),
     "local": factory(diskprovider),
@@ -19,4 +19,4 @@ defaultproviderregistry = {
 }
 
 if shutil.which("hg") is not None:  # pragma: no cover
-    defaultproviderregistry["hg"] = hgproviderfactory
+    defaultproviderfactories["hg"] = hgproviderfactory

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from yarl import URL
 
-from cutty.repositories.adapters.registry import defaultproviderregistry
+from cutty.repositories.adapters.registry import defaultproviderfactories
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderRegistry
 from cutty.repositories.domain.providers import ProviderStore
@@ -154,6 +154,6 @@ def getdefaultrepositoryprovider(
 ) -> ProviderRegistry:
     """Return a repository provider."""
     return ProviderRegistry(
-        defaultproviderregistry,
+        defaultproviderfactories,
         getdefaultproviderstore(path, timer=timer),
     )

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -16,8 +16,8 @@ from yarl import URL
 
 from cutty.repositories.adapters.registry import defaultproviderregistry
 from cutty.repositories.domain.providers import ProviderName
+from cutty.repositories.domain.providers import ProviderRegistry
 from cutty.repositories.domain.providers import ProviderStore
-from cutty.repositories.domain.providers import RepositoryProvider
 from cutty.repositories.domain.stores import Store
 
 
@@ -151,9 +151,9 @@ def getdefaultproviderstore(
 
 def getdefaultrepositoryprovider(
     path: pathlib.Path, *, timer: Timer = defaulttimer
-) -> RepositoryProvider:
+) -> ProviderRegistry:
     """Return a repository provider."""
-    return RepositoryProvider(
+    return ProviderRegistry(
         defaultproviderregistry,
         getdefaultproviderstore(path, timer=timer),
     )

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -18,7 +18,6 @@ from cutty.repositories.adapters.registry import defaultproviderregistry
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import RepositoryProvider
-from cutty.repositories.domain.providers import repositoryprovider
 from cutty.repositories.domain.stores import Store
 
 
@@ -154,7 +153,7 @@ def getdefaultrepositoryprovider(
     path: pathlib.Path, *, timer: Timer = defaulttimer
 ) -> RepositoryProvider:
     """Return a repository provider."""
-    return repositoryprovider(
+    return RepositoryProvider(
         defaultproviderregistry,
         getdefaultproviderstore(path, timer=timer),
     )

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -214,11 +214,11 @@ class ProviderRegistry:
         directory: Optional[PurePath] = None,
     ) -> Repository:
         """Return the repository located at the given URL."""
-        location_ = parselocation(rawlocation)
-        providername, location_ = self._splitprovidername(location_)
+        location = parselocation(rawlocation)
+        providername, location = self._splitprovidername(location)
         providers = self._createproviders(fetchmode, providername)
 
-        repository = provide(providers, location_, revision)
+        repository = provide(providers, location, revision)
 
         if directory is not None:
             name = directory.name

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -215,7 +215,7 @@ class ProviderRegistry:
     ) -> Repository:
         """Return the repository located at the given URL."""
         location = parselocation(rawlocation)
-        providername, location = self._splitprovidername(location)
+        providername, location = self._extractprovidername(location)
         providers = self._createproviders(fetchmode, providername)
 
         repository = provide(providers, location, revision)
@@ -229,7 +229,7 @@ class ProviderRegistry:
 
         return repository
 
-    def _splitprovidername(
+    def _extractprovidername(
         self, location: Location
     ) -> tuple[Optional[ProviderName], Location]:
         """Split off the provider name from the URL scheme, if any."""

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 from collections.abc import Mapping
 from dataclasses import dataclass
-from types import MappingProxyType
 from typing import Optional
 
 from yarl import URL
@@ -189,9 +188,6 @@ def remoteproviderfactory(
 ProviderName = str
 ProviderStore = Callable[[ProviderName], Store]
 ProviderFactories = Mapping[ProviderName, ProviderFactory]
-
-
-_emptyproviderregistry: ProviderFactories = MappingProxyType({})
 
 
 def constproviderfactory(provider: Provider) -> ProviderFactory:

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -208,13 +208,13 @@ class ProviderRegistry:
 
     def __call__(
         self,
-        location: str,
+        rawlocation: str,
         revision: Optional[Revision] = None,
         fetchmode: FetchMode = FetchMode.ALWAYS,
         directory: Optional[PurePath] = None,
     ) -> Repository:
         """Return the repository located at the given URL."""
-        location_ = parselocation(location)
+        location_ = parselocation(rawlocation)
         providername, location_ = self._splitprovidername(location_)
         providers = self._createproviders(fetchmode, providername)
 

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -201,17 +201,6 @@ def constproviderfactory(provider: Provider) -> ProviderFactory:
     return _providerfactory
 
 
-def _createprovider(
-    providername: ProviderName,
-    providerfactory: ProviderFactory,
-    providerstore: ProviderStore,
-    fetchmode: FetchMode,
-) -> Provider:
-    """Create a provider."""
-    store = providerstore(providername)
-    return providerfactory(store, fetchmode)
-
-
 def _splitprovidername(
     location: Location, providerregistry: ProviderRegistry
 ) -> tuple[Optional[ProviderName], Location]:
@@ -266,11 +255,17 @@ class RepositoryProvider:
         """Create providers."""
         if providername is not None:
             providerfactory = self.providerregistry[providername]
-            yield _createprovider(
-                providername, providerfactory, self.providerstore, fetchmode
-            )
+            yield self._createprovider(providername, providerfactory, fetchmode)
         else:
             for providername, providerfactory in self.providerregistry.items():
-                yield _createprovider(
-                    providername, providerfactory, self.providerstore, fetchmode
-                )
+                yield self._createprovider(providername, providerfactory, fetchmode)
+
+    def _createprovider(
+        self,
+        providername: ProviderName,
+        providerfactory: ProviderFactory,
+        fetchmode: FetchMode,
+    ) -> Provider:
+        """Create a provider."""
+        store = self.providerstore(providername)
+        return providerfactory(store, fetchmode)

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -217,12 +217,10 @@ def _splitprovidername(
 class RepositoryProvider:
     """The repository provider turns a repository URL into a filesystem path."""
 
-    def __init__(
-        self, providerregistry: ProviderRegistry, providerstore: ProviderStore
-    ) -> None:
+    def __init__(self, registry: ProviderRegistry, store: ProviderStore) -> None:
         """Initialize."""
-        self.providerregistry = providerregistry
-        self.providerstore = providerstore
+        self.registry = registry
+        self.store = store
 
     def __call__(
         self,
@@ -233,7 +231,7 @@ class RepositoryProvider:
     ) -> Repository:
         """Return the repository located at the given URL."""
         location_ = parselocation(location)
-        providername, location_ = _splitprovidername(location_, self.providerregistry)
+        providername, location_ = _splitprovidername(location_, self.registry)
         providers = self._createproviders(fetchmode, providername)
 
         repository = provide(providers, location_, revision)
@@ -254,10 +252,10 @@ class RepositoryProvider:
     ) -> Iterator[Provider]:
         """Create providers."""
         if providername is not None:
-            providerfactory = self.providerregistry[providername]
+            providerfactory = self.registry[providername]
             yield self._createprovider(providername, providerfactory, fetchmode)
         else:
-            for providername, providerfactory in self.providerregistry.items():
+            for providername, providerfactory in self.registry.items():
                 yield self._createprovider(providername, providerfactory, fetchmode)
 
     def _createprovider(
@@ -267,5 +265,5 @@ class RepositoryProvider:
         fetchmode: FetchMode,
     ) -> Provider:
         """Create a provider."""
-        store = self.providerstore(providername)
+        store = self.store(providername)
         return providerfactory(store, fetchmode)

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -160,6 +160,8 @@ class RemoteProvider(BaseProvider):
         return None
 
 
+ProviderName = str
+ProviderStore = Callable[[ProviderName], Store]
 ProviderFactory = Callable[[Store, FetchMode], Provider]
 
 
@@ -183,10 +185,6 @@ def remoteproviderfactory(
         )
 
     return _remoteproviderfactory
-
-
-ProviderName = str
-ProviderStore = Callable[[ProviderName], Store]
 
 
 def constproviderfactory(provider: Provider) -> ProviderFactory:

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -188,10 +188,10 @@ def remoteproviderfactory(
 
 ProviderName = str
 ProviderStore = Callable[[ProviderName], Store]
-ProviderRegistry = Mapping[ProviderName, ProviderFactory]
+ProviderFactories = Mapping[ProviderName, ProviderFactory]
 
 
-_emptyproviderregistry: ProviderRegistry = MappingProxyType({})
+_emptyproviderregistry: ProviderFactories = MappingProxyType({})
 
 
 def constproviderfactory(provider: Provider) -> ProviderFactory:
@@ -206,7 +206,7 @@ def constproviderfactory(provider: Provider) -> ProviderFactory:
 class RepositoryProvider:
     """The repository provider retrieves repositories using registered providers."""
 
-    def __init__(self, registry: ProviderRegistry, store: ProviderStore) -> None:
+    def __init__(self, registry: ProviderFactories, store: ProviderStore) -> None:
         """Initialize."""
         self.registry = registry
         self.store = store

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -276,6 +276,3 @@ class RepositoryProvider:
             return Repository(name, path, repository.revision)
 
         return repository
-
-
-repositoryprovider = RepositoryProvider

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -203,7 +203,7 @@ def constproviderfactory(provider: Provider) -> ProviderFactory:
     return _providerfactory
 
 
-class RepositoryProvider:
+class ProviderRegistry:
     """The repository provider retrieves repositories using registered providers."""
 
     def __init__(self, registry: ProviderFactories, store: ProviderStore) -> None:

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -197,7 +197,7 @@ def constproviderfactory(provider: Provider) -> ProviderFactory:
 
 
 class ProviderRegistry:
-    """The repository provider retrieves repositories using registered providers."""
+    """The provider registry retrieves repositories using registered providers."""
 
     def __init__(
         self, registry: Mapping[ProviderName, ProviderFactory], store: ProviderStore

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -65,7 +65,6 @@ def provide(
     raise UnknownLocationError(location)
 
 
-ProviderFactory = Callable[[Store, FetchMode], Provider]
 GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]
 
 
@@ -160,6 +159,9 @@ class RemoteProvider(BaseProvider):
                     return self._loadrepository(location, revision, path)
 
         return None
+
+
+ProviderFactory = Callable[[Store, FetchMode], Provider]
 
 
 def remoteproviderfactory(

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -204,7 +204,7 @@ def constproviderfactory(provider: Provider) -> ProviderFactory:
 
 
 class RepositoryProvider:
-    """The repository provider turns a repository URL into a filesystem path."""
+    """The repository provider retrieves repositories using registered providers."""
 
     def __init__(self, registry: ProviderRegistry, store: ProviderStore) -> None:
         """Initialize."""

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -39,19 +39,6 @@ class Repository:
     revision: Optional[Revision]
 
 
-class RepositoryProvider(Protocol):
-    """The repository provider turns a repository URL into a filesystem path."""
-
-    def __call__(
-        self,
-        location: str,
-        revision: Optional[Revision] = None,
-        fetchmode: FetchMode = FetchMode.ALWAYS,
-        directory: Optional[PurePath] = None,
-    ) -> Repository:
-        """Return the repository located at the given URL."""
-
-
 class Provider:
     """Provider for a specific type of repository."""
 
@@ -254,6 +241,19 @@ def _splitprovidername(
             return providername, location.with_scheme(scheme)
 
     return None, location
+
+
+class RepositoryProvider(Protocol):
+    """The repository provider turns a repository URL into a filesystem path."""
+
+    def __call__(
+        self,
+        location: str,
+        revision: Optional[Revision] = None,
+        fetchmode: FetchMode = FetchMode.ALWAYS,
+        directory: Optional[PurePath] = None,
+    ) -> Repository:
+        """Return the repository located at the given URL."""
 
 
 def repositoryprovider(

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -187,7 +187,6 @@ def remoteproviderfactory(
 
 ProviderName = str
 ProviderStore = Callable[[ProviderName], Store]
-ProviderFactories = Mapping[ProviderName, ProviderFactory]
 
 
 def constproviderfactory(provider: Provider) -> ProviderFactory:
@@ -202,7 +201,9 @@ def constproviderfactory(provider: Provider) -> ProviderFactory:
 class ProviderRegistry:
     """The repository provider retrieves repositories using registered providers."""
 
-    def __init__(self, registry: ProviderFactories, store: ProviderStore) -> None:
+    def __init__(
+        self, registry: Mapping[ProviderName, ProviderFactory], store: ProviderStore
+    ) -> None:
         """Initialize."""
         self.registry = registry
         self.store = store

--- a/tests/unit/repositories/adapters/test_registry.py
+++ b/tests/unit/repositories/adapters/test_registry.py
@@ -1,26 +1,26 @@
 """Unit tests for cutty.repositories.adapters.registry."""
 from yarl import URL
 
-from cutty.repositories.adapters.registry import defaultproviderregistry
+from cutty.repositories.adapters.registry import defaultproviderfactories
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.stores import Store
 
 
-def test_defaultproviderregistry_non_empty() -> None:
+def test_defaultproviderfactories_non_empty() -> None:
     """It is not empty."""
-    assert defaultproviderregistry
+    assert defaultproviderfactories
 
 
-def test_defaultproviderregistry_strings() -> None:
+def test_defaultproviderfactories_strings() -> None:
     """Its keys are strings."""
     assert all(
-        isinstance(providername, str) for providername in defaultproviderregistry
+        isinstance(providername, str) for providername in defaultproviderfactories
     )
 
 
-def test_defaultproviderregistry_providerfactories(store: Store) -> None:
+def test_defaultproviderfactories_providerfactories(store: Store) -> None:
     """Its values are provider factories."""
     url = URL("mailto:you@example.com")
-    for providerfactory in defaultproviderregistry.values():
+    for providerfactory in defaultproviderfactories.values():
         provider = providerfactory(store, FetchMode.ALWAYS)
         assert provider(url, None) is None

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -21,10 +21,10 @@ from cutty.repositories.domain.providers import constproviderfactory
 from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import provide
 from cutty.repositories.domain.providers import Provider
+from cutty.repositories.domain.providers import ProviderRegistry
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import remoteproviderfactory
 from cutty.repositories.domain.providers import Repository
-from cutty.repositories.domain.providers import RepositoryProvider
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
 
@@ -281,7 +281,7 @@ def test_remoteproviderfactory_mounter(
 
 def test_repositoryprovider_none(providerstore: ProviderStore, url: URL) -> None:
     """It raises an exception if the registry is empty."""
-    provider = RepositoryProvider({}, providerstore)
+    provider = ProviderRegistry({}, providerstore)
     with pytest.raises(Exception):
         provider(str(url))
 
@@ -291,7 +291,7 @@ def test_repositoryprovider_with_url(
 ) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory(fetch=[fetcher])
-    provider = RepositoryProvider({"default": providerfactory}, providerstore)
+    provider = ProviderRegistry({"default": providerfactory}, providerstore)
     repository = provider(str(url))
     assert not list(repository.path.iterdir())
 
@@ -308,7 +308,7 @@ def test_repositoryprovider_with_path(
         LocalProvider(match=lambda path: True, mount=defaultmount)
     )
 
-    provider = RepositoryProvider({"default": providerfactory}, providerstore)
+    provider = ProviderRegistry({"default": providerfactory}, providerstore)
     repository = provider(str(directory))
     [entry] = repository.path.iterdir()
 
@@ -324,7 +324,7 @@ def test_repositoryprovider_with_provider_specific_url(
         "default": remoteproviderfactory(fetch=[fetcher]),
         "null": constproviderfactory(nullprovider),
     }
-    provider = RepositoryProvider(registry, providerstore)
+    provider = ProviderRegistry(registry, providerstore)
     with pytest.raises(Exception):
         provider(str(url))
 
@@ -337,7 +337,7 @@ def test_repositoryprovider_unknown_provider_in_url_scheme(
     repository = Repository("example", repositorypath, None)
 
     registry = {"default": constproviderfactory(constprovider(repository))}
-    provider_ = RepositoryProvider(registry, providerstore)
+    provider_ = ProviderRegistry(registry, providerstore)
     url = url.with_scheme(f"invalid+{url.scheme}")
 
     assert repository == provider_(str(url))
@@ -348,6 +348,6 @@ def test_repositoryprovider_name_from_url(
 ) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory(fetch=[fetcher])
-    provider = RepositoryProvider({"default": providerfactory}, providerstore)
+    provider = ProviderRegistry({"default": providerfactory}, providerstore)
     repository = provider("https://example.com/path/to/example?query#fragment")
     assert "example" == repository.name

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -24,7 +24,7 @@ from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import remoteproviderfactory
 from cutty.repositories.domain.providers import Repository
-from cutty.repositories.domain.providers import repositoryprovider
+from cutty.repositories.domain.providers import RepositoryProvider
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
 
@@ -269,7 +269,7 @@ def test_remoteproviderfactory_mounter(
 
 def test_repositoryprovider_none(providerstore: ProviderStore, url: URL) -> None:
     """It raises an exception if the registry is empty."""
-    provider = repositoryprovider({}, providerstore)
+    provider = RepositoryProvider({}, providerstore)
     with pytest.raises(Exception):
         provider(str(url))
 
@@ -279,7 +279,7 @@ def test_repositoryprovider_with_url(
 ) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory(fetch=[fetcher])
-    provider = repositoryprovider({"default": providerfactory}, providerstore)
+    provider = RepositoryProvider({"default": providerfactory}, providerstore)
     repository = provider(str(url))
     assert not list(repository.path.iterdir())
 
@@ -296,7 +296,7 @@ def test_repositoryprovider_with_path(
         LocalProvider(match=lambda path: True, mount=defaultmount)
     )
 
-    provider = repositoryprovider({"default": providerfactory}, providerstore)
+    provider = RepositoryProvider({"default": providerfactory}, providerstore)
     repository = provider(str(directory))
     [entry] = repository.path.iterdir()
 
@@ -312,7 +312,7 @@ def test_repositoryprovider_with_provider_specific_url(
         "default": remoteproviderfactory(fetch=[fetcher]),
         "null": constproviderfactory(nullprovider),
     }
-    provider = repositoryprovider(registry, providerstore)
+    provider = RepositoryProvider(registry, providerstore)
     with pytest.raises(Exception):
         provider(str(url))
 
@@ -332,7 +332,7 @@ def test_repositoryprovider_unknown_provider_in_url_scheme(
         return repository
 
     registry = {"default": constproviderfactory(fakeprovider)}
-    provider_ = repositoryprovider(registry, providerstore)
+    provider_ = RepositoryProvider(registry, providerstore)
     url = url.with_scheme(f"invalid+{url.scheme}")
 
     assert repository == provider_(str(url))
@@ -343,6 +343,6 @@ def test_repositoryprovider_name_from_url(
 ) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory(fetch=[fetcher])
-    provider = repositoryprovider({"default": providerfactory}, providerstore)
+    provider = RepositoryProvider({"default": providerfactory}, providerstore)
     repository = provider("https://example.com/path/to/example?query#fragment")
     assert "example" == repository.name

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -48,6 +48,18 @@ nullprovider = Provider()
 """Provider that matches no location."""
 
 
+def constprovider(repository: Repository) -> Provider:
+    """Provider that returns the same repository always."""
+
+    @provider
+    def _constprovider(
+        location: Location, revision: Optional[Revision]
+    ) -> Optional[Repository]:
+        return repository
+
+    return _constprovider
+
+
 def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider:
     """Provider that matches every URL with a repository."""
 
@@ -324,14 +336,7 @@ def test_repositoryprovider_unknown_provider_in_url_scheme(
     repositorypath = Path(filesystem=DictFilesystem({}))
     repository = Repository("example", repositorypath, None)
 
-    @provider
-    def fakeprovider(
-        location: Location, revision: Optional[Revision]
-    ) -> Optional[Repository]:
-        """Fake provider."""
-        return repository
-
-    registry = {"default": constproviderfactory(fakeprovider)}
+    registry = {"default": constproviderfactory(constprovider(repository))}
     provider_ = RepositoryProvider(registry, providerstore)
     url = url.with_scheme(f"invalid+{url.scheme}")
 


### PR DESCRIPTION
- :recycle: [repositories] Slide protocol definition of `RepositoryProvider`
- :recycle: [repositories] Replace `RepositoryProvider` protocol with concrete class
- :recycle: [repositories] Inline alias `repositoryprovider`
- :recycle: [repositories] Move function `_createproviders` into `RepositoryProvider`
- :recycle: [repositories] Move function `_createprovider` into `RepositoryProvider`
- :recycle: [repository] Omit `provider` prefix from `RepositoryProvider` attributes
- :recycle: [repositories] Move function `_splitprovidername` into `RepositoryProvider`
- :recycle: [repositories] Replace `fakeprovider` with `constprovider`
- :recycle: [repositories] Slide definition of `ProviderFactory`
- :bulb: [repositories] Update obsolete docstring for `RepositoryProvider`
- :recycle: [repositories] Rename `ProviderRegistry` to `ProviderFactories`
- :recycle: [repositories] Rename `RepositoryProvider` to `ProviderRegistry`
- :recycle: [repositories] Rename variable `provider` to `registry`
- :recycle: [repositories] Rename `defaultproviderregistry` to `defaultproviderfactories`
- :recycle: [repositories] Remove variable `_emptyproviderregistry`
- :recycle: [repositories] Inline type alias `ProviderFactories`
- :recycle: [repositories] Slide definitions of `ProviderName` and `ProviderStore`
- :bulb: [repositories] Update obsolete docstring of `ProviderRegistry`
- :recycle: [repositories] Rename parameter `location` to `rawlocation`
- :recycle: [repositories] Rename variable `location_` to `location`
- :recycle: [repositories] Rename function `_{split => extract}providername`
