### PR TITLE
:recycle: [repositories] Extract method `Repository.descend`

### DIFF
--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -40,6 +40,16 @@ def provide(
     raise UnknownLocationError(location)
 
 
+def descend(repository: Repository, directory: PurePath) -> Repository:
+    """Return the subrepository located in the given directory."""
+    path = repository.path.joinpath(*directory.parts)
+    return Repository(
+        directory.name,
+        Path(filesystem=PathFilesystem(path)),
+        repository.revision,
+    )
+
+
 class ProviderRegistry:
     """The provider registry retrieves repositories using registered providers."""
 
@@ -64,15 +74,7 @@ class ProviderRegistry:
         providers = self._createproviders(fetchmode, providername)
         repository = provide(providers, location, revision)
 
-        if directory is not None:
-            path = repository.path.joinpath(*directory.parts)
-            return Repository(
-                directory.name,
-                Path(filesystem=PathFilesystem(path)),
-                repository.revision,
-            )
-
-        return repository
+        return repository if directory is None else descend(repository, directory)
 
     def _extractprovidername(
         self, location: Location

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -16,7 +16,6 @@ from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import ProviderFactory
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
-from cutty.repositories.domain.repository import descend
 from cutty.repositories.domain.repository import Repository
 from cutty.repositories.domain.revisions import Revision
 
@@ -63,7 +62,7 @@ class ProviderRegistry:
         providers = self._createproviders(fetchmode, providername)
         repository = provide(providers, location, revision)
 
-        return repository if directory is None else descend(repository, directory)
+        return repository if directory is None else repository.descend(directory)
 
     def _extractprovidername(
         self, location: Location

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -59,17 +59,18 @@ class ProviderRegistry:
     ) -> Repository:
         """Return the repository located at the given URL."""
         location = parselocation(rawlocation)
+
         providername, location = self._extractprovidername(location)
         providers = self._createproviders(fetchmode, providername)
-
         repository = provide(providers, location, revision)
 
         if directory is not None:
-            name = directory.name
-            path = Path(
-                filesystem=PathFilesystem(repository.path.joinpath(*directory.parts))
+            path = repository.path.joinpath(*directory.parts)
+            return Repository(
+                directory.name,
+                Path(filesystem=PathFilesystem(path)),
+                repository.revision,
             )
-            return Repository(name, path, repository.revision)
 
         return repository
 

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -8,8 +8,6 @@ from typing import Optional
 from yarl import URL
 
 from cutty.errors import CuttyError
-from cutty.filesystems.domain.path import Path
-from cutty.filesystems.domain.pathfs import PathFilesystem
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import Location
@@ -18,6 +16,7 @@ from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import ProviderFactory
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
+from cutty.repositories.domain.repository import descend
 from cutty.repositories.domain.repository import Repository
 from cutty.repositories.domain.revisions import Revision
 
@@ -38,16 +37,6 @@ def provide(
             return repository
 
     raise UnknownLocationError(location)
-
-
-def descend(repository: Repository, directory: PurePath) -> Repository:
-    """Return the subrepository located in the given directory."""
-    path = repository.path.joinpath(*directory.parts)
-    return Repository(
-        directory.name,
-        Path(filesystem=PathFilesystem(path)),
-        repository.revision,
-    )
 
 
 class ProviderRegistry:

--- a/src/cutty/repositories/domain/repository.py
+++ b/src/cutty/repositories/domain/repository.py
@@ -1,4 +1,6 @@
 """Repository."""
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 
@@ -16,12 +18,11 @@ class Repository:
     path: Path
     revision: Optional[Revision]
 
-
-def descend(repository: Repository, directory: PurePath) -> Repository:
-    """Return the subrepository located in the given directory."""
-    path = repository.path.joinpath(*directory.parts)
-    return Repository(
-        directory.name,
-        Path(filesystem=PathFilesystem(path)),
-        repository.revision,
-    )
+    def descend(self, directory: PurePath) -> Repository:
+        """Return the subrepository located in the given directory."""
+        path = self.path.joinpath(*directory.parts)
+        return Repository(
+            directory.name,
+            Path(filesystem=PathFilesystem(path)),
+            self.revision,
+        )

--- a/src/cutty/repositories/domain/repository.py
+++ b/src/cutty/repositories/domain/repository.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 from cutty.filesystems.domain.path import Path
+from cutty.filesystems.domain.pathfs import PathFilesystem
+from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.domain.revisions import Revision
 
 
@@ -13,3 +15,13 @@ class Repository:
     name: str
     path: Path
     revision: Optional[Revision]
+
+
+def descend(repository: Repository, directory: PurePath) -> Repository:
+    """Return the subrepository located in the given directory."""
+    path = repository.path.joinpath(*directory.parts)
+    return Repository(
+        directory.name,
+        Path(filesystem=PathFilesystem(path)),
+        repository.revision,
+    )


### PR DESCRIPTION
- :recycle: [repositories] Re-extract variable `path` in `ProviderRegistry`
- :recycle: [repositories] Extract function `descend` from `ProviderRegistry`
- :recycle: [repositories] Move function `descend` to `repository`
- :recycle: [repositories] Move function `descend` into `Repository` class
