### PR TITLE
🐛 [util] Fix missing prune in `Repository.worktree` when exceptions are raised

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -222,10 +222,9 @@ class Repository:
 
         try:
             with tempfile.TemporaryDirectory() as directory:
-                name = _hash(branch.name)
-                path = Path(directory) / name
+                path = Path(directory) / _hash(branch.name)
                 worktree = self._repository.add_worktree(
-                    name, path, self._repository.branches[branch.name]
+                    path.name, path, self._repository.branches[branch.name]
                 )
 
                 if not checkout:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -216,9 +216,13 @@ class Repository:
     @contextmanager
     def worktree(self, branch: Branch, *, checkout: bool = True) -> Iterator[Path]:
         """Create a worktree for the branch in the repository."""
+
+        def _hash(name: str) -> str:
+            return hashlib.blake2b(name.encode(), digest_size=32).hexdigest()
+
         try:
             with tempfile.TemporaryDirectory() as directory:
-                name = hashlib.blake2b(branch.name.encode(), digest_size=32).hexdigest()
+                name = _hash(branch.name)
                 path = Path(directory) / name
                 worktree = self._repository.add_worktree(
                     name, path, self._repository.branches[branch.name]

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -322,6 +322,18 @@ def test_worktree_removes_worktree_on_exit(repository: Repository) -> None:
     assert not worktree.is_dir()
 
 
+def test_worktree_prunes_worktree_on_failure(repository: Repository) -> None:
+    """It removes the administrative files for the worktree on failure."""
+    branch = repository.heads.create("branch")
+
+    with pytest.raises(Exception, match="Boom"):
+        with repository.worktree(branch) as worktree:
+            raise Exception("Boom")
+
+    privatedir = repository.path / ".git" / "worktrees" / worktree.name
+    assert not privatedir.exists()
+
+
 def test_worktree_does_checkout(repository: Repository, path: Path) -> None:
     """It checks out a working tree."""
     updatefile(path)


### PR DESCRIPTION
- ✅ [util] Add test for `Repository.worktree` when an exception is raised
- 🐛 [util] Fix missing prune in `Repository.worktree` when exceptions are raised
- ♻ [util] Extract function `_hash`
- ♻ [util] Inline variable `name`
