### PR TITLE
✨ [services] Allow reading the template from .cookiecutter.json

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -10,6 +10,7 @@ from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
 from cutty.repositories.adapters.providers.git import RevisionNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
+from cutty.services.link import TemplateNotSpecifiedError
 from cutty.util.exceptionhandlers import exceptionhandler
 
 
@@ -73,6 +74,11 @@ def _revisionnotfound(error: RevisionNotFoundError) -> NoReturn:
     _die(f"revision not found: {error.revision}")
 
 
+@exceptionhandler
+def _templatenotspecified(error: TemplateNotSpecifiedError) -> NoReturn:
+    _die("template not specified")
+
+
 fatal = (
     _unknownlocation
     >> _unsupportedrevision
@@ -82,4 +88,5 @@ fatal = (
     >> _filefetcher
     >> _httpfetcher
     >> _revisionnotfound
+    >> _templatenotspecified
 )

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -9,7 +9,7 @@ from cutty.services.link import link as service_link
 from cutty.templates.domain.bindings import Binding
 
 
-@click.argument("template")
+@click.argument("template", required=False)
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
     "--no-input",
@@ -42,7 +42,7 @@ from cutty.templates.domain.bindings import Binding
     ),
 )
 def link(
-    template: str,
+    template: Optional[str],
     extra_context: dict[str, str],
     no_input: bool,
     cwd: Optional[pathlib.Path],

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -4,6 +4,7 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
+from cutty.errors import CuttyError
 from cutty.filestorage.adapters.observers.git import LATEST_BRANCH
 from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.services.create import create
@@ -11,6 +12,10 @@ from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_F
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
+
+
+class TemplateNotSpecifiedError(CuttyError):
+    """The template was not specified."""
 
 
 def link(
@@ -36,7 +41,8 @@ def link(
         if template is None:
             template = projectconfig.template
 
-    assert template is not None  # noqa: S101
+    if template is None:
+        raise TemplateNotSpecifiedError()
 
     latest = project.heads.setdefault(LATEST_BRANCH, project.head.commit)
     update = project.heads.create(UPDATE_BRANCH, latest, force=True)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -14,13 +14,14 @@ from cutty.util.git import Repository
 
 
 def link(
-    template: str,
+    template: Optional[str] = None,
+    /,
     *,
     extrabindings: Sequence[Binding] = (),
     no_input: bool = False,
     checkout: Optional[str] = None,
     directory: Optional[pathlib.PurePosixPath] = None,
-    projectdir: Optional[pathlib.Path] = None
+    projectdir: Optional[pathlib.Path] = None,
 ) -> None:
     """Link project to a Cookiecutter template."""
     if projectdir is None:
@@ -31,6 +32,11 @@ def link(
     with contextlib.suppress(FileNotFoundError):
         projectconfig = readcookiecutterjson(project.path)
         extrabindings = list(projectconfig.bindings) + list(extrabindings)
+
+        if template is None:
+            template = projectconfig.template
+
+    assert template is not None  # noqa: S101
 
     latest = project.heads.setdefault(LATEST_BRANCH, project.head.commit)
     update = project.heads.create(UPDATE_BRANCH, latest, force=True)

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -8,6 +8,7 @@ from cutty.filestorage.adapters.observers.git import UPDATE_BRANCH
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
+from tests.functional.conftest import RunCuttyError
 from tests.functional.test_update import projectvariable
 from tests.util.files import chdir
 from tests.util.git import move_repository_files_to_subdirectory
@@ -155,3 +156,11 @@ def test_legacy_project_config_template(runcutty: RunCutty, template: Path) -> N
     project.commit(message="Initial")
 
     runcutty("link", f"--cwd={project.path}")
+
+
+def test_template_not_specified(
+    runcutty: RunCutty, project: Path, template: Path
+) -> None:
+    """It exits with an error."""
+    with pytest.raises(RunCuttyError):
+        runcutty("link", f"--cwd={project}")

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -124,7 +124,7 @@ def test_commit_message(runcutty: RunCutty, project: Path, template: Path) -> No
     assert template.name in repository.head.commit.message
 
 
-def test_legacy_project_config(runcutty: RunCutty, template: Path) -> None:
+def test_legacy_project_config_bindings(runcutty: RunCutty, template: Path) -> None:
     """It reads bindings from .cookiecutter.json if it exists."""
     updatefile(
         template / "{{ cookiecutter.project }}" / ".cookiecutter.json",
@@ -140,3 +140,18 @@ def test_legacy_project_config(runcutty: RunCutty, template: Path) -> None:
     runcutty("link", f"--cwd={project}", str(template))
 
     assert project.name == projectvariable(project, "project")
+
+
+def test_legacy_project_config_template(runcutty: RunCutty, template: Path) -> None:
+    """It reads the template from .cookiecutter.json if it exists."""
+    updatefile(
+        template / "{{ cookiecutter.project }}" / ".cookiecutter.json",
+        "{{ cookiecutter | jsonify }}",
+    )
+
+    runcutty("cookiecutter", str(template))
+
+    project = Repository.init(Path("example"))
+    project.commit(message="Initial")
+
+    runcutty("link", f"--cwd={project.path}")

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -15,6 +15,7 @@ from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
 from cutty.repositories.adapters.providers.git import RevisionNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
+from cutty.services.link import TemplateNotSpecifiedError
 
 
 @pytest.mark.parametrize(
@@ -53,6 +54,7 @@ from cutty.repositories.domain.registry import UnknownLocationError
         UnsupportedRevisionError("v1.0.0"),
         UnknownLocationError(URL("invalid://location")),
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),
+        TemplateNotSpecifiedError(),
     ],
 )
 def test_errors(error: CuttyError) -> None:


### PR DESCRIPTION
- ✅ [functional] Add test for reading template location from .cookiecutter.json
- ✨ [services] Allow reading the template from .cookiecutter.json
- ✨ [entrypoints] Allow invoking `cutty link` without `<template>`
- ♻ [services] Extract exception class `TemplateNotSpecifiedError`
- ✅ [entrypoints] Add test for `TemplateNotSpecifiedError`
- ✅ [functional] Add test for `cutty link` when template not specified
