### PR TITLE
:sparkles: [repositories] Do not invoke providers if the location is an inexistent path

### DIFF
--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -92,7 +92,7 @@ class LocalProvider(BaseProvider):
         except ValueError:
             return None
 
-        if self.match(path):
+        if path.exists() and self.match(path):
             return self._loadrepository(location, revision, path)
 
         return None

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -132,7 +132,12 @@ class RemoteProvider(BaseProvider):
         self, location: Location, revision: Optional[Revision]
     ) -> Optional[Repository]:
         """Return the repository at the given location."""
-        url = location if isinstance(location, URL) else asurl(location)
+        if isinstance(location, URL):
+            url = location
+        elif location.exists():
+            url = asurl(location)
+        else:
+            return None
 
         if self.match is None or self.match(url):
             for fetcher in self.fetch:

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -93,7 +93,13 @@ def test_commit_message_revision(runcutty: RunCutty, template: Path) -> None:
     assert str(revision)[:7] in repository.head.commit.message
 
 
-def test_unknown_location(runcutty: RunCutty) -> None:
+def test_unknown_location_invalid_url(runcutty: RunCutty) -> None:
     """It prints an error message."""
     with pytest.raises(Exception, match="unknown location"):
         runcutty("create", "invalid://location")
+
+
+def test_unknown_location_no_such_path(runcutty: RunCutty) -> None:
+    """It prints an error message."""
+    with pytest.raises(Exception, match="unknown location"):
+        runcutty("create", "/no/such/file/or/directory")

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -75,6 +75,14 @@ def test_localprovider_not_matching(
     assert provider(url, None) is None
 
 
+def test_localprovider_inexistent_path(diskmounter: Mounter) -> None:
+    """It returns None if the location is an inexistent path."""
+    provider = LocalProvider(match=lambda path: True, mount=diskmounter)
+    path = pathlib.Path("/no/such/file/or/directory")
+
+    assert provider(path, None) is None
+
+
 def test_localprovider_path(tmp_path: pathlib.Path, diskmounter: Mounter) -> None:
     """It returns the repository."""
     repository = tmp_path / "repository"

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -196,3 +196,14 @@ def test_remoteproviderfactory_mounter(
 
     assert repository is not None
     assert (repository.path / "marker").read_text() == "Lorem"
+
+
+def test_remoteproviderfactory_inexistent_path(
+    store: Store, emptyfetcher: Fetcher, nullmatcher: Matcher
+) -> None:
+    """It returns None if the location is an inexistent path."""
+    providerfactory = RemoteProviderFactory(fetch=[emptyfetcher])
+    provider = providerfactory(store, FetchMode.ALWAYS)
+    path = pathlib.Path("/no/such/file/or/directory")
+
+    assert provider(path, None) is None


### PR DESCRIPTION
- :white_check_mark: [functional] Add test for inexistent template path
- :white_check_mark: [repositories] Add test for remote provider with inexistent path
- :sparkles: [repositories] Do not invoke remote providers with inexistent paths
- :white_check_mark: [repositories] Add test for local provider with inexistent path
- :sparkles: [repositories] Do not invoke local providers with inexistent paths
