### PR TITLE
:sparkles: [entrypoints] Improve error message when `filefetcher` fails

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -2,6 +2,7 @@
 import pathlib
 from typing import NoReturn
 
+from cutty.repositories.adapters.fetchers.file import FileFetcherError
 from cutty.repositories.adapters.fetchers.git import GitFetcherError
 from cutty.repositories.adapters.fetchers.mercurial import HgError
 from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
@@ -55,4 +56,16 @@ def _hg(error: HgError) -> NoReturn:
     _die(f"{command}: {message}")
 
 
-fatal = _unknownlocation >> _unsupportedrevision >> _gitfetcher >> _hgnotfound >> _hg
+@exceptionhandler
+def _filefetcher(error: FileFetcherError) -> NoReturn:
+    _die(f"cannot fetch template: {error.error}")
+
+
+fatal = (
+    _unknownlocation
+    >> _unsupportedrevision
+    >> _gitfetcher
+    >> _hgnotfound
+    >> _hg
+    >> _filefetcher
+)

--- a/src/cutty/repositories/adapters/fetchers/file.py
+++ b/src/cutty/repositories/adapters/fetchers/file.py
@@ -1,6 +1,7 @@
 """Fetch a repository from the filesystem."""
 import pathlib
 import shutil
+from dataclasses import dataclass
 from typing import NoReturn
 from typing import Optional
 
@@ -14,9 +15,16 @@ from cutty.repositories.domain.revisions import Revision
 from cutty.util.exceptionhandlers import exceptionhandler
 
 
+@dataclass
+class FileFetcherError(CuttyError):
+    """The file or directory could not be fetched."""
+
+    error: OSError
+
+
 @exceptionhandler
 def _errorhandler(error: OSError) -> NoReturn:
-    raise CuttyError(error)
+    raise FileFetcherError(error)
 
 
 @fetcher(match=scheme("file"))

--- a/src/cutty/repositories/adapters/fetchers/file.py
+++ b/src/cutty/repositories/adapters/fetchers/file.py
@@ -1,17 +1,26 @@
 """Fetch a repository from the filesystem."""
 import pathlib
 import shutil
+from typing import NoReturn
 from typing import Optional
 
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.repositories.domain.fetchers import fetcher
 from cutty.repositories.domain.locations import aspath
 from cutty.repositories.domain.matchers import scheme
 from cutty.repositories.domain.revisions import Revision
+from cutty.util.exceptionhandlers import exceptionhandler
+
+
+@exceptionhandler
+def _errorhandler(error: OSError) -> NoReturn:
+    raise CuttyError(error)
 
 
 @fetcher(match=scheme("file"))
+@_errorhandler
 def filefetcher(
     url: URL, destination: pathlib.Path, revision: Optional[Revision]
 ) -> None:

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -6,6 +6,7 @@ from yarl import URL
 
 from cutty.entrypoints.cli.errors import fatal
 from cutty.errors import CuttyError
+from cutty.repositories.adapters.fetchers.file import FileFetcherError
 from cutty.repositories.adapters.fetchers.git import GitFetcherError
 from cutty.repositories.adapters.fetchers.mercurial import HgError
 from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
@@ -29,6 +30,9 @@ from cutty.repositories.domain.registry import UnknownLocationError
             None,
         ),
         HgError(("/usr/bin/hg",), "", "", 1, pathlib.Path("/home/user")),
+        FileFetcherError(
+            FileNotFoundError(2, "No such file or directory", "/no/such/file")
+        ),
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),

--- a/tests/unit/repositories/adapters/fetchers/test_file.py
+++ b/tests/unit/repositories/adapters/fetchers/test_file.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.repositories.adapters.fetchers.file import filefetcher
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import asurl
@@ -75,3 +76,10 @@ def test_filefetcher_file_update(repository: Path, store: Store) -> None:
     # Check that the marker file is updated.
     assert path is not None
     assert path.read_text() == "Ipsum"
+
+
+def test_fetch_error(store: Store) -> None:
+    """It raises an exception."""
+    url = URL("file:///no/such/file")
+    with pytest.raises(CuttyError):
+        filefetcher(url, store, None, FetchMode.ALWAYS)


### PR DESCRIPTION
- :white_check_mark: [repositories] Add test for `filefetcher` with inexistent path
- :recycle: [repositories] Wrap `OSError` in `CuttyError` in `filefetcher`
- :recycle: [repositories] Wrap `OSError` in `FileFetcherError`
- :white_check_mark: [entrypoints] Add test for FileFetcherError
- :sparkles: [entrypoints] Improve error message when `filefetcher` fails
