### PR TITLE
:recycle: [repositories] Provide default arguments for `Provider`, `ProviderFactory`, and `Fetcher`

### DIFF
--- a/src/cutty/repositories/domain/fetchers.py
+++ b/src/cutty/repositories/domain/fetchers.py
@@ -3,6 +3,7 @@ import enum
 import pathlib
 from collections.abc import Callable
 from typing import Optional
+from typing import Protocol
 
 from yarl import URL
 
@@ -20,7 +21,15 @@ class FetchMode(enum.Enum):
     NEVER = enum.auto()
 
 
-Fetcher = Callable[[URL, Store, Optional[Revision], FetchMode], Optional[pathlib.Path]]
+class Fetcher(Protocol):
+    """The typing protocol for a fetcher."""
+
+    def __call__(
+        self, url: URL, store: Store, revision: Optional[Revision], mode: FetchMode
+    ) -> Optional[pathlib.Path]:
+        """Retrieve the repository at the URL into local storage."""
+
+
 FetchFunction = Callable[[URL, pathlib.Path, Optional[Revision]], None]
 FetchDecorator = Callable[[FetchFunction], Fetcher]
 

--- a/src/cutty/repositories/domain/fetchers.py
+++ b/src/cutty/repositories/domain/fetchers.py
@@ -25,7 +25,11 @@ class Fetcher(Protocol):
     """The typing protocol for a fetcher."""
 
     def __call__(
-        self, url: URL, store: Store, revision: Optional[Revision], mode: FetchMode
+        self,
+        url: URL,
+        store: Store,
+        revision: Optional[Revision],
+        mode: FetchMode = FetchMode.ALWAYS,
     ) -> Optional[pathlib.Path]:
         """Retrieve the repository at the URL into local storage."""
 
@@ -40,7 +44,10 @@ def fetcher(*, match: Matcher, store: Store = defaultstore) -> FetchDecorator:
 
     def _decorator(fetch: FetchFunction) -> Fetcher:
         def _fetcher(
-            url: URL, store: Store, revision: Optional[Revision], mode: FetchMode
+            url: URL,
+            store: Store,
+            revision: Optional[Revision],
+            mode: FetchMode = FetchMode.ALWAYS,
         ) -> Optional[pathlib.Path]:
             if not match(url):
                 return None

--- a/src/cutty/repositories/domain/fetchers.py
+++ b/src/cutty/repositories/domain/fetchers.py
@@ -28,7 +28,7 @@ class Fetcher(Protocol):
         self,
         url: URL,
         store: Store,
-        revision: Optional[Revision],
+        revision: Optional[Revision] = None,
         mode: FetchMode = FetchMode.ALWAYS,
     ) -> Optional[pathlib.Path]:
         """Retrieve the repository at the URL into local storage."""
@@ -46,7 +46,7 @@ def fetcher(*, match: Matcher, store: Store = defaultstore) -> FetchDecorator:
         def _fetcher(
             url: URL,
             store: Store,
-            revision: Optional[Revision],
+            revision: Optional[Revision] = None,
             mode: FetchMode = FetchMode.ALWAYS,
         ) -> Optional[pathlib.Path]:
             if not match(url):

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -31,7 +31,7 @@ class Provider:
         self.name = name
 
     def __call__(
-        self, location: Location, revision: Optional[Revision]
+        self, location: Location, revision: Optional[Revision] = None
     ) -> Optional[Repository]:
         """Return the repository at the given location."""
 
@@ -84,7 +84,7 @@ class LocalProvider(BaseProvider):
         self.match = match
 
     def __call__(
-        self, location: Location, revision: Optional[Revision]
+        self, location: Location, revision: Optional[Revision] = None
     ) -> Optional[Repository]:
         """Return the repository at the given location."""
         try:
@@ -129,7 +129,7 @@ class RemoteProvider(BaseProvider):
         self.fetchmode = fetchmode
 
     def __call__(
-        self, location: Location, revision: Optional[Revision]
+        self, location: Location, revision: Optional[Revision] = None
     ) -> Optional[Repository]:
         """Return the repository at the given location."""
         if isinstance(location, URL):

--- a/src/cutty/repositories/domain/providers.py
+++ b/src/cutty/repositories/domain/providers.py
@@ -115,7 +115,7 @@ class RemoteProvider(BaseProvider):
         mount: Optional[Mounter] = None,
         getrevision: Optional[GetRevision] = None,
         store: Store,
-        fetchmode: FetchMode,
+        fetchmode: FetchMode = FetchMode.ALWAYS,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -159,7 +159,9 @@ class ProviderFactory(abc.ABC):
         self.name = name
 
     @abc.abstractmethod
-    def __call__(self, store: Store, fetchmode: FetchMode) -> Provider:
+    def __call__(
+        self, store: Store, fetchmode: FetchMode = FetchMode.ALWAYS
+    ) -> Provider:
         """Create a provider."""
 
 
@@ -183,7 +185,9 @@ class RemoteProviderFactory(ProviderFactory):
         self.mount = mount
         self.getrevision = getrevision
 
