### PR TITLE
:sparkles: [repositories] Improve error message when template does not support revisions

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -2,6 +2,7 @@
 import pathlib
 from typing import NoReturn
 
+from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
 from cutty.util.exceptionhandlers import exceptionhandler
 
@@ -18,4 +19,9 @@ def _unknownlocation(error: UnknownLocationError) -> NoReturn:
     _die(f"unknown location {error.location}")
 
 
-fatal = _unknownlocation
+@exceptionhandler
+def _unsupportedrevision(error: UnsupportedRevisionError) -> NoReturn:
+    _die(f"template does not support revisions, got {error.revision!r}")
+
+
+fatal = _unknownlocation >> _unsupportedrevision

--- a/src/cutty/repositories/domain/mounters.py
+++ b/src/cutty/repositories/domain/mounters.py
@@ -1,8 +1,10 @@
 """Mounting filesystems."""
 import pathlib
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Optional
 
+from cutty.errors import CuttyError
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.repositories.domain.revisions import Revision
 
@@ -10,12 +12,19 @@ from cutty.repositories.domain.revisions import Revision
 Mounter = Callable[[pathlib.Path, Optional[Revision]], Filesystem]
 
 
+@dataclass
+class UnsupportedRevisionError(CuttyError):
+    """The filesystem does not support revisions."""
+
+    revision: Revision
+
+
 def unversioned_mounter(filesystem: Callable[[pathlib.Path], Filesystem]) -> Mounter:
     """Return a mounter that raises when a revision is passed."""
 
     def _mount(storage: pathlib.Path, revision: Optional[Revision]) -> Filesystem:
         if revision is not None:
-            raise RuntimeError(f"filesystem does not support revisions, got {revision}")
+            raise UnsupportedRevisionError(revision)
         return filesystem(storage)
 
     return _mount

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -6,12 +6,14 @@ from yarl import URL
 
 from cutty.entrypoints.cli.errors import fatal
 from cutty.errors import CuttyError
+from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
 
 
 @pytest.mark.parametrize(
     "error",
     [
+        UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),
     ],


### PR DESCRIPTION
- :white_check_mark: [entrypoints] Add test for `UnsupportedRevisionError` handler
- :sparkles: [repositories] Improve error message when template does not support revisions
