### PR TITLE
:sparkles: [repositories] Improve error message when remote git repository cannot be accessed

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -2,6 +2,7 @@
 import pathlib
 from typing import NoReturn
 
+from cutty.repositories.adapters.fetchers.git import GitFetcherError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
 from cutty.util.exceptionhandlers import exceptionhandler
@@ -24,4 +25,9 @@ def _unsupportedrevision(error: UnsupportedRevisionError) -> NoReturn:
     _die(f"template does not support revisions, got {error.revision!r}")
 
 
-fatal = _unknownlocation >> _unsupportedrevision
+@exceptionhandler
+def _gitfetcher(error: GitFetcherError) -> NoReturn:
+    _die(f"cannot access remote git repository: {error.message}")
+
+
+fatal = _unknownlocation >> _unsupportedrevision >> _gitfetcher

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -27,7 +27,7 @@ def _unsupportedrevision(error: UnsupportedRevisionError) -> NoReturn:
 
 @exceptionhandler
 def _gitfetcher(error: GitFetcherError) -> NoReturn:
-    _die(f"cannot access remote git repository: {error.message}")
+    _die(f"cannot access remote git repository at {error.url}: {error.message}")
 
 
 fatal = _unknownlocation >> _unsupportedrevision >> _gitfetcher

--- a/src/cutty/repositories/adapters/fetchers/git.py
+++ b/src/cutty/repositories/adapters/fetchers/git.py
@@ -1,20 +1,38 @@
 """Fetcher for git repositories."""
 import pathlib
+from dataclasses import dataclass
+from typing import NoReturn
 from typing import Optional
 
+import pygit2
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.repositories.domain.fetchers import fetcher
 from cutty.repositories.domain.matchers import scheme
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import defaultstore
+from cutty.util.exceptionhandlers import exceptionhandler
 from cutty.util.git import Repository
+
+
+@dataclass
+class GitFetcherError(CuttyError):
+    """Cannot access the remote repository."""
+
+    message: str
+
+
+@exceptionhandler
+def _errorhandler(error: pygit2.GitError) -> NoReturn:
+    raise GitFetcherError(str(error))
 
 
 @fetcher(
     match=scheme("file", "git", "http", "https", "ssh"),
     store=lambda url: defaultstore(url).with_suffix(".git"),
 )
+@_errorhandler
 def gitfetcher(
     url: URL, destination: pathlib.Path, revision: Optional[Revision]
 ) -> None:

--- a/src/cutty/repositories/adapters/fetchers/git.py
+++ b/src/cutty/repositories/adapters/fetchers/git.py
@@ -32,13 +32,13 @@ def _errorhandler(error: pygit2.GitError) -> NoReturn:
     match=scheme("file", "git", "http", "https", "ssh"),
     store=lambda url: defaultstore(url).with_suffix(".git"),
 )
-@_errorhandler
 def gitfetcher(
     url: URL, destination: pathlib.Path, revision: Optional[Revision]
 ) -> None:
     """Fetch a git repository."""
-    if destination.exists():
-        repository = Repository.open(destination)
-        repository.fetch(prune=True)
-    else:
-        Repository.clone(str(url), destination, mirror=True)
+    with _errorhandler:
+        if destination.exists():
+            repository = Repository.open(destination)
+            repository.fetch(prune=True)
+        else:
+            Repository.clone(str(url), destination, mirror=True)

--- a/src/cutty/repositories/adapters/fetchers/git.py
+++ b/src/cutty/repositories/adapters/fetchers/git.py
@@ -21,13 +21,14 @@ from cutty.util.git import Repository
 class GitFetcherError(CuttyError):
     """Cannot access the remote repository."""
 
+    url: URL
     message: str
 
 
-def _errorhandler() -> ExceptionHandler:
+def _errorhandler(url: URL) -> ExceptionHandler:
     @exceptionhandler
     def _(error: pygit2.GitError) -> NoReturn:
-        raise GitFetcherError(str(error))
+        raise GitFetcherError(url, str(error))
 
     return _
 
@@ -40,7 +41,7 @@ def gitfetcher(
     url: URL, destination: pathlib.Path, revision: Optional[Revision]
 ) -> None:
     """Fetch a git repository."""
-    with _errorhandler():
+    with _errorhandler(url):
         if destination.exists():
             repository = Repository.open(destination)
             repository.fetch(prune=True)

--- a/src/cutty/repositories/adapters/fetchers/git.py
+++ b/src/cutty/repositories/adapters/fetchers/git.py
@@ -12,6 +12,7 @@ from cutty.repositories.domain.fetchers import fetcher
 from cutty.repositories.domain.matchers import scheme
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import defaultstore
+from cutty.util.exceptionhandlers import ExceptionHandler
 from cutty.util.exceptionhandlers import exceptionhandler
 from cutty.util.git import Repository
 
@@ -23,9 +24,12 @@ class GitFetcherError(CuttyError):
     message: str
 
 
