### PR TITLE
:refactor: [repositories] Extract `ProviderFactory` class hierarchy and add `Provider.name`

### DIFF
--- a/src/cutty/repositories/adapters/providers/disk.py
+++ b/src/cutty/repositories/adapters/providers/disk.py
@@ -5,6 +5,7 @@ from cutty.repositories.domain.providers import LocalProvider
 
 
 diskprovider = LocalProvider(
+    "local",
     match=lambda path: path.is_dir(),
     mount=unversioned_mounter(DiskFilesystem),
 )

--- a/src/cutty/repositories/adapters/providers/git.py
+++ b/src/cutty/repositories/adapters/providers/git.py
@@ -7,7 +7,7 @@ import pygit2
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.repositories.adapters.fetchers.git import gitfetcher
 from cutty.repositories.domain.providers import LocalProvider
-from cutty.repositories.domain.providers import remoteproviderfactory
+from cutty.repositories.domain.providers import RemoteProviderFactory
 from cutty.repositories.domain.revisions import Revision
 
 
@@ -57,6 +57,6 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
 localgitprovider = LocalProvider(
     "localgit", match=match, mount=mount, getrevision=getrevision
 )
-gitproviderfactory = remoteproviderfactory(
+gitproviderfactory = RemoteProviderFactory(
     "git", fetch=[gitfetcher], mount=mount, getrevision=getrevision
 )

--- a/src/cutty/repositories/adapters/providers/git.py
+++ b/src/cutty/repositories/adapters/providers/git.py
@@ -54,7 +54,9 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
     return revision
 
 
-localgitprovider = LocalProvider(match=match, mount=mount, getrevision=getrevision)
+localgitprovider = LocalProvider(
+    "localgit", match=match, mount=mount, getrevision=getrevision
+)
 gitproviderfactory = remoteproviderfactory(
-    fetch=[gitfetcher], mount=mount, getrevision=getrevision
+    "git", fetch=[gitfetcher], mount=mount, getrevision=getrevision
 )

--- a/src/cutty/repositories/adapters/providers/mercurial.py
+++ b/src/cutty/repositories/adapters/providers/mercurial.py
@@ -24,4 +24,6 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
     return result.stdout
 
 
-hgproviderfactory = remoteproviderfactory(fetch=[hgfetcher], getrevision=getrevision)
+hgproviderfactory = remoteproviderfactory(
+    "hg", fetch=[hgfetcher], getrevision=getrevision
+)

--- a/src/cutty/repositories/adapters/providers/mercurial.py
+++ b/src/cutty/repositories/adapters/providers/mercurial.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from cutty.repositories.adapters.fetchers.mercurial import findhg
 from cutty.repositories.adapters.fetchers.mercurial import hgfetcher
-from cutty.repositories.domain.providers import remoteproviderfactory
+from cutty.repositories.domain.providers import RemoteProviderFactory
 from cutty.repositories.domain.revisions import Revision
 
 
@@ -24,6 +24,6 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
     return result.stdout
 
 
-hgproviderfactory = remoteproviderfactory(
+hgproviderfactory = RemoteProviderFactory(
     "hg", fetch=[hgfetcher], getrevision=getrevision
 )

--- a/src/cutty/repositories/adapters/providers/zip.py
+++ b/src/cutty/repositories/adapters/providers/zip.py
@@ -16,8 +16,9 @@ def match(path: Path) -> bool:
 
 
 mount = unversioned_mounter(ZipFilesystem)
-localzipprovider = LocalProvider(match=match, mount=mount)
+localzipprovider = LocalProvider("localzip", match=match, mount=mount)
 zipproviderfactory = remoteproviderfactory(
+    "zip",
     match=lambda url: url.path.lower().endswith(".zip"),
     fetch=[httpfetcher, ftpfetcher, filefetcher],
     mount=mount,

--- a/src/cutty/repositories/adapters/providers/zip.py
+++ b/src/cutty/repositories/adapters/providers/zip.py
@@ -7,7 +7,7 @@ from cutty.repositories.adapters.fetchers.ftp import ftpfetcher
 from cutty.repositories.adapters.fetchers.http import httpfetcher
 from cutty.repositories.domain.mounters import unversioned_mounter
 from cutty.repositories.domain.providers import LocalProvider
-from cutty.repositories.domain.providers import remoteproviderfactory
+from cutty.repositories.domain.providers import RemoteProviderFactory
 
 
 def match(path: Path) -> bool:
@@ -17,7 +17,7 @@ def match(path: Path) -> bool:
 
 mount = unversioned_mounter(ZipFilesystem)
 localzipprovider = LocalProvider("localzip", match=match, mount=mount)
-zipproviderfactory = remoteproviderfactory(
+zipproviderfactory = RemoteProviderFactory(
     "zip",
     match=lambda url: url.path.lower().endswith(".zip"),
     fetch=[httpfetcher, ftpfetcher, filefetcher],

--- a/src/cutty/repositories/adapters/registry.py
+++ b/src/cutty/repositories/adapters/registry.py
@@ -7,13 +7,13 @@ from cutty.repositories.adapters.providers.git import localgitprovider
 from cutty.repositories.adapters.providers.mercurial import hgproviderfactory
 from cutty.repositories.adapters.providers.zip import localzipprovider
 from cutty.repositories.adapters.providers.zip import zipproviderfactory
-from cutty.repositories.domain.providers import constproviderfactory as factory
+from cutty.repositories.domain.providers import ConstProviderFactory as Factory
 
 
 defaultproviderfactories = [
-    factory(localzipprovider),
-    factory(localgitprovider),
-    factory(diskprovider),
+    Factory(localzipprovider),
+    Factory(localgitprovider),
+    Factory(diskprovider),
     zipproviderfactory,
     gitproviderfactory,
 ]

--- a/src/cutty/repositories/adapters/registry.py
+++ b/src/cutty/repositories/adapters/registry.py
@@ -10,7 +10,7 @@ from cutty.repositories.adapters.providers.zip import zipproviderfactory
 from cutty.repositories.domain.providers import constproviderfactory as factory
 
 
-defaultproviderfactories2 = [
+defaultproviderfactories = [
     factory(localzipprovider),
     factory(localgitprovider),
     factory(diskprovider),
@@ -19,4 +19,4 @@ defaultproviderfactories2 = [
 ]
 
 if shutil.which("hg") is not None:  # pragma: no cover
-    defaultproviderfactories2.append(hgproviderfactory)
+    defaultproviderfactories.append(hgproviderfactory)

--- a/src/cutty/repositories/adapters/registry.py
+++ b/src/cutty/repositories/adapters/registry.py
@@ -20,8 +20,3 @@ defaultproviderfactories2 = [
 
 if shutil.which("hg") is not None:  # pragma: no cover
     defaultproviderfactories2.append(hgproviderfactory)
-
-defaultproviderfactories = {
-    providerfactory.name: providerfactory
-    for providerfactory in defaultproviderfactories2
-}

--- a/src/cutty/repositories/adapters/registry.py
+++ b/src/cutty/repositories/adapters/registry.py
@@ -10,13 +10,18 @@ from cutty.repositories.adapters.providers.zip import zipproviderfactory
 from cutty.repositories.domain.providers import constproviderfactory as factory
 
 
-defaultproviderfactories = {
-    "localzip": factory(localzipprovider),
-    "localgit": factory(localgitprovider),
-    "local": factory(diskprovider),
-    "zip": zipproviderfactory,
-    "git": gitproviderfactory,
-}
+defaultproviderfactories2 = [
+    factory(localzipprovider),
+    factory(localgitprovider),
+    factory(diskprovider),
+    zipproviderfactory,
+    gitproviderfactory,
+]
 
 if shutil.which("hg") is not None:  # pragma: no cover
-    defaultproviderfactories["hg"] = hgproviderfactory
+    defaultproviderfactories2.append(hgproviderfactory)
+
+defaultproviderfactories = {
+    providerfactory.name: providerfactory
+    for providerfactory in defaultproviderfactories2
+}

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -154,9 +154,7 @@ def getdefaultrepositoryprovider(
 ) -> ProviderRegistry:
     """Return a repository provider."""
     return ProviderRegistry(
-        {
-            providerfactory.name: providerfactory
-            for providerfactory in defaultproviderfactories
-        },
+        {},
         getdefaultproviderstore(path, timer=timer),
+        factories=defaultproviderfactories,
     )

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from yarl import URL
 
-from cutty.repositories.adapters.registry import defaultproviderfactories2
+from cutty.repositories.adapters.registry import defaultproviderfactories
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.registry import ProviderRegistry
@@ -156,7 +156,7 @@ def getdefaultrepositoryprovider(
     return ProviderRegistry(
         {
             providerfactory.name: providerfactory
-            for providerfactory in defaultproviderfactories2
+            for providerfactory in defaultproviderfactories
         },
         getdefaultproviderstore(path, timer=timer),
     )

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -154,7 +154,6 @@ def getdefaultrepositoryprovider(
 ) -> ProviderRegistry:
     """Return a repository provider."""
     return ProviderRegistry(
-        {},
         getdefaultproviderstore(path, timer=timer),
         factories=defaultproviderfactories,
     )

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -155,5 +155,5 @@ def getdefaultrepositoryprovider(
     """Return a repository provider."""
     return ProviderRegistry(
         getdefaultproviderstore(path, timer=timer),
-        factories=defaultproviderfactories,
+        defaultproviderfactories,
     )

--- a/src/cutty/repositories/adapters/storage.py
+++ b/src/cutty/repositories/adapters/storage.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from yarl import URL
 
-from cutty.repositories.adapters.registry import defaultproviderfactories
+from cutty.repositories.adapters.registry import defaultproviderfactories2
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.registry import ProviderRegistry
@@ -154,6 +154,9 @@ def getdefaultrepositoryprovider(
 ) -> ProviderRegistry:
     """Return a repository provider."""
     return ProviderRegistry(
-        defaultproviderfactories,
+        {
+            providerfactory.name: providerfactory
+            for providerfactory in defaultproviderfactories2
+        },
         getdefaultproviderstore(path, timer=timer),
     )

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -146,7 +146,7 @@ ProviderName = str
 ProviderStore = Callable[[ProviderName], Store]
 
 
-class ProviderFactory2(abc.ABC):
+class ProviderFactory(abc.ABC):
     """Provider factory."""
 
     def __init__(self, name: str = "") -> None:
@@ -158,7 +158,7 @@ class ProviderFactory2(abc.ABC):
         """Create a provider."""
 
 
-class RemoteProviderFactory(ProviderFactory2):
+class RemoteProviderFactory(ProviderFactory):
     """Factory for remote providers."""
 
     def __init__(
@@ -191,7 +191,7 @@ class RemoteProviderFactory(ProviderFactory2):
         )
 
 
-class ConstProviderFactory(ProviderFactory2):
+class ConstProviderFactory(ProviderFactory):
     """Provider factory returning a given provider."""
 
     def __init__(self, provider: Provider) -> None:

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -144,7 +144,6 @@ class RemoteProvider(BaseProvider):
 
 ProviderName = str
 ProviderStore = Callable[[ProviderName], Store]
-ProviderFactory = Callable[[Store, FetchMode], Provider]
 
 
 class ProviderFactory2(abc.ABC):

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -202,6 +202,3 @@ class ConstProviderFactory(ProviderFactory):
     def __call__(self, store: Store, fetchmode: FetchMode) -> Provider:
         """Return the provider."""
         return self.provider
-
-
-constproviderfactory = ConstProviderFactory

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -204,5 +204,4 @@ class ConstProviderFactory(ProviderFactory):
         return self.provider
 
 
-remoteproviderfactory = RemoteProviderFactory
 constproviderfactory = ConstProviderFactory

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -25,6 +25,10 @@ from cutty.repositories.domain.stores import Store
 class Provider:
     """Provider for a specific type of repository."""
 
+    def __init__(self, name: str = "") -> None:
+        """Initialize."""
+        self.name = name
+
     def __call__(
         self, location: Location, revision: Optional[Revision]
     ) -> Optional[Repository]:
@@ -39,11 +43,15 @@ class BaseProvider(Provider):
 
     def __init__(
         self,
+        name: str = "",
+        /,
         *,
         mount: Mounter,
         getrevision: Optional[GetRevision] = None,
     ) -> None:
         """Initialize."""
+        super().__init__(name)
+
         self.mount = mount
         self.getrevision = getrevision
 
@@ -63,13 +71,15 @@ class LocalProvider(BaseProvider):
 
     def __init__(
         self,
+        name: str = "local",
+        /,
         *,
         match: PathMatcher,
         mount: Mounter,
         getrevision: Optional[GetRevision] = None,
     ) -> None:
         """Initialize."""
-        super().__init__(mount=mount, getrevision=getrevision)
+        super().__init__(name, mount=mount, getrevision=getrevision)
         self.match = match
 
     def __call__(
@@ -96,6 +106,8 @@ class RemoteProvider(BaseProvider):
 
     def __init__(
         self,
+        name: str = "remote",
+        /,
         *,
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
@@ -106,7 +118,9 @@ class RemoteProvider(BaseProvider):
     ) -> None:
         """Initialize."""
         super().__init__(
-            mount=mount if mount is not None else _defaultmount, getrevision=getrevision
+            name,
+            mount=mount if mount is not None else _defaultmount,
+            getrevision=getrevision,
         )
         self.match = match
         self.fetch = tuple(fetch)
@@ -133,6 +147,8 @@ ProviderFactory = Callable[[Store, FetchMode], Provider]
 
 
 def remoteproviderfactory(
+    name: str = "remote",
+    /,
     *,
     match: Optional[Matcher] = None,
     fetch: Iterable[Fetcher],
@@ -143,6 +159,7 @@ def remoteproviderfactory(
 
     def _remoteproviderfactory(store: Store, fetchmode: FetchMode) -> Provider:
         return RemoteProvider(
+            name,
             match=match,
             fetch=fetch,
             mount=mount,

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -47,11 +47,10 @@ class ProviderRegistry:
         factories: Iterable[ProviderFactory2],
     ) -> None:
         """Initialize."""
-        registry2 = {
+        self.store = store
+        self.registry = {
             providerfactory.name: providerfactory for providerfactory in factories
         }
-        self.registry = {**registry2}
-        self.store = store
 
     def __call__(
         self,

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -12,7 +12,6 @@ from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import Location
 from cutty.repositories.domain.locations import parselocation
 from cutty.repositories.domain.providers import Provider
-from cutty.repositories.domain.providers import ProviderFactory
 from cutty.repositories.domain.providers import ProviderFactory2
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
@@ -88,17 +87,16 @@ class ProviderRegistry:
         """Create providers."""
         if providername is not None:
             providerfactory = self.registry[providername]
-            yield self._createprovider(providername, providerfactory, fetchmode)
+            yield self._createprovider(providerfactory, fetchmode)
         else:
-            for providername, providerfactory in self.registry.items():
-                yield self._createprovider(providername, providerfactory, fetchmode)
+            for providerfactory in self.registry.values():
+                yield self._createprovider(providerfactory, fetchmode)
 
     def _createprovider(
         self,
-        providername: ProviderName,
-        providerfactory: ProviderFactory,
+        providerfactory: ProviderFactory2,
         fetchmode: FetchMode,
     ) -> Provider:
         """Create a provider."""
-        store = self.store(providername)
+        store = self.store(providerfactory.name)
         return providerfactory(store, fetchmode)

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -14,6 +14,7 @@ from cutty.repositories.domain.locations import Location
 from cutty.repositories.domain.locations import parselocation
 from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import ProviderFactory
+from cutty.repositories.domain.providers import ProviderFactory2
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.repository import Repository
@@ -42,10 +43,16 @@ class ProviderRegistry:
     """The provider registry retrieves repositories using registered providers."""
 
     def __init__(
-        self, registry: Mapping[ProviderName, ProviderFactory], store: ProviderStore
+        self,
+        registry: Mapping[ProviderName, ProviderFactory],
+        store: ProviderStore,
+        factories: Iterable[ProviderFactory2] = (),
     ) -> None:
         """Initialize."""
-        self.registry = registry
+        registry2 = {
+            providerfactory.name: providerfactory for providerfactory in factories
+        }
+        self.registry = {**registry, **registry2}
         self.store = store
 
     def __call__(

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -12,7 +12,7 @@ from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import Location
 from cutty.repositories.domain.locations import parselocation
 from cutty.repositories.domain.providers import Provider
-from cutty.repositories.domain.providers import ProviderFactory2
+from cutty.repositories.domain.providers import ProviderFactory
 from cutty.repositories.domain.providers import ProviderName
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.repository import Repository
@@ -43,7 +43,7 @@ class ProviderRegistry:
     def __init__(
         self,
         store: ProviderStore,
-        factories: Iterable[ProviderFactory2],
+        factories: Iterable[ProviderFactory],
     ) -> None:
         """Initialize."""
         self.store = store
@@ -94,7 +94,7 @@ class ProviderRegistry:
 
     def _createprovider(
         self,
-        providerfactory: ProviderFactory2,
+        providerfactory: ProviderFactory,
         fetchmode: FetchMode,
     ) -> Provider:
         """Create a provider."""

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -1,7 +1,6 @@
 """The provider registry is the main entry point of cutty.repositories."""
 from collections.abc import Iterable
 from collections.abc import Iterator
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Optional
 
@@ -44,15 +43,14 @@ class ProviderRegistry:
 
     def __init__(
         self,
-        registry: Mapping[ProviderName, ProviderFactory],
         store: ProviderStore,
-        factories: Iterable[ProviderFactory2] = (),
+        factories: Iterable[ProviderFactory2],
     ) -> None:
         """Initialize."""
         registry2 = {
             providerfactory.name: providerfactory for providerfactory in factories
         }
-        self.registry = {**registry, **registry2}
+        self.registry = {**registry2}
         self.store = store
 
     def __call__(

--- a/tests/unit/repositories/adapters/test_registry.py
+++ b/tests/unit/repositories/adapters/test_registry.py
@@ -1,26 +1,19 @@
 """Unit tests for cutty.repositories.adapters.registry."""
 from yarl import URL
 
-from cutty.repositories.adapters.registry import defaultproviderfactories
+from cutty.repositories.adapters.registry import defaultproviderfactories2
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.stores import Store
 
 
 def test_defaultproviderfactories_non_empty() -> None:
     """It is not empty."""
-    assert defaultproviderfactories
-
-
-def test_defaultproviderfactories_strings() -> None:
-    """Its keys are strings."""
-    assert all(
-        isinstance(providername, str) for providername in defaultproviderfactories
-    )
+    assert defaultproviderfactories2
 
 
 def test_defaultproviderfactories_providerfactories(store: Store) -> None:
-    """Its values are provider factories."""
+    """Its items are provider factories."""
     url = URL("mailto:you@example.com")
-    for providerfactory in defaultproviderfactories.values():
+    for providerfactory in defaultproviderfactories2:
         provider = providerfactory(store, FetchMode.ALWAYS)
         assert provider(url, None) is None

--- a/tests/unit/repositories/adapters/test_registry.py
+++ b/tests/unit/repositories/adapters/test_registry.py
@@ -1,19 +1,19 @@
 """Unit tests for cutty.repositories.adapters.registry."""
 from yarl import URL
 
-from cutty.repositories.adapters.registry import defaultproviderfactories2
+from cutty.repositories.adapters.registry import defaultproviderfactories
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.stores import Store
 
 
 def test_defaultproviderfactories_non_empty() -> None:
     """It is not empty."""
-    assert defaultproviderfactories2
+    assert defaultproviderfactories
 
 
 def test_defaultproviderfactories_providerfactories(store: Store) -> None:
     """Its items are provider factories."""
     url = URL("mailto:you@example.com")
-    for providerfactory in defaultproviderfactories2:
+    for providerfactory in defaultproviderfactories:
         provider = providerfactory(store, FetchMode.ALWAYS)
         assert provider(url, None) is None

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -13,7 +13,7 @@ from cutty.repositories.domain.matchers import Matcher
 from cutty.repositories.domain.mounters import Mounter
 from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import Provider
-from cutty.repositories.domain.providers import remoteproviderfactory
+from cutty.repositories.domain.providers import RemoteProviderFactory
 from cutty.repositories.domain.registry import provide
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
@@ -126,7 +126,7 @@ def test_localprovider_repository_revision(
 
 def test_remoteproviderfactory_no_fetchers(store: Store) -> None:
     """It returns None if there are no fetchers."""
-    providerfactory = remoteproviderfactory(fetch=[])
+    providerfactory = RemoteProviderFactory(fetch=[])
     provider = providerfactory(store, FetchMode.ALWAYS)
     assert provider(URL(), None) is None
 
@@ -135,7 +135,7 @@ def test_remoteproviderfactory_no_matching_fetchers(
     store: Store, nullfetcher: Fetcher
 ) -> None:
     """It returns None if all fetchers return None."""
-    providerfactory = remoteproviderfactory(fetch=[nullfetcher])
+    providerfactory = RemoteProviderFactory(fetch=[nullfetcher])
     provider = providerfactory(store, FetchMode.ALWAYS)
     assert provider(URL(), None) is None
 
@@ -144,7 +144,7 @@ def test_remoteproviderfactory_happy(
     store: Store, emptyfetcher: Fetcher, url: URL
 ) -> None:
     """It mounts a filesystem for the fetched repository."""
-    providerfactory = remoteproviderfactory(fetch=[emptyfetcher])
+    providerfactory = RemoteProviderFactory(fetch=[emptyfetcher])
     provider = providerfactory(store, FetchMode.ALWAYS)
     repository = provider(url, None)
 
@@ -162,7 +162,7 @@ def test_remoteproviderfactory_repository_revision(
         """Return a fake version."""
         return "v1.0"
 
-    providerfactory = remoteproviderfactory(
+    providerfactory = RemoteProviderFactory(
         fetch=[emptyfetcher], getrevision=getrevision
     )
     provider = providerfactory(store, FetchMode.ALWAYS)
@@ -175,7 +175,7 @@ def test_remoteproviderfactory_not_matching(
     store: Store, emptyfetcher: Fetcher, url: URL, nullmatcher: Matcher
 ) -> None:
     """It returns None if the provider itself does not match."""
-    providerfactory = remoteproviderfactory(match=nullmatcher, fetch=[emptyfetcher])
+    providerfactory = RemoteProviderFactory(match=nullmatcher, fetch=[emptyfetcher])
     provider = providerfactory(store, FetchMode.ALWAYS)
     assert provider(url, None) is None
 
@@ -190,7 +190,7 @@ def test_remoteproviderfactory_mounter(
         text = json.dumps({revision: {"marker": "Lorem"}})
         path.write_text(text)
 
-    providerfactory = remoteproviderfactory(fetch=[emptyfetcher], mount=jsonmounter)
+    providerfactory = RemoteProviderFactory(fetch=[emptyfetcher], mount=jsonmounter)
     provider = providerfactory(store, FetchMode.ALWAYS)
     repository = provider(url, revision)
 

--- a/tests/unit/repositories/domain/test_registry.py
+++ b/tests/unit/repositories/domain/test_registry.py
@@ -27,7 +27,7 @@ pytest_plugins = [
 
 def test_repositoryprovider_none(providerstore: ProviderStore, url: URL) -> None:
     """It raises an exception if the registry is empty."""
-    registry = ProviderRegistry({}, providerstore, factories=[])
+    registry = ProviderRegistry(providerstore, factories=[])
     with pytest.raises(Exception):
         registry(str(url))
 
@@ -37,7 +37,7 @@ def test_repositoryprovider_with_url(
 ) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory("default", fetch=[emptyfetcher])
-    registry = ProviderRegistry({}, providerstore, factories=[providerfactory])
+    registry = ProviderRegistry(providerstore, factories=[providerfactory])
     repository = registry(str(url))
     assert not list(repository.path.iterdir())
 
@@ -56,7 +56,7 @@ def test_repositoryprovider_with_path(
         LocalProvider("default", match=lambda path: True, mount=diskmounter)
     )
 
-    registry = ProviderRegistry({}, providerstore, factories=[providerfactory])
+    registry = ProviderRegistry(providerstore, factories=[providerfactory])
     repository = registry(str(directory))
     [entry] = repository.path.iterdir()
 
@@ -72,7 +72,7 @@ def test_repositoryprovider_with_provider_specific_url(
         remoteproviderfactory("default", fetch=[emptyfetcher]),
         constproviderfactory(nullprovider),
     ]
-    registry = ProviderRegistry({}, providerstore, factories)
+    registry = ProviderRegistry(providerstore, factories)
     with pytest.raises(Exception):
         registry(str(url))
 
@@ -85,7 +85,7 @@ def test_repositoryprovider_unknown_provider_in_url_scheme(
     repository = Repository("example", repositorypath, None)
 
     factories = [constproviderfactory(constprovider("default", repository))]
-    registry = ProviderRegistry({}, providerstore, factories)
+    registry = ProviderRegistry(providerstore, factories)
     url = url.with_scheme(f"invalid+{url.scheme}")
 
     assert repository == registry(str(url))
@@ -96,6 +96,6 @@ def test_repositoryprovider_name_from_url(
 ) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory("default", fetch=[emptyfetcher])
-    registry = ProviderRegistry({}, providerstore, factories=[providerfactory])
+    registry = ProviderRegistry(providerstore, factories=[providerfactory])
     repository = registry("https://example.com/path/to/example?query#fragment")
     assert "example" == repository.name

--- a/tests/unit/repositories/domain/test_registry.py
+++ b/tests/unit/repositories/domain/test_registry.py
@@ -11,7 +11,7 @@ from cutty.repositories.domain.mounters import Mounter
 from cutty.repositories.domain.providers import constproviderfactory
 from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import ProviderStore
-from cutty.repositories.domain.providers import remoteproviderfactory
+from cutty.repositories.domain.providers import RemoteProviderFactory
 from cutty.repositories.domain.registry import ProviderRegistry
 from cutty.repositories.domain.repository import Repository
 from tests.fixtures.repositories.domain.providers import constprovider
@@ -36,7 +36,7 @@ def test_repositoryprovider_with_url(
     providerstore: ProviderStore, emptyfetcher: Fetcher, url: URL
 ) -> None:
     """It returns a provider that allows traversing repositories."""
-    providerfactory = remoteproviderfactory("default", fetch=[emptyfetcher])
+    providerfactory = RemoteProviderFactory("default", fetch=[emptyfetcher])
     registry = ProviderRegistry(providerstore, [providerfactory])
     repository = registry(str(url))
     assert not list(repository.path.iterdir())
@@ -69,7 +69,7 @@ def test_repositoryprovider_with_provider_specific_url(
     """It selects the provider indicated by the URL scheme."""
     url = url.with_scheme(f"null+{url.scheme}")
     factories = [
-        remoteproviderfactory("default", fetch=[emptyfetcher]),
+        RemoteProviderFactory("default", fetch=[emptyfetcher]),
         constproviderfactory(nullprovider),
     ]
     registry = ProviderRegistry(providerstore, factories)
@@ -95,7 +95,7 @@ def test_repositoryprovider_name_from_url(
     providerstore: ProviderStore, emptyfetcher: Fetcher
 ) -> None:
     """It returns a provider that allows traversing repositories."""
-    providerfactory = remoteproviderfactory("default", fetch=[emptyfetcher])
+    providerfactory = RemoteProviderFactory("default", fetch=[emptyfetcher])
     registry = ProviderRegistry(providerstore, [providerfactory])
     repository = registry("https://example.com/path/to/example?query#fragment")
     assert "example" == repository.name

--- a/tests/unit/repositories/domain/test_registry.py
+++ b/tests/unit/repositories/domain/test_registry.py
@@ -8,7 +8,7 @@ from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.repositories.domain.fetchers import Fetcher
 from cutty.repositories.domain.mounters import Mounter
-from cutty.repositories.domain.providers import constproviderfactory
+from cutty.repositories.domain.providers import ConstProviderFactory
 from cutty.repositories.domain.providers import LocalProvider
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import RemoteProviderFactory
@@ -52,7 +52,7 @@ def test_repositoryprovider_with_path(
     directory.mkdir()
     (directory / "marker").touch()
 
-    providerfactory = constproviderfactory(
+    providerfactory = ConstProviderFactory(
         LocalProvider("default", match=lambda path: True, mount=diskmounter)
     )
 
@@ -70,7 +70,7 @@ def test_repositoryprovider_with_provider_specific_url(
     url = url.with_scheme(f"null+{url.scheme}")
     factories = [
         RemoteProviderFactory("default", fetch=[emptyfetcher]),
-        constproviderfactory(nullprovider),
+        ConstProviderFactory(nullprovider),
     ]
     registry = ProviderRegistry(providerstore, factories)
     with pytest.raises(Exception):
@@ -84,7 +84,7 @@ def test_repositoryprovider_unknown_provider_in_url_scheme(
     repositorypath = Path(filesystem=DictFilesystem({}))
     repository = Repository("example", repositorypath, None)
 
-    factories = [constproviderfactory(constprovider("default", repository))]
+    factories = [ConstProviderFactory(constprovider("default", repository))]
     registry = ProviderRegistry(providerstore, factories)
     url = url.with_scheme(f"invalid+{url.scheme}")
 

--- a/tests/unit/repositories/domain/test_registry.py
+++ b/tests/unit/repositories/domain/test_registry.py
@@ -37,7 +37,7 @@ def test_repositoryprovider_with_url(
 ) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory("default", fetch=[emptyfetcher])
-    registry = ProviderRegistry(providerstore, factories=[providerfactory])
+    registry = ProviderRegistry(providerstore, [providerfactory])
     repository = registry(str(url))
     assert not list(repository.path.iterdir())
 
@@ -56,7 +56,7 @@ def test_repositoryprovider_with_path(
         LocalProvider("default", match=lambda path: True, mount=diskmounter)
     )
 
-    registry = ProviderRegistry(providerstore, factories=[providerfactory])
+    registry = ProviderRegistry(providerstore, [providerfactory])
     repository = registry(str(directory))
     [entry] = repository.path.iterdir()
 
@@ -96,6 +96,6 @@ def test_repositoryprovider_name_from_url(
 ) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = remoteproviderfactory("default", fetch=[emptyfetcher])
-    registry = ProviderRegistry(providerstore, factories=[providerfactory])
+    registry = ProviderRegistry(providerstore, [providerfactory])
     repository = registry("https://example.com/path/to/example?query#fragment")
     assert "example" == repository.name


### PR DESCRIPTION
- :recycle: [repositories] Add optional `name` attribute to `Provider`
- :recycle: [repositories] Store provider names in provider adapters
- :recycle: [repositories] Extract classes `RemoveProviderFactory` and `ConstProviderFactory`
- :recycle: [repositories] Remove duplication of provider names in `adapters.registry`
- :recycle: [repositories] Inline variable `defaultproviderfactories`
- :recycle: [repositories] Rename variable `defaultproviderfactories2`
- :recycle: [repositories] Add optional `factories` parameter to `ProviderRegistry`
- :recycle: [repositories] Use `factories` parameter in `getdefaultrepositoryprovider`
- :recycle: [repositories] Use `factories` parameter in registry tests
- :recycle: [repositories] Remove parameter `registry` for `ProviderRegistry`
- :recycle: [repositories] Inline variable `registry2`
- :recycle: [repositories] Omit keyword `factories` unless passing an empty list
- :recycle: [repositories] Remove `providername` parameter from `_createprovider`
- :recycle: [repositories] Remove type alias `ProviderFactory`
- :recycle: [repositories] Rename class `ProviderFactory2`
- :recycle: [repositories] Inline alias `remoteproviderfactory`
- :recycle: [repositories] Inline alias `constproviderfactory`
