### PR TITLE
:children_crossing: [entrypoints] Strip trailing colon from `hg` error message

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -43,7 +43,12 @@ def _hg(error: HgError) -> NoReturn:
 
     if message := error.stderr + error.stdout:
         message = message.splitlines()[0]
-        message = message.removeprefix("abort: ").removeprefix("error: ")
+        message = (
+            message.removeprefix("abort: ")
+            .removeprefix("error: ")
+            .removesuffix(":")
+            .strip()
+        )
     else:
         message = str(error.status)
 

--- a/tests/unit/repositories/adapters/fetchers/test_mercurial.py
+++ b/tests/unit/repositories/adapters/fetchers/test_mercurial.py
@@ -79,6 +79,8 @@ def test_hgfetcher_update(url: URL, hg: Hg, store: Store) -> None:
     "url",
     [
         URL("https://example.invalid/repository.git"),
+        URL("https://example.com/repository.git"),
+        URL("https://example.com/index.html"),
     ],
 )
 def test_fetch_error(url: URL, hg: Hg, store: Store) -> None:


### PR DESCRIPTION
- :white_check_mark: [repositories] Add more test cases for `hgfetcher` failures
- :children_crossing: [entrypoints] Strip trailing colon from `hg` error message
