### PR TITLE
:sparkles: [entrypoints] Improve error message for HTTP fetch failures

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -4,6 +4,7 @@ from typing import NoReturn
 
 from cutty.repositories.adapters.fetchers.file import FileFetcherError
 from cutty.repositories.adapters.fetchers.git import GitFetcherError
+from cutty.repositories.adapters.fetchers.http import HTTPFetcherError
 from cutty.repositories.adapters.fetchers.mercurial import HgError
 from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
@@ -61,6 +62,11 @@ def _filefetcher(error: FileFetcherError) -> NoReturn:
     _die(f"cannot fetch template: {error.error}")
 
 
+@exceptionhandler
+def _httpfetcher(error: HTTPFetcherError) -> NoReturn:
+    _die(f"cannot fetch template: {error.error}")
+
+
 fatal = (
     _unknownlocation
     >> _unsupportedrevision
@@ -68,4 +74,5 @@ fatal = (
     >> _hgnotfound
     >> _hg
     >> _filefetcher
+    >> _httpfetcher
 )

--- a/src/cutty/repositories/adapters/fetchers/http.py
+++ b/src/cutty/repositories/adapters/fetchers/http.py
@@ -1,16 +1,33 @@
 """Fetch a repository via HTTP."""
+from dataclasses import dataclass
 from pathlib import Path
+from typing import NoReturn
 from typing import Optional
 
 import httpx
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.repositories.domain.fetchers import fetcher
 from cutty.repositories.domain.matchers import scheme
 from cutty.repositories.domain.revisions import Revision
+from cutty.util.exceptionhandlers import exceptionhandler
+
+
+@dataclass
+class HTTPFetcherError(CuttyError):
+    """The HTTP resource could not be fetched."""
+
+    error: httpx.HTTPError
+
+
+@exceptionhandler
+def _errorhandler(error: httpx.HTTPError) -> NoReturn:
+    raise HTTPFetcherError(error)
 
 
 @fetcher(match=scheme("http", "https"))
+@_errorhandler
 def httpfetcher(url: URL, destination: Path, revision: Optional[Revision]) -> None:
     """Fetch via HTTP."""
     with httpx.stream("GET", str(url)) as response:

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -1,6 +1,7 @@
 """Unit tests for cutty.entrypoints.cli.errors."""
 import pathlib
 
+import httpx
 import pytest
 from yarl import URL
 
@@ -8,6 +9,7 @@ from cutty.entrypoints.cli.errors import fatal
 from cutty.errors import CuttyError
 from cutty.repositories.adapters.fetchers.file import FileFetcherError
 from cutty.repositories.adapters.fetchers.git import GitFetcherError
+from cutty.repositories.adapters.fetchers.http import HTTPFetcherError
 from cutty.repositories.adapters.fetchers.mercurial import HgError
 from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
@@ -32,6 +34,12 @@ from cutty.repositories.domain.registry import UnknownLocationError
         HgError(("/usr/bin/hg",), "", "", 1, pathlib.Path("/home/user")),
         FileFetcherError(
             FileNotFoundError(2, "No such file or directory", "/no/such/file")
+        ),
+        HTTPFetcherError(
+            httpx.TooManyRedirects(
+                "Exceeded maximum allowed redirects.",
+                request=httpx.Request("GET", "https://example.com/repository"),
+            )
         ),
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),

--- a/tests/unit/repositories/adapters/fetchers/test_http.py
+++ b/tests/unit/repositories/adapters/fetchers/test_http.py
@@ -10,6 +10,7 @@ from threading import Thread
 import pytest
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.repositories.adapters.fetchers.http import httpfetcher
 from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.stores import Store
@@ -73,3 +74,10 @@ def test_httpfetcher_update(server: URL, store: Store, repository: Path) -> None
 
     assert path is not None
     assert path.read_text() == repository.read_text()
+
+
+def test_httpfetcher_error(store: Store) -> None:
+    """It raises an exception."""
+    url = URL("https://example.invalid/repository")
+    with pytest.raises(CuttyError):
+        httpfetcher(url, store, None, FetchMode.ALWAYS)


### PR DESCRIPTION
- :white_check_mark: [repositories] Add test for `httpfetcher` with invalid domain
- :recycle: [repositories] Wrap `httpx.HTTPError` in `HTTPFetcherError`
- :white_check_mark: [entrypoints] Add test for `HTTPFetcherError`
- :sparkles: [entrypoints] Improve error message for HTTP fetch failures
