### PR TITLE
:bug: [repositories] Do not match ftp:// and ftps:// URLs in git provider

### DIFF
--- a/src/cutty/repositories/adapters/fetchers/git.py
+++ b/src/cutty/repositories/adapters/fetchers/git.py
@@ -12,7 +12,7 @@ from cutty.util.git import Repository
 
 
 @fetcher(
-    match=scheme("file", "ftp", "ftps", "git", "http", "https", "ssh"),
+    match=scheme("file", "git", "http", "https", "ssh"),
     store=lambda url: defaultstore(url).with_suffix(".git"),
 )
 def gitfetcher(


### PR DESCRIPTION
libgit2 does not support these at all, which makes this a bug. They're also
deprecated in git.git.
