### PR TITLE
✨ [services] Load .cookiecutter.json in `cutty link` if it exists

### DIFF
--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -6,6 +6,9 @@ from typing import Optional
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.create import create
+from cutty.templates.adapters.cookiecutter.projectconfig import (
+    LEGACY_PROJECT_CONFIG_FILE,
+)
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
@@ -27,7 +30,7 @@ def link(
 
     project = Repository.open(projectdir)
 
-    cookiecutterjson = project.path / ".cookiecutter.json"
+    cookiecutterjson = project.path / LEGACY_PROJECT_CONFIG_FILE
     if cookiecutterjson.is_file():
         projectconfig = readcookiecutterjson(cookiecutterjson.read_text())
         extrabindings = list(projectconfig.bindings) + list(extrabindings)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -10,7 +10,7 @@ from cutty.templates.adapters.cookiecutter.projectconfig import (
     LEGACY_PROJECT_CONFIG_FILE,
 )
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
-from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
+from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson2
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
 
@@ -32,7 +32,7 @@ def link(
 
     cookiecutterjson = project.path / LEGACY_PROJECT_CONFIG_FILE
     if cookiecutterjson.is_file():
-        projectconfig = readcookiecutterjson(cookiecutterjson.read_text())
+        projectconfig = readcookiecutterjson2(project.path)
         extrabindings = list(projectconfig.bindings) + list(extrabindings)
 
     latest = project.heads.setdefault(LATEST_BRANCH, project.head.commit)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -10,7 +10,7 @@ from cutty.templates.adapters.cookiecutter.projectconfig import (
     LEGACY_PROJECT_CONFIG_FILE,
 )
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
-from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson2
+from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
 
@@ -32,7 +32,7 @@ def link(
 
     cookiecutterjson = project.path / LEGACY_PROJECT_CONFIG_FILE
     if cookiecutterjson.is_file():
-        projectconfig = readcookiecutterjson2(project.path)
+        projectconfig = readcookiecutterjson(project.path)
         extrabindings = list(projectconfig.bindings) + list(extrabindings)
 
     latest = project.heads.setdefault(LATEST_BRANCH, project.head.commit)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -7,6 +7,7 @@ from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.create import create
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
+from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
 
@@ -25,6 +26,12 @@ def link(
         projectdir = pathlib.Path.cwd()
 
     project = Repository.open(projectdir)
+
+    cookiecutterjson = project.path / ".cookiecutter.json"
+    if cookiecutterjson.is_file():
+        projectconfig = readcookiecutterjson(cookiecutterjson.read_text())
+        extrabindings = list(projectconfig.bindings) + list(extrabindings)
+
     latest = project.heads.setdefault(LATEST_BRANCH, project.head.commit)
     update = project.heads.create(UPDATE_BRANCH, latest, force=True)
     # XXX orphan branch would be better

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -1,4 +1,5 @@
 """Link a project to a Cookiecutter template."""
+import contextlib
 import pathlib
 from collections.abc import Sequence
 from typing import Optional
@@ -27,11 +28,8 @@ def link(
 
     project = Repository.open(projectdir)
 
-    try:
+    with contextlib.suppress(FileNotFoundError):
         projectconfig = readcookiecutterjson(project.path)
-    except FileNotFoundError:
-        pass
-    else:
         extrabindings = list(projectconfig.bindings) + list(extrabindings)
 
     latest = project.heads.setdefault(LATEST_BRANCH, project.head.commit)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -6,9 +6,6 @@ from typing import Optional
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.create import create
-from cutty.templates.adapters.cookiecutter.projectconfig import (
-    LEGACY_PROJECT_CONFIG_FILE,
-)
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
@@ -30,9 +27,11 @@ def link(
 
     project = Repository.open(projectdir)
 
-    cookiecutterjson = project.path / LEGACY_PROJECT_CONFIG_FILE
-    if cookiecutterjson.is_file():
+    try:
         projectconfig = readcookiecutterjson(project.path)
+    except FileNotFoundError:
+        pass
+    else:
         extrabindings = list(projectconfig.bindings) + list(extrabindings)
 
     latest = project.heads.setdefault(LATEST_BRANCH, project.head.commit)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -69,11 +69,7 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
 def readcookiecutterjson2(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration from a .cookiecutter.json file."""
     path = project / LEGACY_PROJECT_CONFIG_FILE
-    return readcookiecutterjson(path.read_text())
-
-
-def readcookiecutterjson(text: str) -> ProjectConfig:
-    """Load the project configuration from a .cookiecutter.json file."""
+    text = path.read_text()
     data = json.loads(text)
 
     template = data.pop("_template")

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -66,7 +66,7 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     )
 
 
-def readcookiecutterjson2(project: pathlib.Path) -> ProjectConfig:
+def readcookiecutterjson(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration from a .cookiecutter.json file."""
     path = project / LEGACY_PROJECT_CONFIG_FILE
     text = path.read_text()

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -11,6 +11,7 @@ from cutty.templates.domain.bindings import Binding
 
 
 PROJECT_CONFIG_FILE = "cutty.json"
+LEGACY_PROJECT_CONFIG_FILE = ".cookiecutter.json"
 
 
 @dataclass

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -63,3 +63,13 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
         bindings,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )
+
+
+def readcookiecutterjson(text: str) -> ProjectConfig:
+    """Load the project configuration from a .cookiecutter.json file."""
+    data = json.loads(text)
+
+    template = data.pop("_template")
+    bindings = [Binding(name, value) for name, value in data.items()]
+
+    return ProjectConfig(template, bindings)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -66,6 +66,12 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
     )
 
 
+def readcookiecutterjson2(project: pathlib.Path) -> ProjectConfig:
+    """Load the project configuration from a .cookiecutter.json file."""
+    path = project / LEGACY_PROJECT_CONFIG_FILE
+    return readcookiecutterjson(path.read_text())
+
+
 def readcookiecutterjson(text: str) -> ProjectConfig:
     """Load the project configuration from a .cookiecutter.json file."""
     data = json.loads(text)

--- a/src/cutty/templates/adapters/cookiecutter/projectconfig.py
+++ b/src/cutty/templates/adapters/cookiecutter/projectconfig.py
@@ -11,7 +11,7 @@ from cutty.templates.domain.bindings import Binding
 
 
 PROJECT_CONFIG_FILE = "cutty.json"
-LEGACY_PROJECT_CONFIG_FILE = ".cookiecutter.json"
+COOKIECUTTER_JSON_FILE = ".cookiecutter.json"
 
 
 @dataclass
@@ -68,7 +68,7 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
 
 def readcookiecutterjson(project: pathlib.Path) -> ProjectConfig:
     """Load the project configuration from a .cookiecutter.json file."""
-    path = project / LEGACY_PROJECT_CONFIG_FILE
+    path = project / COOKIECUTTER_JSON_FILE
     text = path.read_text()
     data = json.loads(text)
 

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -122,3 +122,21 @@ def test_commit_message(runcutty: RunCutty, project: Path, template: Path) -> No
 
     repository = Repository.open(project)
     assert template.name in repository.head.commit.message
+
+
+def test_legacy_project_config(runcutty: RunCutty, template: Path) -> None:
+    """It reads bindings from .cookiecutter.json if it exists."""
+    updatefile(
+        template / "{{ cookiecutter.project }}" / ".cookiecutter.json",
+        "{{ cookiecutter | jsonify }}",
+    )
+
+    project = Path("bespoke-project")
+
+    runcutty("cookiecutter", str(template), f"project={project}")
+
+    Repository.init(project).commit(message="Initial")
+
+    runcutty("link", f"--cwd={project}", str(template))
+
+    assert project.name == projectvariable(project, "project")

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -8,10 +8,8 @@ import pytest
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filesystems.domain.purepath import PurePath
+from cutty.templates.adapters.cookiecutter.projectconfig import COOKIECUTTER_JSON_FILE
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
-from cutty.templates.adapters.cookiecutter.projectconfig import (
-    LEGACY_PROJECT_CONFIG_FILE,
-)
 from cutty.templates.adapters.cookiecutter.projectconfig import ProjectConfig
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
@@ -119,7 +117,7 @@ def createlegacyprojectconfigfile(
         binding.name: binding.value for binding in projectconfig.bindings
     }
 
-    path = project / LEGACY_PROJECT_CONFIG_FILE
+    path = project / COOKIECUTTER_JSON_FILE
     text = json.dumps(data, indent=4)
 
     return RegularFile(path, text.encode())

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -9,6 +9,7 @@ from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
 from cutty.templates.adapters.cookiecutter.projectconfig import ProjectConfig
+from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
@@ -104,3 +105,15 @@ def test_createprojectconfigfile_format(
     assert lines[1].startswith('  "')
     assert lines[1].endswith('": {\n')
     assert "}\n" == lines[-1]
+
+
+def test_readcookiecutterjson(projectconfig: ProjectConfig) -> None:
+    """It loads a project configuration from a .cookiecutter.json file."""
+    # The .cookiecutter.json format does not include the template directory.
+    projectconfig = dataclasses.replace(projectconfig, directory=None)
+
+    data = {binding.name: binding.value for binding in projectconfig.bindings}
+    data["_template"] = projectconfig.template
+    text = json.dumps(data)
+
+    assert projectconfig == readcookiecutterjson(text)

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -13,7 +13,7 @@ from cutty.templates.adapters.cookiecutter.projectconfig import (
     LEGACY_PROJECT_CONFIG_FILE,
 )
 from cutty.templates.adapters.cookiecutter.projectconfig import ProjectConfig
-from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson2
+from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
@@ -137,4 +137,4 @@ def test_readcookiecutterjson(
     with storage:
         storage.add(file)
 
-    assert projectconfig == readcookiecutterjson2(storage.root)
+    assert projectconfig == readcookiecutterjson(storage.root)

--- a/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
+++ b/tests/unit/templates/adapters/cookiecutter/test_projectconfig.py
@@ -8,8 +8,11 @@ import pytest
 from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.templates.adapters.cookiecutter.projectconfig import createprojectconfigfile
+from cutty.templates.adapters.cookiecutter.projectconfig import (
+    LEGACY_PROJECT_CONFIG_FILE,
+)
 from cutty.templates.adapters.cookiecutter.projectconfig import ProjectConfig
-from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
+from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson2
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
@@ -107,7 +110,9 @@ def test_createprojectconfigfile_format(
     assert "}\n" == lines[-1]
 
 
-def test_readcookiecutterjson(projectconfig: ProjectConfig) -> None:
+def test_readcookiecutterjson(
+    tmp_path: pathlib.Path, projectconfig: ProjectConfig
+) -> None:
     """It loads a project configuration from a .cookiecutter.json file."""
     # The .cookiecutter.json format does not include the template directory.
     projectconfig = dataclasses.replace(projectconfig, directory=None)
@@ -116,4 +121,8 @@ def test_readcookiecutterjson(projectconfig: ProjectConfig) -> None:
     data["_template"] = projectconfig.template
     text = json.dumps(data)
 
-    assert projectconfig == readcookiecutterjson(text)
+    path = tmp_path / "project" / LEGACY_PROJECT_CONFIG_FILE
+    path.parent.mkdir()
+    path.write_text(text)
+
+    assert projectconfig == readcookiecutterjson2(path.parent)


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty link` with `.cookiecutter.json`
- ✅ [templates] Add test for `readcookiecutterjson`
- ✨ [templates] Add function `readcookiecutterjson` to load project configuration
- ✨ [services] Load .cookiecutter.json in `cutty link` if it exists
- ♻ [templates] Extract constant `LEGACY_PROJECT_CONFIG_FILE`
- ♻ [templates] Extract function `readcookiecutterjson2`
- ✅ [templates] Add test for `readcookiecutterjson2`
- ♻ [templates] Extract function `createlegacyprojectconfigfile` from test
- ♻ [templates] Inline function `readcookiecutterjson`
- ♻ [templates] Rename function `readcookiecutterjson2`
- ♻ [services] Do not check for existence of .cookiecutter.json (EAFP)
- ♻ [services] Replace inline code with `contextlib.suppress`
- ♻ [templates] Rename constant to `COOKIECUTTER_JSON_FILE`
