### PR TITLE
♻️ [services] Move repository creation from `create` to its callers

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,8 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.create import create as service_create
+from cutty.services.create import createproject
+from cutty.services.create import EmptyTemplateError
 from cutty.templates.domain.bindings import Binding
 
 
@@ -66,15 +67,17 @@ def cookiecutter(
 ) -> None:
     """Generate projects from Cookiecutter templates."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-    service_create(
-        template,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        checkout=checkout,
-        outputdir=output_dir,
-        directory=PurePosixPath(directory) if directory is not None else None,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
-        createrepository=False,
-        createconfigfile=False,
-    )
+    try:
+        createproject(
+            template,
+            extrabindings=extrabindings,
+            no_input=no_input,
+            checkout=checkout,
+            outputdir=output_dir,
+            directory=PurePosixPath(directory) if directory is not None else None,
+            overwrite_if_exists=overwrite_if_exists,
+            skip_if_file_exists=skip_if_file_exists,
+            createconfigfile=False,
+        )
+    except EmptyTemplateError:  # pragma: no cover
+        pass

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.create import createproject
+from cutty.services.create import create
 from cutty.services.create import EmptyTemplateError
 from cutty.templates.domain.bindings import Binding
 
@@ -68,7 +68,7 @@ def cookiecutter(
     """Generate projects from Cookiecutter templates."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
     try:
