### PR TITLE
:recycle: [repositories] Move `ProviderRegistry` to `registry` module

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -2,7 +2,7 @@
 from typing import NoReturn
 
 from cutty.errors import CuttyError
-from cutty.repositories.domain.providers import UnknownLocationError
+from cutty.repositories.domain.registry import UnknownLocationError
 from cutty.util.exceptionhandlers import exceptionhandler
 
 

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -16,8 +16,8 @@ from yarl import URL
 
 from cutty.repositories.adapters.registry import defaultproviderfactories
 from cutty.repositories.domain.providers import ProviderName
-from cutty.repositories.domain.providers import ProviderRegistry
 from cutty.repositories.domain.providers import ProviderStore
+from cutty.repositories.domain.registry import ProviderRegistry
 from cutty.repositories.domain.stores import Store
 
 

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -2,8 +2,6 @@
 import pathlib
 from collections.abc import Callable
 from collections.abc import Iterable
-from collections.abc import Iterator
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Optional
 
@@ -13,14 +11,11 @@ from cutty.errors import CuttyError
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.filesystems.domain.path import Path
-from cutty.filesystems.domain.pathfs import PathFilesystem
-from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.domain.fetchers import Fetcher
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import aspath
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.locations import Location
-from cutty.repositories.domain.locations import parselocation
 from cutty.repositories.domain.matchers import Matcher
 from cutty.repositories.domain.matchers import PathMatcher
 from cutty.repositories.domain.mounters import Mounter
@@ -194,72 +189,3 @@ def constproviderfactory(provider: Provider) -> ProviderFactory:
         return provider
 
     return _providerfactory
-
-
-class ProviderRegistry:
-    """The provider registry retrieves repositories using registered providers."""
-
-    def __init__(
-        self, registry: Mapping[ProviderName, ProviderFactory], store: ProviderStore
-    ) -> None:
-        """Initialize."""
-        self.registry = registry
-        self.store = store
-
-    def __call__(
-        self,
-        rawlocation: str,
-        revision: Optional[Revision] = None,
-        fetchmode: FetchMode = FetchMode.ALWAYS,
-        directory: Optional[PurePath] = None,
-    ) -> Repository:
-        """Return the repository located at the given URL."""
-        location = parselocation(rawlocation)
-        providername, location = self._extractprovidername(location)
-        providers = self._createproviders(fetchmode, providername)
-
-        repository = provide(providers, location, revision)
-
-        if directory is not None:
-            name = directory.name
-            path = Path(
-                filesystem=PathFilesystem(repository.path.joinpath(*directory.parts))
-            )
-            return Repository(name, path, repository.revision)
-
-        return repository
-
-    def _extractprovidername(
-        self, location: Location
-    ) -> tuple[Optional[ProviderName], Location]:
-        """Split off the provider name from the URL scheme, if any."""
-        if isinstance(location, URL):
-            providername, _, scheme = location.scheme.rpartition("+")
-
-            if providername and providername in self.registry:
-                return providername, location.with_scheme(scheme)
-
-        return None, location
-
-    def _createproviders(
-        self,
-        fetchmode: FetchMode,
-        providername: Optional[ProviderName],
-    ) -> Iterator[Provider]:
-        """Create providers."""
-        if providername is not None:
-            providerfactory = self.registry[providername]
-            yield self._createprovider(providername, providerfactory, fetchmode)
-        else:
-            for providername, providerfactory in self.registry.items():
-                yield self._createprovider(providername, providerfactory, fetchmode)
-
-    def _createprovider(
-        self,
-        providername: ProviderName,
-        providerfactory: ProviderFactory,
-        fetchmode: FetchMode,
-    ) -> Provider:
-        """Create a provider."""
-        store = self.store(providername)
-        return providerfactory(store, fetchmode)

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 from yarl import URL
 
-from cutty.errors import CuttyError
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.filesystems.domain.path import Path
@@ -39,24 +38,6 @@ class Provider:
         self, location: Location, revision: Optional[Revision]
     ) -> Optional[Repository]:
         """Return the repository at the given location."""
-
-
-@dataclass
-class UnknownLocationError(CuttyError):
-    """The repository location could not be processed by any provider."""
-
-    location: Location
-
-
-def provide(
-    providers: Iterable[Provider], location: Location, revision: Optional[Revision]
-) -> Repository:
-    """Provide the repository located at the given URL."""
-    for provider in providers:
-        if repository := provider(location, revision):
-            return repository
-
-    raise UnknownLocationError(location)
 
 
 GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -1,0 +1,89 @@
