### PR TITLE
:sparkles: [services] Add command `cutty link <template>`

### DIFF
--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -3,12 +3,13 @@ from cutty.entrypoints.cli._main import main
 from cutty.entrypoints.cli.cookiecutter import cookiecutter
 from cutty.entrypoints.cli.create import create
 from cutty.entrypoints.cli.errors import fatal
+from cutty.entrypoints.cli.link import link
 from cutty.entrypoints.cli.update import update
 
 
 registercommand = main.command()
 
-for command in [create, update, cookiecutter]:
+for command in [create, update, link, cookiecutter]:
     registercommand(fatal(command))
 
 

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -26,14 +26,28 @@ from cutty.templates.domain.bindings import Binding
     ),
     help="Directory of the generated project.",
 )
+@click.option(
+    "--directory",
+    metavar="DIR",
+    type=click.Path(path_type=pathlib.Path),
+    help=(
+        "Directory within the template repository that contains the "
+        "cookiecutter.json file."
+    ),
+)
 def link(
     template: str,
     extra_context: dict[str, str],
     no_input: bool,
     cwd: Optional[pathlib.Path],
+    directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
     service_link(
-        template, extrabindings=extrabindings, no_input=no_input, projectdir=cwd
+        template,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        projectdir=cwd,
+        directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -12,6 +12,12 @@ from cutty.templates.domain.bindings import Binding
 @click.argument("template")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
+    "--no-input",
+    is_flag=True,
+    default=False,
+    help="Do not prompt for template variables.",
+)
+@click.option(
     "-C",
     "--cwd",
     metavar="DIR",
@@ -21,8 +27,13 @@ from cutty.templates.domain.bindings import Binding
     help="Directory of the generated project.",
 )
 def link(
-    template: str, extra_context: dict[str, str], cwd: Optional[pathlib.Path]
+    template: str,
+    extra_context: dict[str, str],
+    no_input: bool,
+    cwd: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-    service_link(template, extrabindings=extrabindings, projectdir=cwd)
+    service_link(
+        template, extrabindings=extrabindings, no_input=no_input, projectdir=cwd
+    )

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -27,6 +27,12 @@ from cutty.templates.domain.bindings import Binding
     help="Directory of the generated project.",
 )
 @click.option(
+    "-c",
+    "--checkout",
+    metavar="REV",
+    help="Branch, tag, or commit hash of the template repository.",
+)
+@click.option(
     "--directory",
     metavar="DIR",
     type=click.Path(path_type=pathlib.Path),
@@ -40,6 +46,7 @@ def link(
     extra_context: dict[str, str],
     no_input: bool,
     cwd: Optional[pathlib.Path],
+    checkout: Optional[str],
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
@@ -49,5 +56,6 @@ def link(
         extrabindings=extrabindings,
         no_input=no_input,
         projectdir=cwd,
+        checkout=checkout,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -1,0 +1,7 @@
+"""Command-line interface for linking projects to a Cookiecutter template."""
+import click
+
+
+@click.argument("template")
+def link(template: str) -> None:
+    """Link project to a Cookiecutter template."""

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -4,10 +4,13 @@ from typing import Optional
 
 import click
 
+from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.link import link as service_link
+from cutty.templates.domain.bindings import Binding
 
 
 @click.argument("template")
+@click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
     "-C",
     "--cwd",
@@ -17,6 +20,9 @@ from cutty.services.link import link as service_link
     ),
     help="Directory of the generated project.",
 )
-def link(template: str, cwd: Optional[pathlib.Path]) -> None:
+def link(
+    template: str, extra_context: dict[str, str], cwd: Optional[pathlib.Path]
+) -> None:
     """Link project to a Cookiecutter template."""
-    service_link(template, projectdir=cwd)
+    extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+    service_link(template, extrabindings=extrabindings, projectdir=cwd)

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -1,32 +1,10 @@
 """Command-line interface for linking projects to a Cookiecutter template."""
-import pathlib
-
 import click
 
-from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
-from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
-from cutty.services.create import create
-from cutty.util.git import Repository
+from cutty.services.link import link as service_link
 
 
 @click.argument("template")
 def link(template: str) -> None:
     """Link project to a Cookiecutter template."""
-    project = Repository.open(pathlib.Path.cwd())
-    branch = project.heads.create(UPDATE_BRANCH)  # XXX orphan branch would be better
-
-    with project.worktree(branch, checkout=False) as worktree:
-        create(
-            template,
-            outputdir=worktree,
-            outputdirisproject=True,
-            extrabindings=(),
-            no_input=False,
-            checkout=None,
-            directory=None,
-        )
-
-    (project.path / "cutty.json").write_bytes((branch.commit.tree / "cutty.json").data)
-    project.commit(message="Link to project template")  # XXX mention name and revision
-
-    project.heads[LATEST_BRANCH] = branch.commit
+    service_link(template)

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -1,7 +1,32 @@
 """Command-line interface for linking projects to a Cookiecutter template."""
+import pathlib
+
 import click
+
+from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
+from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
+from cutty.services.create import create
+from cutty.util.git import Repository
 
 
 @click.argument("template")
 def link(template: str) -> None:
     """Link project to a Cookiecutter template."""
+    project = Repository.open(pathlib.Path.cwd())
+    branch = project.heads.create(UPDATE_BRANCH)  # XXX orphan branch would be better
+
+    with project.worktree(branch, checkout=False) as worktree:
+        create(
+            template,
+            outputdir=worktree,
+            outputdirisproject=True,
+            extrabindings=(),
+            no_input=False,
+            checkout=None,
+            directory=None,
+        )
+
+    (project.path / "cutty.json").write_bytes((branch.commit.tree / "cutty.json").data)
+    project.commit(message="Link to project template")  # XXX mention name and revision
+
+    project.heads[LATEST_BRANCH] = branch.commit

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -1,10 +1,22 @@
 """Command-line interface for linking projects to a Cookiecutter template."""
+import pathlib
+from typing import Optional
+
 import click
 
 from cutty.services.link import link as service_link
 
 
 @click.argument("template")
-def link(template: str) -> None:
+@click.option(
+    "-C",
+    "--cwd",
+    metavar="DIR",
+    type=click.Path(
+        exists=True, file_okay=False, dir_okay=True, path_type=pathlib.Path
+    ),
+    help="Directory of the generated project.",
+)
+def link(template: str, cwd: Optional[pathlib.Path]) -> None:
     """Link project to a Cookiecutter template."""
-    service_link(template)
+    service_link(template, projectdir=cwd)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -14,6 +14,7 @@ def link(
     template: str,
     *,
     extrabindings: Sequence[Binding] = (),
+    no_input: bool = False,
     projectdir: Optional[pathlib.Path] = None
 ) -> None:
     """Link project to a Cookiecutter template."""
@@ -29,7 +30,7 @@ def link(
             outputdir=worktree,
             outputdirisproject=True,
             extrabindings=extrabindings,
-            no_input=False,
+            no_input=no_input,
             checkout=None,
             directory=None,
         )

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -1,5 +1,6 @@
 """Link a project to a Cookiecutter template."""
 import pathlib
+from typing import Optional
 
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
@@ -7,9 +8,12 @@ from cutty.services.create import create
 from cutty.util.git import Repository
 
 
-def link(template: str) -> None:
+def link(template: str, *, projectdir: Optional[pathlib.Path] = None) -> None:
     """Link project to a Cookiecutter template."""
-    project = Repository.open(pathlib.Path.cwd())
+    if projectdir is None:
+        projectdir = pathlib.Path.cwd()
+
+    project = Repository.open(projectdir)
     branch = project.heads.create(UPDATE_BRANCH)  # XXX orphan branch would be better
 
     with project.worktree(branch, checkout=False) as worktree:

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -1,14 +1,21 @@
 """Link a project to a Cookiecutter template."""
 import pathlib
+from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.create import create
+from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
 
 
-def link(template: str, *, projectdir: Optional[pathlib.Path] = None) -> None:
+def link(
+    template: str,
+    *,
+    extrabindings: Sequence[Binding] = (),
+    projectdir: Optional[pathlib.Path] = None
+) -> None:
     """Link project to a Cookiecutter template."""
     if projectdir is None:
         projectdir = pathlib.Path.cwd()
@@ -21,7 +28,7 @@ def link(template: str, *, projectdir: Optional[pathlib.Path] = None) -> None:
             template,
             outputdir=worktree,
             outputdirisproject=True,
-            extrabindings=(),
+            extrabindings=extrabindings,
             no_input=False,
             checkout=None,
             directory=None,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -1,0 +1,29 @@
+"""Link a project to a Cookiecutter template."""
+import pathlib
+
+from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
+from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
+from cutty.services.create import create
+from cutty.util.git import Repository
+
+
+def link(template: str) -> None:
+    """Link project to a Cookiecutter template."""
+    project = Repository.open(pathlib.Path.cwd())
+    branch = project.heads.create(UPDATE_BRANCH)  # XXX orphan branch would be better
+
+    with project.worktree(branch, checkout=False) as worktree:
+        create(
+            template,
+            outputdir=worktree,
+            outputdirisproject=True,
+            extrabindings=(),
+            no_input=False,
+            checkout=None,
+            directory=None,
+        )
+
+    (project.path / "cutty.json").write_bytes((branch.commit.tree / "cutty.json").data)
+    project.commit(message="Link to project template")  # XXX mention name and revision
+
+    project.heads[LATEST_BRANCH] = branch.commit

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -15,6 +15,7 @@ def link(
     *,
     extrabindings: Sequence[Binding] = (),
     no_input: bool = False,
+    directory: Optional[pathlib.PurePosixPath] = None,
     projectdir: Optional[pathlib.Path] = None
 ) -> None:
     """Link project to a Cookiecutter template."""
@@ -32,7 +33,7 @@ def link(
             extrabindings=extrabindings,
             no_input=no_input,
             checkout=None,
-            directory=None,
+            directory=directory,
         )
 
     (project.path / "cutty.json").write_bytes((branch.commit.tree / "cutty.json").data)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -15,6 +15,7 @@ def link(
     *,
     extrabindings: Sequence[Binding] = (),
     no_input: bool = False,
+    checkout: Optional[str] = None,
     directory: Optional[pathlib.PurePosixPath] = None,
     projectdir: Optional[pathlib.Path] = None
 ) -> None:
@@ -32,7 +33,7 @@ def link(
             outputdirisproject=True,
             extrabindings=extrabindings,
             no_input=no_input,
-            checkout=None,
+            checkout=checkout,
             directory=directory,
         )
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -28,6 +28,10 @@ class RunCutty(Protocol):
         """Invoke the cutty CLI."""
 
 
+class RunCuttyError(Exception):
+    """The cutty CLI exited with a non-zero status."""
+
+
 @pytest.fixture
 def runcutty(runner: CliRunner) -> RunCutty:
     """Fixture for invoking the cutty CLI."""
@@ -36,7 +40,7 @@ def runcutty(runner: CliRunner) -> RunCutty:
         result = runner.invoke(main, args, input=input, catch_exceptions=False)
 
         if result.exit_code != 0:
-            raise RuntimeError(result)
+            raise RunCuttyError(result.output or str(result.exit_code))
 
         return result.output
 

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -63,7 +63,7 @@ def test_inplace(runcutty: RunCutty, template: Path) -> None:
     assert template_files(template) == project_files(".") - EXTRA
 
 
-def test_directory(runcutty: RunCutty, template: Path, tmp_path: Path) -> None:
+def test_directory(runcutty: RunCutty, template: Path) -> None:
     """It uses the template in the given subdirectory."""
     directory = "a"
     move_repository_files_to_subdirectory(template, directory)

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -45,3 +45,10 @@ def test_extra_context(runcutty: RunCutty, project: Path, template: Path) -> Non
     runcutty("link", f"--cwd={project}", str(template), "project=excellent")
 
     assert "excellent" == projectvariable(project, "project")
+
+
+def test_no_input(runcutty: RunCutty, project: Path, template: Path) -> None:
+    """It does not prompt for variables."""
+    runcutty("link", f"--cwd={project}", "--no-input", str(template), input="ignored\n")
+
+    assert "example" == projectvariable(project, "project")

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -1,7 +1,24 @@
 """Functional tests for `cutty link`."""
+from pathlib import Path
+
+from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
+from tests.util.files import chdir
 
 
 def test_help(runcutty: RunCutty) -> None:
     """It exits with a status code of zero."""
     runcutty("link", "--help")
+
+
+def test_project_config(runcutty: RunCutty, template: Path) -> None:
+    """It adds a cutty.json to the project."""
+    runcutty("cookiecutter", str(template))
+
+    project = Repository.init(Path("example"))
+    project.commit(message="Initial")
+
+    with chdir(project.path):
+        runcutty("link", str(template))
+
+    assert (project.path / "cutty.json").is_file()

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -5,6 +5,7 @@ import pytest
 
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
+from tests.functional.test_update import projectvariable
 from tests.util.files import chdir
 
 
@@ -37,3 +38,10 @@ def test_cwd(runcutty: RunCutty, project: Path, template: Path) -> None:
     runcutty("link", f"--cwd={project}", str(template))
 
     assert (project / "cutty.json").is_file()
+
+
+def test_extra_context(runcutty: RunCutty, project: Path, template: Path) -> None:
+    """It allows setting variables on the command-line."""
+    runcutty("link", f"--cwd={project}", str(template), "project=excellent")
+
+    assert "excellent" == projectvariable(project, "project")

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -1,0 +1,7 @@
+"""Functional tests for `cutty link`."""
+from tests.functional.conftest import RunCutty
+
+
+def test_help(runcutty: RunCutty) -> None:
+    """It exits with a status code of zero."""
+    runcutty("link", "--help")

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -30,3 +30,10 @@ def test_project_config(runcutty: RunCutty, project: Path, template: Path) -> No
         runcutty("link", str(template))
 
     assert (project / "cutty.json").is_file()
+
+
+def test_cwd(runcutty: RunCutty, project: Path, template: Path) -> None:
+    """It links the project in the specified directory."""
+    runcutty("link", f"--cwd={project}", str(template))
+
+    assert (project / "cutty.json").is_file()

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -3,10 +3,12 @@ from pathlib import Path
 
 import pytest
 
+from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
 from tests.functional.test_update import projectvariable
 from tests.util.files import chdir
+from tests.util.git import move_repository_files_to_subdirectory
 
 
 def test_help(runcutty: RunCutty) -> None:
@@ -52,3 +54,14 @@ def test_no_input(runcutty: RunCutty, project: Path, template: Path) -> None:
     runcutty("link", f"--cwd={project}", "--no-input", str(template), input="ignored\n")
 
     assert "example" == projectvariable(project, "project")
+
+
+def test_directory(runcutty: RunCutty, project: Path, template: Path) -> None:
+    """It uses the template in the given subdirectory."""
+    directory = "a"
+    move_repository_files_to_subdirectory(template, directory)
+
+    runcutty("link", f"--cwd={project}", f"--directory={directory}", str(template))
+
+    config = readprojectconfigfile(project)
+    assert directory == str(config.directory)

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -1,6 +1,8 @@
 """Functional tests for `cutty link`."""
 from pathlib import Path
 
+import pytest
+
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
 from tests.util.files import chdir
@@ -11,14 +13,20 @@ def test_help(runcutty: RunCutty) -> None:
     runcutty("link", "--help")
 
 
-def test_project_config(runcutty: RunCutty, template: Path) -> None:
-    """It adds a cutty.json to the project."""
+@pytest.fixture
+def project(runcutty: RunCutty, template: Path) -> Path:
+    """Fixture for a project."""
     runcutty("cookiecutter", str(template))
 
     project = Repository.init(Path("example"))
     project.commit(message="Initial")
 
-    with chdir(project.path):
+    return project.path
+
+
+def test_project_config(runcutty: RunCutty, project: Path, template: Path) -> None:
+    """It adds a cutty.json to the project."""
+    with chdir(project):
         runcutty("link", str(template))
 
-    assert (project.path / "cutty.json").is_file()
+    assert (project / "cutty.json").is_file()


### PR DESCRIPTION
- :recycle: [functional] Improve error message when cutty fails during tests
- :white_check_mark: [functional] Add test for `cutty link --help`
- :sparkles: [entrypoints] Add stub for `cutty link`
- :white_check_mark: [functional] Add test for `cutty link` adding cutty.json
- :sparkles: [entrypoints] Add basic functionality for `cutty link`
- :recycle: [services] Extract function `link` from `entrypoints.cli.link` to `services.link`
- :recycle: [functional] Extract fixture `project` from `cutty link` tests
- :recycle: [functional] Remove unused fixture from `cutty create` test
- :white_check_mark: [functional] Add test for `cutty link --cwd`
- :sparkles: [services] Add `cutty link --cwd=<project>`
- :white_check_mark: [functional] Add test for `cutty link <template> <var>=<value>`
- :sparkles: [services] Add `cutty link <template> <var>=<value>`
- :white_check_mark: [functional] Add test for `cutty link --no-input`
- :sparkles: [services] Add `cutty link --no-input`
- :white_check_mark: [functional] Add test for `cutty link --directory=<directory>`
- :sparkles: [services] Add `cutty link --directory=<directory>`
- :white_check_mark: [functional] Add test for `cutty link --checkout=<revision>`
- :sparkles: [services] Add `cutty link --checkout=<revision>`
