### PR TITLE
:recycle: [repositories] Improve error message when `hg` is not found or fails

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -3,6 +3,7 @@ import pathlib
 from typing import NoReturn
 
 from cutty.repositories.adapters.fetchers.git import GitFetcherError
+from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
 from cutty.util.exceptionhandlers import exceptionhandler
@@ -30,4 +31,9 @@ def _gitfetcher(error: GitFetcherError) -> NoReturn:
     _die(f"cannot access remote git repository at {error.url}: {error.message}")
 
 
-fatal = _unknownlocation >> _unsupportedrevision >> _gitfetcher
+@exceptionhandler
+def _hgnotfound(error: HgNotFoundError) -> NoReturn:
+    _die("cannot locate hg executable on PATH")
+
+
+fatal = _unknownlocation >> _unsupportedrevision >> _gitfetcher >> _hgnotfound

--- a/src/cutty/repositories/adapters/fetchers/mercurial.py
+++ b/src/cutty/repositories/adapters/fetchers/mercurial.py
@@ -7,9 +7,14 @@ from typing import Protocol
 
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.repositories.domain.fetchers import fetcher
 from cutty.repositories.domain.matchers import scheme
 from cutty.repositories.domain.revisions import Revision
+
+
+class HgNotFoundError(CuttyError):
+    """Cannot locate the ``hg`` executable."""
 
 
 class Hg(Protocol):
@@ -24,7 +29,7 @@ class Hg(Protocol):
 def findhg() -> Hg:
     """Return a function for running hg commands."""
     if not (path := shutil.which("hg")):
-        raise RuntimeError("cannot locate hg")
+        raise HgNotFoundError("cannot locate hg")
 
     executable = path
 

--- a/src/cutty/repositories/adapters/fetchers/mercurial.py
+++ b/src/cutty/repositories/adapters/fetchers/mercurial.py
@@ -23,15 +23,15 @@ class Hg(Protocol):
 
 def findhg() -> Hg:
     """Return a function for running hg commands."""
-    executable = shutil.which("hg")
+    if not (path := shutil.which("hg")):
+        raise RuntimeError("cannot locate hg")
+
+    executable = path
 
     def hg(
         *args: str, cwd: Optional[pathlib.Path] = None
     ) -> subprocess.CompletedProcess[str]:
         """Run a hg command."""
-        if executable is None:
-            raise RuntimeError("cannot locate hg")
-
         return subprocess.run(  # noqa: S603
             [executable, *args], check=True, capture_output=True, text=True, cwd=cwd
         )

--- a/src/cutty/repositories/adapters/fetchers/mercurial.py
+++ b/src/cutty/repositories/adapters/fetchers/mercurial.py
@@ -26,6 +26,7 @@ class HgError(CuttyError):
     stdout: str
     stderr: str
     status: int
+    cwd: Optional[pathlib.Path]
 
 
 class Hg(Protocol):
@@ -54,7 +55,7 @@ def findhg() -> Hg:
             )
         except subprocess.CalledProcessError as error:
             raise HgError(
-                (executable, *args), error.stdout, error.stderr, error.returncode
+                (executable, *args), error.stdout, error.stderr, error.returncode, cwd
             )
 
     return hg

--- a/src/cutty/repositories/adapters/fetchers/mercurial.py
+++ b/src/cutty/repositories/adapters/fetchers/mercurial.py
@@ -29,7 +29,7 @@ class Hg(Protocol):
 def findhg() -> Hg:
     """Return a function for running hg commands."""
     if not (path := shutil.which("hg")):
-        raise HgNotFoundError("cannot locate hg")
+        raise HgNotFoundError()
 
     executable = path
 

--- a/tests/fixtures/repositories/adapters/mercurial.py
+++ b/tests/fixtures/repositories/adapters/mercurial.py
@@ -1,8 +1,4 @@
 """Fixtures for cutty.repositories.adapters.providers.mercurial."""
-import pathlib
-import subprocess  # noqa: S404
-from typing import Optional
-
 import pytest
 
 from cutty.repositories.adapters.fetchers.mercurial import findhg
@@ -12,14 +8,7 @@ from cutty.repositories.adapters.fetchers.mercurial import Hg
 @pytest.fixture
 def hg() -> Hg:
     """Fixture for a hg command."""
-    hg = findhg()
-
-    def _hg(
-        *args: str, cwd: Optional[pathlib.Path] = None
-    ) -> subprocess.CompletedProcess[str]:
-        try:
-            return hg(*args, cwd=cwd)
-        except RuntimeError:
-            pytest.skip("cannot locate hg")
-
-    return _hg
+    try:
+        return findhg()
+    except RuntimeError:
+        pytest.skip("cannot locate hg")