-@exceptionhandler
-def _errorhandler(error: pygit2.GitError) -> NoReturn:
-    raise GitFetcherError(str(error))
+def _errorhandler() -> ExceptionHandler:
+    @exceptionhandler
+    def _(error: pygit2.GitError) -> NoReturn:
+        raise GitFetcherError(str(error))
+
+    return _
 
 
 @fetcher(
@@ -36,7 +40,7 @@ def gitfetcher(
     url: URL, destination: pathlib.Path, revision: Optional[Revision]
 ) -> None:
     """Fetch a git repository."""
-    with _errorhandler:
+    with _errorhandler():
         if destination.exists():
             repository = Repository.open(destination)
             repository.fetch(prune=True)

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -14,7 +14,10 @@ from cutty.repositories.domain.registry import UnknownLocationError
 @pytest.mark.parametrize(
     "error",
     [
-        GitFetcherError("unsupported URL protocol"),
+        GitFetcherError(
+            URL("ssh://git@github.com/user/repository.git"),
+            "unsupported URL protocol",
+        ),
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -6,6 +6,7 @@ from yarl import URL
 
 from cutty.entrypoints.cli.errors import fatal
 from cutty.errors import CuttyError
+from cutty.repositories.adapters.fetchers.git import GitFetcherError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
 
@@ -13,6 +14,7 @@ from cutty.repositories.domain.registry import UnknownLocationError
 @pytest.mark.parametrize(
     "error",
     [
+        GitFetcherError("unsupported URL protocol"),
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -7,6 +7,7 @@ import pygit2
 import pytest
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.repositories.adapters.fetchers.git import gitfetcher
@@ -118,3 +119,18 @@ def test_broken_head_after_clone_unexpected_branch(
 
     with pytest.raises(KeyError):
         gitfetcher(asurl(path), store, None, FetchMode.ALWAYS)
+
+
+@pytest.mark.parametrize(
+    ("url", "message"),
+    [
+        (
+            URL("https://example.invalid/repository.git"),
+            "failed to resolve address for example.invalid",
+        ),
+    ],
+)
+def test_fetch_error(url: URL, store: Store, message: str) -> None:
+    """It raises an exception with libgit2's error message."""
+    with pytest.raises(CuttyError, match=message):
+        gitfetcher(url, store, None, FetchMode.ALWAYS)

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -7,10 +7,10 @@ import pygit2
 import pytest
 from yarl import URL
 
-from cutty.errors import CuttyError
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.repositories.adapters.fetchers.git import gitfetcher
+from cutty.repositories.adapters.fetchers.git import GitFetcherError
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import aspath
 from cutty.repositories.domain.locations import asurl
@@ -132,5 +132,7 @@ def test_broken_head_after_clone_unexpected_branch(
 )
 def test_fetch_error(url: URL, store: Store, message: str) -> None:
     """It raises an exception with libgit2's error message."""
-    with pytest.raises(CuttyError, match=message):
+    with pytest.raises(GitFetcherError) as exceptioninfo:
         gitfetcher(url, store, None, FetchMode.ALWAYS)
+
+    assert message in exceptioninfo.value.message

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -122,30 +122,39 @@ def test_broken_head_after_clone_unexpected_branch(
 
 
 @pytest.mark.parametrize(
-    ("url", "message"),
+    ("url", "posixmessage", "windowsmessage"),
     [
         (
             URL("https://example.invalid/repository.git"),
             "failed to resolve address for example.invalid",
+            "failed to send request: The server name or address could not be resolved",
         ),
         (
             URL("https://example.com/repository.git"),
             "unexpected http status code: 404",
+            "request failed with status code: 404",
         ),
         (
             URL("https://example.com/index.html"),
             "invalid content-type: 'text/html; charset=UTF-8'",
+            "received unexpected content-type",
         ),
         (
             URL("https://www.mercurial-scm.org/repo/hg/"),
             "unexpected http status code: 400",
+            "request failed with status code: 400",
         ),
     ],
 )
-def test_fetch_error(url: URL, store: Store, message: str) -> None:
+def test_fetch_error(
+    url: URL, store: Store, posixmessage: str, windowsmessage: str
+) -> None:
     """It raises an exception with libgit2's error message."""
     with pytest.raises(GitFetcherError) as exceptioninfo:
         gitfetcher(url, store, None, FetchMode.ALWAYS)
 
     assert url == exceptioninfo.value.url
-    assert message in exceptioninfo.value.message
+    assert any(
+        message in exceptioninfo.value.message
+        for message in (posixmessage, windowsmessage)
+    )

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -135,4 +135,5 @@ def test_fetch_error(url: URL, store: Store, message: str) -> None:
     with pytest.raises(GitFetcherError) as exceptioninfo:
         gitfetcher(url, store, None, FetchMode.ALWAYS)
 
+    assert url == exceptioninfo.value.url
     assert message in exceptioninfo.value.message

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -128,6 +128,18 @@ def test_broken_head_after_clone_unexpected_branch(
             URL("https://example.invalid/repository.git"),
             "failed to resolve address for example.invalid",
         ),
+        (
+            URL("https://example.com/repository.git"),
+            "unexpected http status code: 404",
+        ),
+        (
+            URL("https://example.com/index.html"),
+            "invalid content-type: 'text/html; charset=UTF-8'",
+        ),
+        (
+            URL("https://www.mercurial-scm.org/repo/hg/"),
+            "unexpected http status code: 400",
+        ),
     ],
 )
 def test_fetch_error(url: URL, store: Store, message: str) -> None:


### PR DESCRIPTION
- :white_check_mark: [repositories] Add test for `gitfetcher` with invalid host
- :recycle: [repositories] Raise dedicated exception on `gitfetcher` errors
- :white_check_mark: [entrypoints] Add test for `GitFetcherError`
- :sparkles: [entrypoints] Improve error message on `gitfetcher` failures
- :recycle: [repositories] Refactor test to check `GitFetcherError.message`
- :white_check_mark: [repositories] Add test for `GitFetcherError.url`
- :recycle: [repositories] Use exception handler as context manager, not decorator
- :recycle: [repositories] Turn `_errorhandler` into a factory function
- :recycle: [repositories] Add attribute `GitFetcherError.url`
- :sparkles: [entrypoints] Include URL in error message on `gitfetcher` failures
- :white_check_mark: [repositories] Add more error cases to `gitfetcher` test
