### PR TITLE
:recycle: [entrypoints] Refactor command-line error handlers

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -2,7 +2,6 @@
 import pathlib
 from typing import NoReturn
 
-from cutty.errors import CuttyError
 from cutty.repositories.domain.registry import UnknownLocationError
 from cutty.util.exceptionhandlers import exceptionhandler
 
@@ -19,9 +18,4 @@ def _unknownlocation(error: UnknownLocationError) -> NoReturn:
     _die(f"unknown location {error.location}")
 
 
-@exceptionhandler
-def _fatal(error: CuttyError) -> NoReturn:
-    _die(str(error))
-
-
-fatal = _unknownlocation >> _fatal
+fatal = _unknownlocation

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -10,14 +10,14 @@ from cutty.util.exceptionhandlers import exceptionhandler
 @exceptionhandler
 def _unknownlocation(error: UnknownLocationError) -> NoReturn:
     if isinstance(error.location, pathlib.Path) and not error.location.exists():
-        raise SystemExit(f"no such file or directory: {error.location}")
+        raise SystemExit(f"error: no such file or directory: {error.location}")
 
-    raise SystemExit(f"unknown location {error.location}")
+    raise SystemExit(f"error: unknown location {error.location}")
 
 
 @exceptionhandler
 def _fatal(error: CuttyError) -> NoReturn:
-    raise SystemExit(f"fatal: {error}")
+    raise SystemExit(f"error: {error}")
 
 
 fatal = _unknownlocation >> _fatal

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -7,17 +7,21 @@ from cutty.repositories.domain.registry import UnknownLocationError
 from cutty.util.exceptionhandlers import exceptionhandler
 
 
+def _die(message: str) -> NoReturn:
+    raise SystemExit(f"error: {message}")
+
+
 @exceptionhandler
 def _unknownlocation(error: UnknownLocationError) -> NoReturn:
     if isinstance(error.location, pathlib.Path) and not error.location.exists():
-        raise SystemExit(f"error: no such file or directory: {error.location}")
+        _die(f"no such file or directory: {error.location}")
 
-    raise SystemExit(f"error: unknown location {error.location}")
+    _die(f"unknown location {error.location}")
 
 
 @exceptionhandler
 def _fatal(error: CuttyError) -> NoReturn:
-    raise SystemExit(f"error: {error}")
+    _die(str(error))
 
 
 fatal = _unknownlocation >> _fatal

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -93,13 +93,7 @@ def test_commit_message_revision(runcutty: RunCutty, template: Path) -> None:
     assert str(revision)[:7] in repository.head.commit.message
 
 
-def test_unknown_location_invalid_url(runcutty: RunCutty) -> None:
-    """It prints an error message."""
+def test_cutty_error(runcutty: RunCutty) -> None:
+    """It prints an error message for known exceptions."""
     with pytest.raises(Exception, match="unknown location"):
         runcutty("create", "invalid://location")
-
-
-def test_unknown_location_no_such_path(runcutty: RunCutty) -> None:
-    """It prints an error message."""
-    with pytest.raises(Exception, match="no such file or directory"):
-        runcutty("create", "/no/such/file/or/directory")

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -16,8 +16,8 @@ from cutty.repositories.domain.registry import UnknownLocationError
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),
     ],
 )
-def test_unknown_location_invalid_url(error: CuttyError) -> None:
-    """It raises SystemExit instead of the original exception."""
-    with pytest.raises(SystemExit):
+def test_errors(error: CuttyError) -> None:
+    """It exits with an error message."""
+    with pytest.raises(SystemExit, match="error: "):
         with fatal:
             raise error

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -9,13 +9,6 @@ from cutty.errors import CuttyError
 from cutty.repositories.domain.registry import UnknownLocationError
 
 
-def test_fatal() -> None:
-    """It raises SystemExit with the exception message."""
-    with pytest.raises(SystemExit, match="error: Boom"):
-        with fatal:
-            raise CuttyError("Boom")
-
-
 @pytest.mark.parametrize(
     "error",
     [

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -11,7 +11,7 @@ from cutty.repositories.domain.registry import UnknownLocationError
 
 def test_fatal() -> None:
     """It raises SystemExit with the exception message."""
-    with pytest.raises(SystemExit, match="fatal: Boom"):
+    with pytest.raises(SystemExit, match="error: Boom"):
         with fatal:
             raise CuttyError("Boom")
 

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -1,8 +1,12 @@
 """Unit tests for cutty.entrypoints.cli.errors."""
+import pathlib
+
 import pytest
+from yarl import URL
 
 from cutty.entrypoints.cli.errors import fatal
 from cutty.errors import CuttyError
+from cutty.repositories.domain.registry import UnknownLocationError
 
 
 def test_fatal() -> None:
@@ -10,3 +14,17 @@ def test_fatal() -> None:
     with pytest.raises(SystemExit, match="fatal: Boom"):
         with fatal:
             raise CuttyError("Boom")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        UnknownLocationError(URL("invalid://location")),
+        UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),
+    ],
+)
+def test_unknown_location_invalid_url(error: CuttyError) -> None:
+    """It raises SystemExit instead of the original exception."""
+    with pytest.raises(SystemExit):
+        with fatal:
+            raise error


### PR DESCRIPTION
- :white_check_mark: [entrypoints] Add tests for `fatal` with `UnknownLocationError`
- :fire: [functional] Reduce to single functional test for error handling
- :children_crossing: [entrypoints] Use "error:" as the prefix for all error messages
- :recycle: [entrypoints] Extract function `_die`
- :fire: [entrypoints] Remove error handler for `CuttyError` base class
- :white_check_mark: [entrypoints] Extend test to check for an error message