--- a/tests/fixtures/repositories/adapters/mercurial.py
+++ b/tests/fixtures/repositories/adapters/mercurial.py
@@ -3,6 +3,7 @@ import pytest
 
 from cutty.repositories.adapters.fetchers.mercurial import findhg
 from cutty.repositories.adapters.fetchers.mercurial import Hg
+from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
 
 
 @pytest.fixture
@@ -10,5 +11,5 @@ def hg() -> Hg:
     """Fixture for a hg command."""
     try:
         return findhg()
-    except RuntimeError:
+    except HgNotFoundError:
         pytest.skip("cannot locate hg")

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -7,6 +7,7 @@ from yarl import URL
 from cutty.entrypoints.cli.errors import fatal
 from cutty.errors import CuttyError
 from cutty.repositories.adapters.fetchers.git import GitFetcherError
+from cutty.repositories.adapters.fetchers.mercurial import HgError
 from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
@@ -20,6 +21,12 @@ from cutty.repositories.domain.registry import UnknownLocationError
             "unsupported URL protocol",
         ),
         HgNotFoundError(),
+        HgError(
+            ("/usr/bin/hg", "pull"),
+            "",
+            "abort: no repository found in '/' (.hg not found)\n",
+            255,
+        ),
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -26,6 +26,7 @@ from cutty.repositories.domain.registry import UnknownLocationError
             "",
             "abort: no repository found in '/' (.hg not found)\n",
             255,
+            None,
         ),
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -28,6 +28,7 @@ from cutty.repositories.domain.registry import UnknownLocationError
             255,
             None,
         ),
+        HgError(("/usr/bin/hg",), "", "", 1, pathlib.Path("/home/user")),
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -7,6 +7,7 @@ from yarl import URL
 from cutty.entrypoints.cli.errors import fatal
 from cutty.errors import CuttyError
 from cutty.repositories.adapters.fetchers.git import GitFetcherError
+from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
 
@@ -18,6 +19,7 @@ from cutty.repositories.domain.registry import UnknownLocationError
             URL("ssh://git@github.com/user/repository.git"),
             "unsupported URL protocol",
         ),
+        HgNotFoundError(),
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),

--- a/tests/unit/repositories/adapters/fetchers/test_mercurial.py
+++ b/tests/unit/repositories/adapters/fetchers/test_mercurial.py
@@ -81,7 +81,7 @@ def test_hgfetcher_update(url: URL, hg: Hg, store: Store) -> None:
         URL("https://example.invalid/repository.git"),
     ],
 )
-def test_fetch_error(url: URL, store: Store) -> None:
+def test_fetch_error(url: URL, hg: Hg, store: Store) -> None:
     """It raises an exception with hg's error message."""
     with pytest.raises(HgError):
         hgfetcher(url, store, None, FetchMode.ALWAYS)

--- a/tests/unit/repositories/adapters/fetchers/test_mercurial.py
+++ b/tests/unit/repositories/adapters/fetchers/test_mercurial.py
@@ -7,6 +7,7 @@ from yarl import URL
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.repositories.adapters.fetchers.mercurial import Hg
+from cutty.repositories.adapters.fetchers.mercurial import HgError
 from cutty.repositories.adapters.fetchers.mercurial import hgfetcher
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import aspath
@@ -72,3 +73,15 @@ def test_hgfetcher_update(url: URL, hg: Hg, store: Store) -> None:
     # Check that the marker file is gone.
     path = Path("marker", filesystem=DiskFilesystem(destination))
     assert not (path / "marker").is_file()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        URL("https://example.invalid/repository.git"),
+    ],
+)
+def test_fetch_error(url: URL, store: Store) -> None:
+    """It raises an exception with hg's error message."""
+    with pytest.raises(HgError):
+        hgfetcher(url, store, None, FetchMode.ALWAYS)


### PR DESCRIPTION
- :recycle: [repositories] Fail early in `findhg`
- :recycle: [repositories] Replace `RuntimeError` with `HgNotFoundError`
- :recycle: [entrypoints] Improve error message when `hg` is not found
- :white_check_mark: [entrypoints] Add test for handling `HgNotFoundError`
- :white_check_mark: [repositories] Add test for `hgfetcher` with invalid domain
- :recycle: [repositories] Raise `HgError` when `hg` exits with failure
- :white_check_mark: [entrypoints] Add test case for `HgError`
- :sparkles: [entrypoints] Improve error message when `hg` fails
- :recycle: [repositories] Add `HgError.cwd` for completeness
- :children_crossing: [entrypoints] Streamline error message for `HgError`
- :white_check_mark: [entrypoints] Extend `HgError` test for edge cases