+"""The provider registry is the main entry point of cutty.repositories."""
+from collections.abc import Iterator
+from collections.abc import Mapping
+from typing import Optional
+
+from yarl import URL
+
+from cutty.filesystems.domain.path import Path
+from cutty.filesystems.domain.pathfs import PathFilesystem
+from cutty.filesystems.domain.purepath import PurePath
+from cutty.repositories.domain.fetchers import FetchMode
+from cutty.repositories.domain.locations import Location
+from cutty.repositories.domain.locations import parselocation
+from cutty.repositories.domain.providers import provide
+from cutty.repositories.domain.providers import Provider
+from cutty.repositories.domain.providers import ProviderFactory
+from cutty.repositories.domain.providers import ProviderName
+from cutty.repositories.domain.providers import ProviderStore
+from cutty.repositories.domain.providers import Repository
+from cutty.repositories.domain.revisions import Revision
+
+
+class ProviderRegistry:
+    """The provider registry retrieves repositories using registered providers."""
+
+    def __init__(
+        self, registry: Mapping[ProviderName, ProviderFactory], store: ProviderStore
+    ) -> None:
+        """Initialize."""
+        self.registry = registry
+        self.store = store
+
+    def __call__(
+        self,
+        rawlocation: str,
+        revision: Optional[Revision] = None,
+        fetchmode: FetchMode = FetchMode.ALWAYS,
+        directory: Optional[PurePath] = None,
+    ) -> Repository:
+        """Return the repository located at the given URL."""
+        location = parselocation(rawlocation)
+        providername, location = self._extractprovidername(location)
+        providers = self._createproviders(fetchmode, providername)
+
+        repository = provide(providers, location, revision)
+
+        if directory is not None:
+            name = directory.name
+            path = Path(
+                filesystem=PathFilesystem(repository.path.joinpath(*directory.parts))
+            )
+            return Repository(name, path, repository.revision)
+
+        return repository
+
+    def _extractprovidername(
+        self, location: Location
+    ) -> tuple[Optional[ProviderName], Location]:
+        """Split off the provider name from the URL scheme, if any."""
+        if isinstance(location, URL):
+            providername, _, scheme = location.scheme.rpartition("+")
+
+            if providername and providername in self.registry:
+                return providername, location.with_scheme(scheme)
+
+        return None, location
+
+    def _createproviders(
+        self,
+        fetchmode: FetchMode,
+        providername: Optional[ProviderName],
+    ) -> Iterator[Provider]:
+        """Create providers."""
+        if providername is not None:
+            providerfactory = self.registry[providername]
+            yield self._createprovider(providername, providerfactory, fetchmode)
+        else:
+            for providername, providerfactory in self.registry.items():
+                yield self._createprovider(providername, providerfactory, fetchmode)
+
+    def _createprovider(
+        self,
+        providername: ProviderName,
+        providerfactory: ProviderFactory,
+        fetchmode: FetchMode,
+    ) -> Provider:
+        """Create a provider."""
+        store = self.store(providername)
+        return providerfactory(store, fetchmode)

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -19,11 +19,11 @@ from cutty.repositories.domain.locations import Location
 from cutty.repositories.domain.mounters import unversioned_mounter
 from cutty.repositories.domain.providers import constproviderfactory
 from cutty.repositories.domain.providers import LocalProvider
-from cutty.repositories.domain.providers import provide
 from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import remoteproviderfactory
 from cutty.repositories.domain.providers import Repository
+from cutty.repositories.domain.registry import provide
 from cutty.repositories.domain.registry import ProviderRegistry
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -21,10 +21,10 @@ from cutty.repositories.domain.providers import constproviderfactory
 from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import provide
 from cutty.repositories.domain.providers import Provider
-from cutty.repositories.domain.providers import ProviderRegistry
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import remoteproviderfactory
 from cutty.repositories.domain.providers import Repository
+from cutty.repositories.domain.registry import ProviderRegistry
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
 


### PR DESCRIPTION
- :recycle: [repositories] Move `ProviderRegistry` to `registry` module
- :recycle: [repositories] Move `provide` and `UnknownLocationError` to `registry`