-        createproject(
+        create(
             template,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import click
 
-from cutty.services.create import createproject
+from cutty.services.create import create as service_create
 from cutty.services.create import EmptyTemplateError
 from cutty.services.git import creategitrepository
 from cutty.templates.domain.bindings import Binding
@@ -95,7 +95,7 @@ def create(
     """Generate projects from Cookiecutter templates."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
     try:
-        project_dir, template2 = createproject(
+        project_dir, template2 = service_create(
             template,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -36,6 +36,10 @@ def loadtemplate(
     )
 
 
+class EmptyTemplateError(Exception):
+    """The template contains no project files."""
+
+
 def createproject(
     location: str,
     *,
@@ -69,7 +73,7 @@ def createproject(
         renderfiles(findcookiecutterpaths(template.path, config), render, bindings)
     )
     if not projectfiles:  # pragma: no cover
-        return None
+        raise EmptyTemplateError()
 
     projectname = projectfiles[0].path.parts[0]
     projectfiles2 = projectfiles.release()
@@ -114,18 +118,21 @@ def create(
     createconfigfile: bool = True,
 ) -> None:
     """Generate a project from a Cookiecutter template."""
-    result = createproject(
-        location,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        checkout=checkout,
-        outputdir=outputdir,
-        directory=directory,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
-        outputdirisproject=outputdirisproject,
-        createconfigfile=createconfigfile,
-    )
-    if result and createrepository:
-        project_dir, template = result
-        creategitrepository(project_dir, template.name, template.revision)
+    try:
+        result = createproject(
+            location,
+            extrabindings=extrabindings,
+            no_input=no_input,
+            checkout=checkout,
+            outputdir=outputdir,
+            directory=directory,
+            overwrite_if_exists=overwrite_if_exists,
+            skip_if_file_exists=skip_if_file_exists,
+            outputdirisproject=outputdirisproject,
+            createconfigfile=createconfigfile,
+        )
+        if result and createrepository:
+            project_dir, template = result
+            creategitrepository(project_dir, template.name, template.revision)
+    except EmptyTemplateError:  # pragma: no cover
+        pass

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -11,7 +11,6 @@ from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
 from cutty.repositories.domain.repository import Repository
-from cutty.services.git import creategitrepository
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterhooks
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterpaths
@@ -101,35 +100,3 @@ def createproject(
             storage.add(projectfile)
 
     return project_dir, template
-
-
-def create(
-    location: str,
-    *,
-    extrabindings: Sequence[Binding] = (),
-    no_input: bool = False,
-    checkout: Optional[str] = None,
-    outputdir: Optional[pathlib.Path] = None,
-    directory: Optional[pathlib.PurePosixPath] = None,
-    overwrite_if_exists: bool = False,
-    skip_if_file_exists: bool = False,
-    outputdirisproject: bool = False,
-    createconfigfile: bool = True,
-) -> None:
-    """Generate a project from a Cookiecutter template."""
-    try:
-        project_dir, template = createproject(
-            location,
-            extrabindings=extrabindings,
-            no_input=no_input,
-            checkout=checkout,
-            outputdir=outputdir,
-            directory=directory,
-            overwrite_if_exists=overwrite_if_exists,
-            skip_if_file_exists=skip_if_file_exists,
-            outputdirisproject=outputdirisproject,
-            createconfigfile=createconfigfile,
-        )
-        creategitrepository(project_dir, template.name, template.revision)
-    except EmptyTemplateError:  # pragma: no cover
-        pass

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -39,7 +39,7 @@ class EmptyTemplateError(Exception):
     """The template contains no project files."""
 
 
-def createproject(
+def create(
     location: str,
     *,
     extrabindings: Sequence[Binding] = (),

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -36,7 +36,7 @@ def loadtemplate(
     )
 
 
-def create(
+def createproject(
     location: str,
     *,
     extrabindings: Sequence[Binding] = (),
@@ -49,7 +49,7 @@ def create(
     outputdirisproject: bool = False,
     createrepository: bool = True,
     createconfigfile: bool = True,
-) -> None:
+) -> Optional[tuple[pathlib.Path, Repository]]:
     """Generate a project from a Cookiecutter template."""
     if outputdir is None:
         outputdir = pathlib.Path.cwd()
@@ -69,7 +69,7 @@ def create(
         renderfiles(findcookiecutterpaths(template.path, config), render, bindings)
     )
     if not projectfiles:  # pragma: no cover
-        return
+        return None
 
     projectname = projectfiles[0].path.parts[0]
     projectfiles2 = projectfiles.release()
@@ -96,5 +96,36 @@ def create(
 
             storage.add(projectfile)
 
-    if createrepository:
+    return project_dir, template
+
+
+def create(
+    location: str,
+    *,
+    extrabindings: Sequence[Binding] = (),
+    no_input: bool = False,
+    checkout: Optional[str] = None,
+    outputdir: Optional[pathlib.Path] = None,
+    directory: Optional[pathlib.PurePosixPath] = None,
+    overwrite_if_exists: bool = False,
+    skip_if_file_exists: bool = False,
+    outputdirisproject: bool = False,
+    createrepository: bool = True,
+    createconfigfile: bool = True,
+) -> None:
+    """Generate a project from a Cookiecutter template."""
+    result = createproject(
+        location,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        outputdir=outputdir,
+        directory=directory,
+        overwrite_if_exists=overwrite_if_exists,
+        skip_if_file_exists=skip_if_file_exists,
+        outputdirisproject=outputdirisproject,
+        createconfigfile=createconfigfile,
+    )
+    if result and createrepository:
+        project_dir, template = result
         creategitrepository(project_dir, template.name, template.revision)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -114,7 +114,6 @@ def create(
     overwrite_if_exists: bool = False,
     skip_if_file_exists: bool = False,
     outputdirisproject: bool = False,
-    createrepository: bool = True,
     createconfigfile: bool = True,
 ) -> None:
     """Generate a project from a Cookiecutter template."""
@@ -131,7 +130,6 @@ def create(
             outputdirisproject=outputdirisproject,
             createconfigfile=createconfigfile,
         )
-        if createrepository:
-            creategitrepository(project_dir, template.name, template.revision)
+        creategitrepository(project_dir, template.name, template.revision)
     except EmptyTemplateError:  # pragma: no cover
         pass

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -53,7 +53,7 @@ def createproject(
     outputdirisproject: bool = False,
     createrepository: bool = True,
     createconfigfile: bool = True,
-) -> Optional[tuple[pathlib.Path, Repository]]:
+) -> tuple[pathlib.Path, Repository]:
     """Generate a project from a Cookiecutter template."""
     if outputdir is None:
         outputdir = pathlib.Path.cwd()
@@ -119,7 +119,7 @@ def create(
 ) -> None:
     """Generate a project from a Cookiecutter template."""
     try:
-        result = createproject(
+        project_dir, template = createproject(
             location,
             extrabindings=extrabindings,
             no_input=no_input,
@@ -131,8 +131,7 @@ def create(
             outputdirisproject=outputdirisproject,
             createconfigfile=createconfigfile,
         )
-        if result and createrepository:
-            project_dir, template = result
+        if createrepository:
             creategitrepository(project_dir, template.name, template.revision)
     except EmptyTemplateError:  # pragma: no cover
         pass

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.services.create import createproject
+from cutty.services.create import create
 from cutty.services.create import EmptyTemplateError
 from cutty.services.git import creategitrepository
 from cutty.services.git import LATEST_BRANCH
@@ -90,7 +90,7 @@ def link(
 
     with project.worktree(update, checkout=False) as worktree:
         try:
-            project_dir, template2 = createproject(
+            project_dir, template2 = create(
                 template,
                 outputdir=worktree,
                 outputdirisproject=True,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
 
-from cutty.services.create import createproject
+from cutty.services.create import create
 from cutty.services.create import EmptyTemplateError
 from cutty.services.git import creategitrepository
 from cutty.services.git import LATEST_BRANCH
@@ -38,7 +38,7 @@ def update(
 
     with repository.worktree(branch, checkout=False) as worktree:
         try:
-            project_dir, template = createproject(
+            project_dir, template = create(
                 projectconfig.template,
                 outputdir=worktree,
                 outputdirisproject=True,


### PR DESCRIPTION
- ♻ [services] Extract function `createproject`
- ♻ [services] Raise `EmptyTemplateError` instead of returning None
- ♻ [services] Simplify return type
- ♻ [services] Inline function `create` in `link` service
- ♻ [services] Inline function `create` in `update` service
- ♻ [entrypoints] Inline function `create` in `cookiecutter` CLI
- ♻ [services] Remove parameter `createrepository` from function `create`
- ♻ [entrypoints] Inline function `services.create` in `cli.create`
- ♻ [services] Remove function `create`
- ♻ [services] Rename function `createproject` to `create`
