### PR TITLE
:sparkles: [entrypoints] Improve error message for invalid git revisions

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -7,6 +7,7 @@ from cutty.repositories.adapters.fetchers.git import GitFetcherError
 from cutty.repositories.adapters.fetchers.http import HTTPFetcherError
 from cutty.repositories.adapters.fetchers.mercurial import HgError
 from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
+from cutty.repositories.adapters.providers.git import RevisionNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
 from cutty.util.exceptionhandlers import exceptionhandler
@@ -67,6 +68,11 @@ def _httpfetcher(error: HTTPFetcherError) -> NoReturn:
     _die(f"cannot fetch template: {error.error}")
 
 
+@exceptionhandler
+def _revisionnotfound(error: RevisionNotFoundError) -> NoReturn:
+    _die(f"revision not found: {error.revision}")
+
+
 fatal = (
     _unknownlocation
     >> _unsupportedrevision
@@ -75,4 +81,5 @@ fatal = (
     >> _hg
     >> _filefetcher
     >> _httpfetcher
+    >> _revisionnotfound
 )

--- a/src/cutty/repositories/adapters/providers/git.py
+++ b/src/cutty/repositories/adapters/providers/git.py
@@ -27,7 +27,9 @@ def mount(path: pathlib.Path, revision: Optional[Revision]) -> GitFilesystem:
     This function returns the root of a Git filesystem for the given
     revision. If ``revision`` is None, HEAD is used instead.
     """
-    return GitFilesystem(path, *filter(None, [revision]))
+    if revision is not None:
+        return GitFilesystem(path, revision)
+    return GitFilesystem(path)
 
 
 def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -12,6 +12,7 @@ from cutty.repositories.adapters.fetchers.git import GitFetcherError
 from cutty.repositories.adapters.fetchers.http import HTTPFetcherError
 from cutty.repositories.adapters.fetchers.mercurial import HgError
 from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
+from cutty.repositories.adapters.providers.git import RevisionNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
 
@@ -41,6 +42,7 @@ from cutty.repositories.domain.registry import UnknownLocationError
                 request=httpx.Request("GET", "https://example.com/repository"),
             )
         ),
+        RevisionNotFoundError("v1.0.0"),
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),

--- a/tests/unit/repositories/adapters/providers/test_git.py
+++ b/tests/unit/repositories/adapters/providers/test_git.py
@@ -7,6 +7,7 @@ import pygit2
 import pytest
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.repositories.adapters.providers.git import gitproviderfactory
 from cutty.repositories.adapters.providers.git import localgitprovider
 from cutty.repositories.domain.fetchers import FetchMode
@@ -49,6 +50,12 @@ def test_localgitprovider_not_matching(tmp_path: pathlib.Path) -> None:
     url = asurl(tmp_path)
     repository = localgitprovider(url, None)
     assert repository is None
+
+
+def test_localgitprovider_invalid_revision(url: URL) -> None:
+    """It raises an exception."""
+    with pytest.raises(CuttyError):
+        localgitprovider(url, "invalid")
 
 
 def test_localgitprovider_revision_tag(url: URL) -> None:


### PR DESCRIPTION
- :recycle: [repositories] Replace `*filter` with `if` statement
- :white_check_mark: [repositories] Add test for invalid git revisions
- :recycle: [repositories] Replace `KeyError` by `RevisionNotFoundError`
- :white_check_mark: [entrypoints] Add test for `git.RevisionNotFoundError`
- :sparkles: [entrypoints] Improve error message for invalid git revisions