-    def __call__(self, store: Store, fetchmode: FetchMode) -> Provider:
+    def __call__(
+        self, store: Store, fetchmode: FetchMode = FetchMode.ALWAYS
+    ) -> Provider:
         """Create a provider."""
         return RemoteProvider(
             self.name,
@@ -204,6 +208,8 @@ class ConstProviderFactory(ProviderFactory):
         super().__init__(provider.name)
         self.provider = provider
 
-    def __call__(self, store: Store, fetchmode: FetchMode) -> Provider:
+    def __call__(
+        self, store: Store, fetchmode: FetchMode = FetchMode.ALWAYS
+    ) -> Provider:
         """Return the provider."""
         return self.provider

--- a/src/cutty/repositories/domain/registry.py
+++ b/src/cutty/repositories/domain/registry.py
@@ -27,7 +27,9 @@ class UnknownLocationError(CuttyError):
 
 
 def provide(
-    providers: Iterable[Provider], location: Location, revision: Optional[Revision]
+    providers: Iterable[Provider],
+    location: Location,
+    revision: Optional[Revision] = None,
 ) -> Repository:
     """Provide the repository located at the given URL."""
     for provider in providers:

--- a/tests/fixtures/repositories/domain/fetchers.py
+++ b/tests/fixtures/repositories/domain/fetchers.py
@@ -21,7 +21,7 @@ def nullfetcher() -> Fetcher:
     def _(
         url: URL,
         store: Store,
-        revision: Optional[Revision],
+        revision: Optional[Revision] = None,
         mode: FetchMode = FetchMode.ALWAYS,
     ) -> Optional[pathlib.Path]:
         return None
@@ -36,7 +36,7 @@ def emptyfetcher() -> Fetcher:
     def _(
         url: URL,
         store: Store,
-        revision: Optional[Revision],
+        revision: Optional[Revision] = None,
         mode: FetchMode = FetchMode.ALWAYS,
     ) -> Optional[pathlib.Path]:
         path = store(url) / url.name

--- a/tests/fixtures/repositories/domain/fetchers.py
+++ b/tests/fixtures/repositories/domain/fetchers.py
@@ -19,7 +19,10 @@ def nullfetcher() -> Fetcher:
     """Fixture for a fetcher that matches no URL."""
 
     def _(
-        url: URL, store: Store, revision: Optional[Revision], mode: FetchMode
+        url: URL,
+        store: Store,
+        revision: Optional[Revision],
+        mode: FetchMode = FetchMode.ALWAYS,
     ) -> Optional[pathlib.Path]:
         return None
 
@@ -31,7 +34,10 @@ def emptyfetcher() -> Fetcher:
     """Fixture for a fetcher that simply creates the destination path."""
 
     def _(
-        url: URL, store: Store, revision: Optional[Revision], mode: FetchMode
+        url: URL,
+        store: Store,
+        revision: Optional[Revision],
+        mode: FetchMode = FetchMode.ALWAYS,
     ) -> Optional[pathlib.Path]:
         path = store(url) / url.name
 

--- a/tests/fixtures/repositories/domain/providers.py
+++ b/tests/fixtures/repositories/domain/providers.py
@@ -26,7 +26,7 @@ def provider(name: str) -> Callable[[ProviderFunction], Provider]:
                 super().__init__(name)
 
             def __call__(
-                self, location: Location, revision: Optional[Revision]
+                self, location: Location, revision: Optional[Revision] = None
             ) -> Optional[Repository]:
                 return function(location, revision)
 

--- a/tests/unit/repositories/adapters/fetchers/test_file.py
+++ b/tests/unit/repositories/adapters/fetchers/test_file.py
@@ -22,7 +22,7 @@ def repository(tmp_path: Path) -> Path:
 def test_directory_happy(repository: Path, store: Store) -> None:
     """It copies the filesystem tree."""
     url = asurl(repository)
-    path = filefetcher(url, store, None)
+    path = filefetcher(url, store)
 
     assert path is not None
     assert (path / "marker").read_text() == "Lorem"
@@ -32,7 +32,7 @@ def test_file_happy(repository: Path, store: Store) -> None:
     """It copies the file."""
     repository /= "marker"
     url = asurl(repository)
-    path = filefetcher(url, store, None)
+    path = filefetcher(url, store)
 
     assert path is not None
     assert path.read_text() == "Lorem"
@@ -40,7 +40,7 @@ def test_file_happy(repository: Path, store: Store) -> None:
 
 def test_not_matched(store: Store, url: URL) -> None:
     """It returns None if the URL does not use the file scheme."""
-    path = filefetcher(url, store, None)
+    path = filefetcher(url, store)
     assert path is None
 
 
@@ -49,11 +49,11 @@ def test_directory_update(repository: Path, store: Store) -> None:
     url = asurl(repository)
 
     # First fetch.
-    filefetcher(url, store, None)
+    filefetcher(url, store)
 
     # Second fetch, without the marker file.
     (repository / "marker").unlink()
-    path = filefetcher(url, store, None)
+    path = filefetcher(url, store)
 
     # Check that the marker file is gone.
     assert path is not None
@@ -66,11 +66,11 @@ def test_file_update(repository: Path, store: Store) -> None:
     url = asurl(repository)
 
     # First fetch.
-    filefetcher(url, store, None)
+    filefetcher(url, store)
 
     # Second fetch, with modified marker file.
     repository.write_text("Ipsum")
-    path = filefetcher(url, store, None)
+    path = filefetcher(url, store)
 
     # Check that the marker file is updated.
     assert path is not None
@@ -81,4 +81,4 @@ def test_fetch_error(store: Store) -> None:
     """It raises an exception."""
     url = URL("file:///no/such/file")
     with pytest.raises(CuttyError):
-        filefetcher(url, store, None)
+        filefetcher(url, store)

--- a/tests/unit/repositories/adapters/fetchers/test_file.py
+++ b/tests/unit/repositories/adapters/fetchers/test_file.py
@@ -6,7 +6,6 @@ from yarl import URL
 
 from cutty.errors import CuttyError
 from cutty.repositories.adapters.fetchers.file import filefetcher
-from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.stores import Store
 
@@ -23,7 +22,7 @@ def repository(tmp_path: Path) -> Path:
 def test_directory_happy(repository: Path, store: Store) -> None:
     """It copies the filesystem tree."""
     url = asurl(repository)
-    path = filefetcher(url, store, None, FetchMode.ALWAYS)
+    path = filefetcher(url, store, None)
 
     assert path is not None
     assert (path / "marker").read_text() == "Lorem"
@@ -33,7 +32,7 @@ def test_file_happy(repository: Path, store: Store) -> None:
     """It copies the file."""
     repository /= "marker"
     url = asurl(repository)
-    path = filefetcher(url, store, None, FetchMode.ALWAYS)
+    path = filefetcher(url, store, None)
 
     assert path is not None
     assert path.read_text() == "Lorem"
@@ -41,7 +40,7 @@ def test_file_happy(repository: Path, store: Store) -> None:
 
 def test_not_matched(store: Store, url: URL) -> None:
     """It returns None if the URL does not use the file scheme."""
-    path = filefetcher(url, store, None, FetchMode.ALWAYS)
+    path = filefetcher(url, store, None)
     assert path is None
 
 
@@ -50,11 +49,11 @@ def test_directory_update(repository: Path, store: Store) -> None:
     url = asurl(repository)
 
     # First fetch.
-    filefetcher(url, store, None, FetchMode.ALWAYS)
+    filefetcher(url, store, None)
 
     # Second fetch, without the marker file.
     (repository / "marker").unlink()
-    path = filefetcher(url, store, None, FetchMode.ALWAYS)
+    path = filefetcher(url, store, None)
 
     # Check that the marker file is gone.
     assert path is not None
@@ -67,11 +66,11 @@ def test_file_update(repository: Path, store: Store) -> None:
     url = asurl(repository)
 
     # First fetch.
-    filefetcher(url, store, None, FetchMode.ALWAYS)
+    filefetcher(url, store, None)
 
     # Second fetch, with modified marker file.
     repository.write_text("Ipsum")
-    path = filefetcher(url, store, None, FetchMode.ALWAYS)
+    path = filefetcher(url, store, None)
 
     # Check that the marker file is updated.
     assert path is not None
@@ -82,4 +81,4 @@ def test_fetch_error(store: Store) -> None:
     """It raises an exception."""
     url = URL("file:///no/such/file")
     with pytest.raises(CuttyError):
-        filefetcher(url, store, None, FetchMode.ALWAYS)
+        filefetcher(url, store, None)

--- a/tests/unit/repositories/adapters/fetchers/test_ftp.py
+++ b/tests/unit/repositories/adapters/fetchers/test_ftp.py
@@ -62,7 +62,7 @@ def server(repository: Path) -> Iterator[URL]:
 
 def test_happy(server: URL, store: Store, repository: Path) -> None:
     """It downloads the file."""
-    path = ftpfetcher(server, store, None)
+    path = ftpfetcher(server, store)
     assert path is not None
     assert path.read_text() == repository.read_text()
 
@@ -70,21 +70,21 @@ def test_happy(server: URL, store: Store, repository: Path) -> None:
 def test_not_matched(store: Store) -> None:
     """It returns None if the URL does not use the ftp scheme."""
     url = URL("file:///")
-    path = ftpfetcher(url, store, None)
+    path = ftpfetcher(url, store)
     assert path is None
 
 
 def test_not_found(server: URL, store: Store) -> None:
     """It raises an exception if the server responds with an error."""
     with pytest.raises(Exception):
-        ftpfetcher(server.with_name("bogus"), store, None)
+        ftpfetcher(server.with_name("bogus"), store)
 
 
 def test_update(server: URL, store: Store, repository: Path) -> None:
     """It updates a file from a previous fetch."""
-    ftpfetcher(server, store, None)
+    ftpfetcher(server, store)
     repository.write_text("ipsum")
-    path = ftpfetcher(server, store, None)
+    path = ftpfetcher(server, store)
 
     assert path is not None
     assert path.read_text() == repository.read_text()

--- a/tests/unit/repositories/adapters/fetchers/test_ftp.py
+++ b/tests/unit/repositories/adapters/fetchers/test_ftp.py
@@ -12,7 +12,6 @@ from pyftpdlib.servers import FTPServer
 from yarl import URL
 
 from cutty.repositories.adapters.fetchers.ftp import ftpfetcher
-from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.stores import Store
 
 
@@ -63,7 +62,7 @@ def server(repository: Path) -> Iterator[URL]:
 
 def test_happy(server: URL, store: Store, repository: Path) -> None:
     """It downloads the file."""
-    path = ftpfetcher(server, store, None, FetchMode.ALWAYS)
+    path = ftpfetcher(server, store, None)
     assert path is not None
     assert path.read_text() == repository.read_text()
 
@@ -71,21 +70,21 @@ def test_happy(server: URL, store: Store, repository: Path) -> None:
 def test_not_matched(store: Store) -> None:
     """It returns None if the URL does not use the ftp scheme."""
     url = URL("file:///")
-    path = ftpfetcher(url, store, None, FetchMode.ALWAYS)
+    path = ftpfetcher(url, store, None)
     assert path is None
 
 
 def test_not_found(server: URL, store: Store) -> None:
     """It raises an exception if the server responds with an error."""
     with pytest.raises(Exception):
-        ftpfetcher(server.with_name("bogus"), store, None, FetchMode.ALWAYS)
+        ftpfetcher(server.with_name("bogus"), store, None)
 
 
 def test_update(server: URL, store: Store, repository: Path) -> None:
     """It updates a file from a previous fetch."""
-    ftpfetcher(server, store, None, FetchMode.ALWAYS)
+    ftpfetcher(server, store, None)
     repository.write_text("ipsum")
-    path = ftpfetcher(server, store, None, FetchMode.ALWAYS)
+    path = ftpfetcher(server, store, None)
 
     assert path is not None
     assert path.read_text() == repository.read_text()

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -11,7 +11,6 @@ from cutty.errors import CuttyError
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.repositories.adapters.fetchers.git import gitfetcher
-from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import aspath
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.stores import Store
@@ -35,7 +34,7 @@ def url(tmp_path: pathlib.Path) -> URL:
 
 def test_happy(url: URL, store: Store) -> None:
     """It clones the git repository."""
-    destination = gitfetcher(url, store, None, FetchMode.ALWAYS)
+    destination = gitfetcher(url, store, None)
     assert destination is not None
 
     path = Path("marker", filesystem=GitFilesystem(destination))
@@ -45,20 +44,20 @@ def test_happy(url: URL, store: Store) -> None:
 def test_not_matched(store: Store) -> None:
     """It returns None if the URL does not use a recognized scheme."""
     url = URL("mailto:you@example.com")
-    path = gitfetcher(url, store, None, FetchMode.ALWAYS)
+    path = gitfetcher(url, store, None)
     assert path is None
 
 
 def test_update(url: URL, store: Store) -> None:
     """It updates the repository from a previous fetch."""
     # First fetch.
-    gitfetcher(url, store, None, FetchMode.ALWAYS)
+    gitfetcher(url, store, None)
 
     # Remove the marker file.
     removefile(aspath(url) / "marker")
 
     # Second fetch.
-    destination = gitfetcher(url, store, None, FetchMode.ALWAYS)
+    destination = gitfetcher(url, store, None)
     assert destination is not None
 
     # Check that the marker file is gone.
@@ -103,7 +102,7 @@ def test_broken_head_after_clone(
     url: URL, store: Store, custom_default_branch: str
 ) -> None:
     """It works around a bug in libgit2 resulting in a broken HEAD reference."""
-    destination = gitfetcher(url, store, None, FetchMode.ALWAYS)
+    destination = gitfetcher(url, store, None)
     assert destination is not None
     repository = Repository.open(destination)
     assert repository.head.name != custom_default_branch
@@ -118,11 +117,11 @@ def test_broken_head_after_clone_unexpected_branch(
     repository.commit()
 
     with pytest.raises(KeyError):
-        gitfetcher(asurl(path), store, None, FetchMode.ALWAYS)
+        gitfetcher(asurl(path), store, None)
 
 
 def test_fetch_error(store: Store) -> None:
     """It raises an exception with libgit2's error message."""
     url = URL("https://example.invalid/repository.git")
     with pytest.raises(CuttyError):
-        gitfetcher(url, store, None, FetchMode.ALWAYS)
+        gitfetcher(url, store, None)

--- a/tests/unit/repositories/adapters/fetchers/test_git.py
+++ b/tests/unit/repositories/adapters/fetchers/test_git.py
@@ -34,7 +34,7 @@ def url(tmp_path: pathlib.Path) -> URL:
 
 def test_happy(url: URL, store: Store) -> None:
     """It clones the git repository."""
-    destination = gitfetcher(url, store, None)
+    destination = gitfetcher(url, store)
     assert destination is not None
 
     path = Path("marker", filesystem=GitFilesystem(destination))
@@ -44,20 +44,20 @@ def test_happy(url: URL, store: Store) -> None:
 def test_not_matched(store: Store) -> None:
     """It returns None if the URL does not use a recognized scheme."""
     url = URL("mailto:you@example.com")
-    path = gitfetcher(url, store, None)
+    path = gitfetcher(url, store)
     assert path is None
 
 
 def test_update(url: URL, store: Store) -> None:
     """It updates the repository from a previous fetch."""
     # First fetch.
-    gitfetcher(url, store, None)
+    gitfetcher(url, store)
 
     # Remove the marker file.
     removefile(aspath(url) / "marker")
 
     # Second fetch.
-    destination = gitfetcher(url, store, None)
+    destination = gitfetcher(url, store)
     assert destination is not None
 
     # Check that the marker file is gone.
@@ -102,7 +102,7 @@ def test_broken_head_after_clone(
     url: URL, store: Store, custom_default_branch: str
 ) -> None:
     """It works around a bug in libgit2 resulting in a broken HEAD reference."""
-    destination = gitfetcher(url, store, None)
+    destination = gitfetcher(url, store)
     assert destination is not None
     repository = Repository.open(destination)
     assert repository.head.name != custom_default_branch
@@ -117,11 +117,11 @@ def test_broken_head_after_clone_unexpected_branch(
     repository.commit()
 
     with pytest.raises(KeyError):
-        gitfetcher(asurl(path), store, None)
+        gitfetcher(asurl(path), store)
 
 
 def test_fetch_error(store: Store) -> None:
     """It raises an exception with libgit2's error message."""
     url = URL("https://example.invalid/repository.git")
     with pytest.raises(CuttyError):
-        gitfetcher(url, store, None)
+        gitfetcher(url, store)

--- a/tests/unit/repositories/adapters/fetchers/test_http.py
+++ b/tests/unit/repositories/adapters/fetchers/test_http.py
@@ -12,7 +12,6 @@ from yarl import URL
 
 from cutty.errors import CuttyError
 from cutty.repositories.adapters.fetchers.http import httpfetcher
-from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.stores import Store
 
 
@@ -48,7 +47,7 @@ def server(repository: Path) -> Iterator[URL]:
 
 def test_happy(server: URL, store: Store, repository: Path) -> None:
     """It downloads the file."""
-    path = httpfetcher(server, store, None, FetchMode.ALWAYS)
+    path = httpfetcher(server, store, None)
     assert path is not None
     assert path.read_text() == repository.read_text()
 
@@ -56,21 +55,21 @@ def test_happy(server: URL, store: Store, repository: Path) -> None:
 def test_not_matched(store: Store) -> None:
     """It returns None if the URL does not use the http scheme."""
     url = URL("file:///")
-    path = httpfetcher(url, store, None, FetchMode.ALWAYS)
+    path = httpfetcher(url, store, None)
     assert path is None
 
 
 def test_not_found(server: URL, store: Store) -> None:
     """It raises an exception if the server responds with an error."""
     with pytest.raises(Exception):
-        httpfetcher(server.with_name("bogus"), store, None, FetchMode.ALWAYS)
+        httpfetcher(server.with_name("bogus"), store, None)
 
 
 def test_update(server: URL, store: Store, repository: Path) -> None:
     """It updates a file from a previous fetch."""
-    httpfetcher(server, store, None, FetchMode.ALWAYS)
+    httpfetcher(server, store, None)
     repository.write_text("ipsum")
-    path = httpfetcher(server, store, None, FetchMode.ALWAYS)
+    path = httpfetcher(server, store, None)
 
     assert path is not None
     assert path.read_text() == repository.read_text()
@@ -80,4 +79,4 @@ def test_error(store: Store) -> None:
     """It raises an exception."""
     url = URL("https://example.invalid/repository")
     with pytest.raises(CuttyError):
-        httpfetcher(url, store, None, FetchMode.ALWAYS)
+        httpfetcher(url, store, None)

--- a/tests/unit/repositories/adapters/fetchers/test_http.py
+++ b/tests/unit/repositories/adapters/fetchers/test_http.py
@@ -47,7 +47,7 @@ def server(repository: Path) -> Iterator[URL]:
 
 def test_happy(server: URL, store: Store, repository: Path) -> None:
     """It downloads the file."""
-    path = httpfetcher(server, store, None)
+    path = httpfetcher(server, store)
     assert path is not None
     assert path.read_text() == repository.read_text()
 
@@ -55,21 +55,21 @@ def test_happy(server: URL, store: Store, repository: Path) -> None:
 def test_not_matched(store: Store) -> None:
     """It returns None if the URL does not use the http scheme."""
     url = URL("file:///")
-    path = httpfetcher(url, store, None)
+    path = httpfetcher(url, store)
     assert path is None
 
 
 def test_not_found(server: URL, store: Store) -> None:
     """It raises an exception if the server responds with an error."""
     with pytest.raises(Exception):
-        httpfetcher(server.with_name("bogus"), store, None)
+        httpfetcher(server.with_name("bogus"), store)
 
 
 def test_update(server: URL, store: Store, repository: Path) -> None:
     """It updates a file from a previous fetch."""
-    httpfetcher(server, store, None)
+    httpfetcher(server, store)
     repository.write_text("ipsum")
-    path = httpfetcher(server, store, None)
+    path = httpfetcher(server, store)
 
     assert path is not None
     assert path.read_text() == repository.read_text()
@@ -79,4 +79,4 @@ def test_error(store: Store) -> None:
     """It raises an exception."""
     url = URL("https://example.invalid/repository")
     with pytest.raises(CuttyError):
-        httpfetcher(url, store, None)
+        httpfetcher(url, store)

--- a/tests/unit/repositories/adapters/fetchers/test_mercurial.py
+++ b/tests/unit/repositories/adapters/fetchers/test_mercurial.py
@@ -33,7 +33,7 @@ def url(hg: Hg, tmp_path: pathlib.Path) -> URL:
 
 def test_happy(url: URL, store: Store) -> None:
     """It clones the Mercurial repository."""
-    destination = hgfetcher(url, store, None)
+    destination = hgfetcher(url, store)
     assert destination is not None
 
     path = Path("marker", filesystem=DiskFilesystem(destination))
@@ -43,7 +43,7 @@ def test_happy(url: URL, store: Store) -> None:
 def test_not_matched(store: Store) -> None:
     """It returns None if the URL does not use a recognized scheme."""
     url = URL("mailto:you@example.com")
-    path = hgfetcher(url, store, None)
+    path = hgfetcher(url, store)
     assert path is None
 
 
@@ -51,20 +51,20 @@ def test_no_executable(url: URL, store: Store, monkeypatch: pytest.MonkeyPatch) 
     """It raises an exception if the hg executable cannot be located."""
     monkeypatch.setattr("shutil.which", lambda _: None)
     with pytest.raises(Exception):
-        hgfetcher(url, store, None)
+        hgfetcher(url, store)
 
 
 def test_update(url: URL, hg: Hg, store: Store) -> None:
     """It updates the repository from a previous fetch."""
     # First fetch.
-    hgfetcher(url, store, None)
+    hgfetcher(url, store)
 
     # Remove the marker file.
     hg("rm", "marker", cwd=aspath(url))
     hg("commit", "--message=Remove the marker file", cwd=aspath(url))
 
     # Second fetch.
-    destination = hgfetcher(url, store, None)
+    destination = hgfetcher(url, store)
     assert destination is not None
 
     # Check that the marker file is gone.
@@ -83,7 +83,7 @@ def test_update(url: URL, hg: Hg, store: Store) -> None:
 def test_fetch_error(url: URL, hg: Hg, store: Store) -> None:
     """It raises an exception."""
     with pytest.raises(CuttyError):
-        hgfetcher(url, store, None)
+        hgfetcher(url, store)
 
 
 def test_revision_not_found(url: URL, hg: Hg, store: Store) -> None:

--- a/tests/unit/repositories/adapters/providers/test_disk.py
+++ b/tests/unit/repositories/adapters/providers/test_disk.py
@@ -19,7 +19,7 @@ def repository(tmp_path: Path) -> Path:
 def test_happy(repository: Path) -> None:
     """It provides a repository from a local directory."""
     url = asurl(repository)
-    repository2 = diskprovider(url, None)
+    repository2 = diskprovider(url)
     assert repository2 is not None
 
     text = (repository2.path / "marker").read_text()

--- a/tests/unit/repositories/adapters/providers/test_git.py
+++ b/tests/unit/repositories/adapters/providers/test_git.py
@@ -46,7 +46,7 @@ def test_local_happy(url: URL, revision: Optional[str], expected: str) -> None:
 def test_local_not_matching(tmp_path: pathlib.Path) -> None:
     """It returns None if the path is not a git repository."""
     url = asurl(tmp_path)
-    repository = localgitprovider(url, None)
+    repository = localgitprovider(url)
     assert repository is None
 
 
@@ -65,7 +65,7 @@ def test_local_revision_tag(url: URL) -> None:
 
 def test_local_revision_commit(url: URL) -> None:
     """It returns seven or more hexadecimal digits."""
-    repository = localgitprovider(url, None)
+    repository = localgitprovider(url)
     assert (
         repository is not None
         and repository.revision is not None
@@ -97,7 +97,7 @@ def test_remote_revision_tag(store: Store, url: URL) -> None:
 def test_remote_revision_commit(store: Store, url: URL) -> None:
     """It returns seven or more hexadecimal digits."""
     gitprovider = gitproviderfactory(store, FetchMode.ALWAYS)
-    repository = gitprovider(url, None)
+    repository = gitprovider(url)
     assert (
         repository is not None
         and repository.revision is not None
@@ -110,5 +110,5 @@ def test_remote_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
     url = URL("mailto:you@example.com")
     gitprovider = gitproviderfactory(store, FetchMode.ALWAYS)
-    repository = gitprovider(url, None)
+    repository = gitprovider(url)
     assert repository is None

--- a/tests/unit/repositories/adapters/providers/test_git.py
+++ b/tests/unit/repositories/adapters/providers/test_git.py
@@ -10,7 +10,6 @@ from yarl import URL
 from cutty.errors import CuttyError
 from cutty.repositories.adapters.providers.git import gitproviderfactory
 from cutty.repositories.adapters.providers.git import localgitprovider
-from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.stores import Store
 from cutty.util.git import Repository
@@ -79,7 +78,7 @@ def test_remote_happy(
     store: Store, url: URL, revision: Optional[str], expected: str
 ) -> None:
     """It fetches a git repository into storage."""
-    gitprovider = gitproviderfactory(store, FetchMode.ALWAYS)
+    gitprovider = gitproviderfactory(store)
     repository = gitprovider(url, revision)
     assert repository is not None
 
@@ -89,14 +88,14 @@ def test_remote_happy(
 
 def test_remote_revision_tag(store: Store, url: URL) -> None:
     """It returns the tag name."""
-    gitprovider = gitproviderfactory(store, FetchMode.ALWAYS)
+    gitprovider = gitproviderfactory(store)
     repository = gitprovider(url, "HEAD^")
     assert repository is not None and repository.revision == "v1.0"
 
 
 def test_remote_revision_commit(store: Store, url: URL) -> None:
     """It returns seven or more hexadecimal digits."""
-    gitprovider = gitproviderfactory(store, FetchMode.ALWAYS)
+    gitprovider = gitproviderfactory(store)
     repository = gitprovider(url)
     assert (
         repository is not None
@@ -109,6 +108,6 @@ def test_remote_revision_commit(store: Store, url: URL) -> None:
 def test_remote_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
     url = URL("mailto:you@example.com")
-    gitprovider = gitproviderfactory(store, FetchMode.ALWAYS)
+    gitprovider = gitproviderfactory(store)
     repository = gitprovider(url)
     assert repository is None

--- a/tests/unit/repositories/adapters/providers/test_mercurial.py
+++ b/tests/unit/repositories/adapters/providers/test_mercurial.py
@@ -8,7 +8,6 @@ from yarl import URL
 
 from cutty.repositories.adapters.fetchers.mercurial import Hg
 from cutty.repositories.adapters.providers.mercurial import hgproviderfactory
-from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.stores import Store
 
 
@@ -44,7 +43,7 @@ def test_happy(
     store: Store, hgrepository: pathlib.Path, revision: Optional[str], expected: str
 ) -> None:
     """It fetches a hg repository into storage."""
-    hgprovider = hgproviderfactory(store, FetchMode.ALWAYS)
+    hgprovider = hgproviderfactory(store)
     repository = hgprovider(hgrepository, revision)
     assert repository is not None
 
@@ -59,7 +58,7 @@ def is_mercurial_shorthash(revision: str) -> bool:
 
 def test_revision_commit(store: Store, hgrepository: pathlib.Path) -> None:
     """It returns the short changeset identification hash."""
-    hgprovider = hgproviderfactory(store, FetchMode.ALWAYS)
+    hgprovider = hgproviderfactory(store)
     repository = hgprovider(hgrepository)
     assert (
         repository is not None
@@ -70,7 +69,7 @@ def test_revision_commit(store: Store, hgrepository: pathlib.Path) -> None:
 
 def test_revision_tag(store: Store, hgrepository: pathlib.Path) -> None:
     """It returns the tag name."""
-    hgprovider = hgproviderfactory(store, FetchMode.ALWAYS)
+    hgprovider = hgproviderfactory(store)
     repository = hgprovider(hgrepository, "tip~2")
     assert repository is not None and repository.revision == "v1.0"
 
@@ -85,7 +84,7 @@ def test_revision_no_tags(store: Store, hg: Hg, tmp_path: pathlib.Path) -> None:
     hg("add", "marker", cwd=path)
     hg("commit", "--message=Initial", cwd=path)
 
-    hgprovider = hgproviderfactory(store, FetchMode.ALWAYS)
+    hgprovider = hgproviderfactory(store)
     repository = hgprovider(path)
     assert (
         repository is not None
@@ -106,7 +105,7 @@ def test_revision_multiple_tags(store: Store, hg: Hg, tmp_path: pathlib.Path) ->
     hg("tag", "--rev=0", "tag1", cwd=path)
     hg("tag", "--rev=0", "tag2", cwd=path)
 
-    hgprovider = hgproviderfactory(store, FetchMode.ALWAYS)
+    hgprovider = hgproviderfactory(store)
     repository = hgprovider(path, "tip~2")
     assert repository is not None and repository.revision == "tag1:tag2"
 
@@ -114,6 +113,6 @@ def test_revision_multiple_tags(store: Store, hg: Hg, tmp_path: pathlib.Path) ->
 def test_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
     url = URL("mailto:you@example.com")
-    hgprovider = hgproviderfactory(store, FetchMode.ALWAYS)
+    hgprovider = hgproviderfactory(store)
     repository = hgprovider(url)
     assert repository is None

--- a/tests/unit/repositories/adapters/providers/test_mercurial.py
+++ b/tests/unit/repositories/adapters/providers/test_mercurial.py
@@ -60,7 +60,7 @@ def is_mercurial_shorthash(revision: str) -> bool:
 def test_revision_commit(store: Store, hgrepository: pathlib.Path) -> None:
     """It returns the short changeset identification hash."""
     hgprovider = hgproviderfactory(store, FetchMode.ALWAYS)
-    repository = hgprovider(hgrepository, None)
+    repository = hgprovider(hgrepository)
     assert (
         repository is not None
         and repository.revision is not None
@@ -86,7 +86,7 @@ def test_revision_no_tags(store: Store, hg: Hg, tmp_path: pathlib.Path) -> None:
     hg("commit", "--message=Initial", cwd=path)
 
     hgprovider = hgproviderfactory(store, FetchMode.ALWAYS)
-    repository = hgprovider(path, None)
+    repository = hgprovider(path)
     assert (
         repository is not None
         and repository.revision is not None
@@ -115,5 +115,5 @@ def test_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
     url = URL("mailto:you@example.com")
     hgprovider = hgproviderfactory(store, FetchMode.ALWAYS)
-    repository = hgprovider(url, None)
+    repository = hgprovider(url)
     assert repository is None

--- a/tests/unit/repositories/adapters/providers/test_zip.py
+++ b/tests/unit/repositories/adapters/providers/test_zip.py
@@ -7,7 +7,6 @@ from yarl import URL
 
 from cutty.repositories.adapters.providers.zip import localzipprovider
 from cutty.repositories.adapters.providers.zip import zipproviderfactory
-from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.stores import Store
 
@@ -49,7 +48,7 @@ def test_local_not_matching(tmp_path: Path) -> None:
 
 def test_remote_happy(store: Store, url: URL) -> None:
     """It fetches a zip repository into storage."""
-    zipprovider = zipproviderfactory(store, FetchMode.ALWAYS)
+    zipprovider = zipproviderfactory(store)
     repository = zipprovider(url)
     assert repository is not None
 
@@ -60,6 +59,6 @@ def test_remote_happy(store: Store, url: URL) -> None:
 def test_remote_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
     url = URL("mailto:you@example.com")
-    zipprovider = zipproviderfactory(store, FetchMode.ALWAYS)
+    zipprovider = zipproviderfactory(store)
     repository = zipprovider(url)
     assert repository is None

--- a/tests/unit/repositories/adapters/providers/test_zip.py
+++ b/tests/unit/repositories/adapters/providers/test_zip.py
@@ -27,7 +27,7 @@ def url(tmp_path: Path) -> URL:
 
 def test_local_happy(url: URL) -> None:
     """It provides a repository from a local directory."""
-    repository = localzipprovider(url, None)
+    repository = localzipprovider(url)
     assert repository is not None
 
     text = (repository.path / "marker").read_text()
@@ -43,14 +43,14 @@ def test_local_revision(url: URL) -> None:
 def test_local_not_matching(tmp_path: Path) -> None:
     """It returns None if the path is not a zip repository."""
     url = asurl(tmp_path)
-    repository = localzipprovider(url, None)
+    repository = localzipprovider(url)
     assert repository is None
 
 
 def test_remote_happy(store: Store, url: URL) -> None:
     """It fetches a zip repository into storage."""
     zipprovider = zipproviderfactory(store, FetchMode.ALWAYS)
-    repository = zipprovider(url, None)
+    repository = zipprovider(url)
     assert repository is not None
 
     text = (repository.path / "marker").read_text()
@@ -61,5 +61,5 @@ def test_remote_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
     url = URL("mailto:you@example.com")
     zipprovider = zipproviderfactory(store, FetchMode.ALWAYS)
-    repository = zipprovider(url, None)
+    repository = zipprovider(url)
     assert repository is None

--- a/tests/unit/repositories/domain/test_fetchers.py
+++ b/tests/unit/repositories/domain/test_fetchers.py
@@ -15,7 +15,7 @@ pytest_plugins = [
 
 def test_match(fakefetcher: Fetcher, url: URL, store: Store) -> None:
     """It delegates to the matcher."""
-    path = fakefetcher(url.with_scheme("http"), store, None)
+    path = fakefetcher(url.with_scheme("http"), store)
     assert path is None
 
 
@@ -24,7 +24,7 @@ def test_fetch_always(
 ) -> None:
     """It delegates to the fetch function."""
     destination = store(url) / url.name
-    path = fakefetcher(url, store, None)
+    path = fakefetcher(url, store)
 
     assert path == destination
     assert fetchercalls == [(url, destination, None)]

--- a/tests/unit/repositories/domain/test_fetchers.py
+++ b/tests/unit/repositories/domain/test_fetchers.py
@@ -15,7 +15,7 @@ pytest_plugins = [
 
 def test_match(fakefetcher: Fetcher, url: URL, store: Store) -> None:
     """It delegates to the matcher."""
-    path = fakefetcher(url.with_scheme("http"), store, None, FetchMode.ALWAYS)
+    path = fakefetcher(url.with_scheme("http"), store, None)
     assert path is None
 
 
@@ -24,7 +24,7 @@ def test_fetch_always(
 ) -> None:
     """It delegates to the fetch function."""
     destination = store(url) / url.name
-    path = fakefetcher(url, store, None, FetchMode.ALWAYS)
+    path = fakefetcher(url, store, None)
 
     assert path == destination
     assert fetchercalls == [(url, destination, None)]

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -135,7 +135,7 @@ def test_localprovider_repository_revision(
 def test_remoteproviderfactory_no_fetchers(store: Store) -> None:
     """It returns None if there are no fetchers."""
     providerfactory = RemoteProviderFactory(fetch=[])
-    provider = providerfactory(store, FetchMode.ALWAYS)
+    provider = providerfactory(store)
     assert provider(URL()) is None
 
 
@@ -144,7 +144,7 @@ def test_remoteproviderfactory_no_matching_fetchers(
 ) -> None:
     """It returns None if all fetchers return None."""
     providerfactory = RemoteProviderFactory(fetch=[nullfetcher])
-    provider = providerfactory(store, FetchMode.ALWAYS)
+    provider = providerfactory(store)
     assert provider(URL()) is None
 
 
@@ -153,7 +153,7 @@ def test_remoteproviderfactory_happy(
 ) -> None:
     """It mounts a filesystem for the fetched repository."""
     providerfactory = RemoteProviderFactory(fetch=[emptyfetcher])
-    provider = providerfactory(store, FetchMode.ALWAYS)
+    provider = providerfactory(store)
     repository = provider(url)
 
     assert repository is not None
@@ -173,7 +173,7 @@ def test_remoteproviderfactory_repository_revision(
     providerfactory = RemoteProviderFactory(
         fetch=[emptyfetcher], getrevision=getrevision
     )
-    provider = providerfactory(store, FetchMode.ALWAYS)
+    provider = providerfactory(store)
     repository = provider(url)
 
     assert repository is not None and repository.revision == "v1.0"
@@ -184,7 +184,7 @@ def test_remoteproviderfactory_not_matching(
 ) -> None:
     """It returns None if the provider itself does not match."""
     providerfactory = RemoteProviderFactory(match=nullmatcher, fetch=[emptyfetcher])
-    provider = providerfactory(store, FetchMode.ALWAYS)
+    provider = providerfactory(store)
     assert provider(url) is None
 
 
@@ -199,7 +199,7 @@ def test_remoteproviderfactory_mounter(
         path.write_text(text)
 
     providerfactory = RemoteProviderFactory(fetch=[emptyfetcher], mount=jsonmounter)
-    provider = providerfactory(store, FetchMode.ALWAYS)
+    provider = providerfactory(store)
     repository = provider(url, revision)
 
     assert repository is not None
@@ -211,7 +211,7 @@ def test_remoteproviderfactory_inexistent_path(
 ) -> None:
     """It returns None if the location is an inexistent path."""
     providerfactory = RemoteProviderFactory(fetch=[emptyfetcher])
-    provider = providerfactory(store, FetchMode.ALWAYS)
+    provider = providerfactory(store)
     path = pathlib.Path("/no/such/file/or/directory")
 
     assert provider(path) is None

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -7,7 +7,6 @@ import pytest
 from yarl import URL
 
 from cutty.repositories.domain.fetchers import Fetcher
-from cutty.repositories.domain.fetchers import FetchMode
 from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.matchers import Matcher
 from cutty.repositories.domain.mounters import Mounter
@@ -160,7 +159,7 @@ def test_remoteproviderfactory_mounter(
     """It uses the mounter to mount the filesystem."""
     url = url.with_name(f"{url.name}.json")
     revision = "v1.0.0"
-    if path := emptyfetcher(url, store, revision, FetchMode.ALWAYS):
+    if path := emptyfetcher(url, store, revision):
         text = json.dumps({revision: {"marker": "Lorem"}})
         path.write_text(text)
 

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -12,13 +12,9 @@ from cutty.repositories.domain.locations import asurl
 from cutty.repositories.domain.matchers import Matcher
 from cutty.repositories.domain.mounters import Mounter
 from cutty.repositories.domain.providers import LocalProvider
-from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import RemoteProviderFactory
-from cutty.repositories.domain.registry import provide
 from cutty.repositories.domain.revisions import Revision
 from cutty.repositories.domain.stores import Store
-from tests.fixtures.repositories.domain.providers import dictprovider
-from tests.fixtures.repositories.domain.providers import nullprovider
 
 
 pytest_plugins = [
@@ -26,36 +22,6 @@ pytest_plugins = [
     "tests.fixtures.repositories.domain.matchers",
     "tests.fixtures.repositories.domain.mounters",
 ]
-
-
-@pytest.mark.parametrize(
-    "providers",
-    [
-        [],
-        [nullprovider],
-        [nullprovider, nullprovider],
-    ],
-)
-def test_provide_fail(providers: list[Provider]) -> None:
-    """It raises an exception."""
-    with pytest.raises(Exception):
-        provide(providers, URL())
-
-
-@pytest.mark.parametrize(
-    "providers",
-    [
-        [dictprovider({})],
-        [dictprovider({}), nullprovider],
-        [nullprovider, dictprovider({})],
-        [dictprovider({}), dictprovider({"marker": ""})],
-    ],
-)
-def test_provide_pass(providers: list[Provider]) -> None:
-    """It returns a path to the filesystem."""
-    repository = provide(providers, URL())
-    assert repository.path.is_dir()
-    assert not (repository.path / "marker").is_file()
 
 
 def test_localprovider_not_local(url: URL, diskmounter: Mounter) -> None:

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -62,7 +62,7 @@ def test_localprovider_not_local(url: URL, diskmounter: Mounter) -> None:
     """It returns None if the location is not local."""
     provider = LocalProvider(match=lambda path: True, mount=diskmounter)
 
-    assert provider(url, None) is None
+    assert provider(url) is None
 
 
 def test_localprovider_not_matching(
@@ -72,7 +72,7 @@ def test_localprovider_not_matching(
     url = asurl(tmp_path)
     provider = LocalProvider(match=lambda path: False, mount=diskmounter)
 
-    assert provider(url, None) is None
+    assert provider(url) is None
 
 
 def test_localprovider_inexistent_path(diskmounter: Mounter) -> None:
@@ -80,7 +80,7 @@ def test_localprovider_inexistent_path(diskmounter: Mounter) -> None:
     provider = LocalProvider(match=lambda path: True, mount=diskmounter)
     path = pathlib.Path("/no/such/file/or/directory")
 
-    assert provider(path, None) is None
+    assert provider(path) is None
 
 
 def test_localprovider_path(tmp_path: pathlib.Path, diskmounter: Mounter) -> None:
@@ -91,7 +91,7 @@ def test_localprovider_path(tmp_path: pathlib.Path, diskmounter: Mounter) -> Non
 
     url = asurl(repository)
     provider = LocalProvider(match=lambda path: True, mount=diskmounter)
-    repository2 = provider(url, None)
+    repository2 = provider(url)
 
     assert repository2 is not None
     [entry] = repository2.path.iterdir()
@@ -126,7 +126,7 @@ def test_localprovider_repository_revision(
     path.mkdir()
     (path / "VERSION").write_text("1.0")
 
-    repository = provider(asurl(path), None)
+    repository = provider(asurl(path))
 
     assert repository is not None
     assert "1.0" == repository.revision
@@ -136,7 +136,7 @@ def test_remoteproviderfactory_no_fetchers(store: Store) -> None:
     """It returns None if there are no fetchers."""
     providerfactory = RemoteProviderFactory(fetch=[])
     provider = providerfactory(store, FetchMode.ALWAYS)
-    assert provider(URL(), None) is None
+    assert provider(URL()) is None
 
 
 def test_remoteproviderfactory_no_matching_fetchers(
@@ -145,7 +145,7 @@ def test_remoteproviderfactory_no_matching_fetchers(
     """It returns None if all fetchers return None."""
     providerfactory = RemoteProviderFactory(fetch=[nullfetcher])
     provider = providerfactory(store, FetchMode.ALWAYS)
-    assert provider(URL(), None) is None
+    assert provider(URL()) is None
 
 
 def test_remoteproviderfactory_happy(
@@ -154,7 +154,7 @@ def test_remoteproviderfactory_happy(
     """It mounts a filesystem for the fetched repository."""
     providerfactory = RemoteProviderFactory(fetch=[emptyfetcher])
     provider = providerfactory(store, FetchMode.ALWAYS)
-    repository = provider(url, None)
+    repository = provider(url)
 
     assert repository is not None
 
@@ -174,7 +174,7 @@ def test_remoteproviderfactory_repository_revision(
         fetch=[emptyfetcher], getrevision=getrevision
     )
     provider = providerfactory(store, FetchMode.ALWAYS)
-    repository = provider(url, None)
+    repository = provider(url)
 
     assert repository is not None and repository.revision == "v1.0"
 
@@ -185,7 +185,7 @@ def test_remoteproviderfactory_not_matching(
     """It returns None if the provider itself does not match."""
     providerfactory = RemoteProviderFactory(match=nullmatcher, fetch=[emptyfetcher])
     provider = providerfactory(store, FetchMode.ALWAYS)
-    assert provider(url, None) is None
+    assert provider(url) is None
 
 
 def test_remoteproviderfactory_mounter(
@@ -214,4 +214,4 @@ def test_remoteproviderfactory_inexistent_path(
     provider = providerfactory(store, FetchMode.ALWAYS)
     path = pathlib.Path("/no/such/file/or/directory")
 
-    assert provider(path, None) is None
+    assert provider(path) is None

--- a/tests/unit/repositories/domain/test_providers.py
+++ b/tests/unit/repositories/domain/test_providers.py
@@ -39,7 +39,7 @@ pytest_plugins = [
 def test_provide_fail(providers: list[Provider]) -> None:
     """It raises an exception."""
     with pytest.raises(Exception):
-        provide(providers, URL(), None)
+        provide(providers, URL())
 
 
 @pytest.mark.parametrize(
@@ -53,7 +53,7 @@ def test_provide_fail(providers: list[Provider]) -> None:
 )
 def test_provide_pass(providers: list[Provider]) -> None:
     """It returns a path to the filesystem."""
-    repository = provide(providers, URL(), None)
+    repository = provide(providers, URL())
     assert repository.path.is_dir()
     assert not (repository.path / "marker").is_file()
 

--- a/tests/unit/repositories/domain/test_registry.py
+++ b/tests/unit/repositories/domain/test_registry.py
@@ -10,8 +10,10 @@ from cutty.repositories.domain.fetchers import Fetcher
 from cutty.repositories.domain.mounters import Mounter
 from cutty.repositories.domain.providers import ConstProviderFactory
 from cutty.repositories.domain.providers import LocalProvider
+from cutty.repositories.domain.providers import Provider
 from cutty.repositories.domain.providers import ProviderStore
 from cutty.repositories.domain.providers import RemoteProviderFactory
+from cutty.repositories.domain.registry import provide
 from cutty.repositories.domain.registry import ProviderRegistry
 from cutty.repositories.domain.repository import Repository
 from tests.fixtures.repositories.domain.providers import constprovider
@@ -24,6 +26,36 @@ pytest_plugins = [
     "tests.fixtures.repositories.domain.mounters",
     "tests.fixtures.repositories.domain.stores",
 ]
+
+
+@pytest.mark.parametrize(
+    "providers",
+    [
+        [],
+        [nullprovider],
+        [nullprovider, nullprovider],
+    ],
+)
+def test_provide_fail(providers: list[Provider]) -> None:
+    """It raises an exception."""
+    with pytest.raises(Exception):
+        provide(providers, URL())
+
+
+@pytest.mark.parametrize(
+    "providers",
+    [
+        [dictprovider({})],
+        [dictprovider({}), nullprovider],
+        [nullprovider, dictprovider({})],
+        [dictprovider({}), dictprovider({"marker": ""})],
+    ],
+)
+def test_provide_pass(providers: list[Provider]) -> None:
+    """It returns a path to the filesystem."""
+    repository = provide(providers, URL())
+    assert repository.path.is_dir()
+    assert not (repository.path / "marker").is_file()
 
 
 def test_none(providerstore: ProviderStore, url: URL) -> None:


### PR DESCRIPTION
- :recycle: [repositories] Make `revision` parameter for `Provider.__call__` optional
- :recycle: [repositories] Omit `revision` argument in provider tests
- :recycle: [repositories] Provide default argument for `fetchmode` in `ProviderFactory`
- :recycle: [repositories] Omit `fetchmode` in provider tests
- :recycle: [repositories] Provide default argument for `revision` in `provide`
- :recycle: [repositories] Omit `revision` in `provide` tests
- :recycle: [repositories] Move `provide` tests to `test_registry`
- :recycle: [repositories] Use `typing.Protocol` instead of `Callable` for `Fetcher`
- :recycle: [repositories] Provide default argument for `fetchmode` in `Fetcher`
- :recycle: [repositories] Omit `fetchmode` in fetcher tests
- :recycle: [repositories] Provide default argument for `revision` in `Fetcher`
- :recycle: [repositories] Omit `revision` argument in fetcher tests
