### PR TITLE
✨ [services] Exit with error when templates contain no project files

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -7,7 +7,6 @@ import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.create import create
-from cutty.services.create import EmptyTemplateError
 from cutty.templates.domain.bindings import Binding
 
 
@@ -67,17 +66,14 @@ def cookiecutter(
 ) -> None:
     """Generate projects from Cookiecutter templates."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-    try:
-        create(
-            template,
-            extrabindings=extrabindings,
-            no_input=no_input,
-            checkout=checkout,
-            outputdir=output_dir,
-            directory=PurePosixPath(directory) if directory is not None else None,
-            overwrite_if_exists=overwrite_if_exists,
-            skip_if_file_exists=skip_if_file_exists,
-            createconfigfile=False,
-        )
-    except EmptyTemplateError:  # pragma: no cover
-        pass
+    create(
+        template,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        outputdir=output_dir,
+        directory=PurePosixPath(directory) if directory is not None else None,
+        overwrite_if_exists=overwrite_if_exists,
+        skip_if_file_exists=skip_if_file_exists,
+        createconfigfile=False,
+    )

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -6,7 +6,6 @@ from typing import Optional
 import click
 
 from cutty.services.create import create as service_create
-from cutty.services.create import EmptyTemplateError
 from cutty.services.git import creategitrepository
 from cutty.templates.domain.bindings import Binding
 
@@ -94,20 +93,17 @@ def create(
 ) -> None:
     """Generate projects from Cookiecutter templates."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-    try:
-        project_dir, template2 = service_create(
-            template,
-            extrabindings=extrabindings,
-            no_input=no_input,
-            checkout=checkout,
-            outputdir=output_dir,
-            directory=pathlib.PurePosixPath(directory)
-            if directory is not None
-            else None,
-            overwrite_if_exists=overwrite_if_exists,
-            skip_if_file_exists=skip_if_file_exists,
-            outputdirisproject=in_place,
-        )
-        creategitrepository(project_dir, template2.name, template2.revision)
-    except EmptyTemplateError:  # pragma: no cover
-        pass
+
+    project_dir, template2 = service_create(
+        template,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        outputdir=output_dir,
+        directory=pathlib.PurePosixPath(directory) if directory is not None else None,
+        overwrite_if_exists=overwrite_if_exists,
+        skip_if_file_exists=skip_if_file_exists,
+        outputdirisproject=in_place,
+    )
+
+    creategitrepository(project_dir, template2.name, template2.revision)

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -10,6 +10,7 @@ from cutty.repositories.adapters.fetchers.mercurial import HgNotFoundError
 from cutty.repositories.adapters.providers.git import RevisionNotFoundError
 from cutty.repositories.domain.mounters import UnsupportedRevisionError
 from cutty.repositories.domain.registry import UnknownLocationError
+from cutty.services.create import EmptyTemplateError
 from cutty.services.link import TemplateNotSpecifiedError
 from cutty.util.exceptionhandlers import exceptionhandler
 
@@ -79,6 +80,11 @@ def _templatenotspecified(error: TemplateNotSpecifiedError) -> NoReturn:
     _die("template not specified")
 
 
+@exceptionhandler
+def _emptytemplate(error: EmptyTemplateError) -> NoReturn:
+    _die("template does not contain project files")
+
+
 fatal = (
     _unknownlocation
     >> _unsupportedrevision
@@ -89,4 +95,5 @@ fatal = (
     >> _httpfetcher
     >> _revisionnotfound
     >> _templatenotspecified
+    >> _emptytemplate
 )

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -7,6 +7,7 @@ from typing import Optional
 import platformdirs
 from lazysequence import lazysequence
 
+from cutty.errors import CuttyError
 from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
@@ -35,7 +36,7 @@ def loadtemplate(
     )
 
 
-class EmptyTemplateError(Exception):
+class EmptyTemplateError(CuttyError):
     """The template contains no project files."""
 
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from cutty.errors import CuttyError
 from cutty.services.create import create
-from cutty.services.create import EmptyTemplateError
 from cutty.services.git import creategitrepository
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
@@ -89,19 +88,16 @@ def link(
         update = _create_orphan_branch(project, UPDATE_BRANCH)
 
     with project.worktree(update, checkout=False) as worktree:
-        try:
-            project_dir, template2 = create(
-                template,
-                outputdir=worktree,
-                outputdirisproject=True,
-                extrabindings=extrabindings,
-                no_input=no_input,
-                checkout=checkout,
-                directory=directory,
-            )
-            creategitrepository(project_dir, template2.name, template2.revision)
-        except EmptyTemplateError:  # pragma: no cover
-            pass
+        project_dir, template2 = create(
+            template,
+            outputdir=worktree,
+            outputdirisproject=True,
+            extrabindings=extrabindings,
+            no_input=no_input,
+            checkout=checkout,
+            directory=directory,
+        )
+        creategitrepository(project_dir, template2.name, template2.revision)
 
     if latest is None:
         # Squash the empty initial commit.

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -5,7 +5,6 @@ from pathlib import PurePosixPath
 from typing import Optional
 
 from cutty.services.create import create
-from cutty.services.create import EmptyTemplateError
 from cutty.services.git import creategitrepository
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
@@ -37,19 +36,16 @@ def update(
     branch = repository.branch(UPDATE_BRANCH)
 
     with repository.worktree(branch, checkout=False) as worktree:
-        try:
-            project_dir, template = create(
-                projectconfig.template,
-                outputdir=worktree,
-                outputdirisproject=True,
-                extrabindings=extrabindings,
-                no_input=no_input,
-                checkout=checkout,
-                directory=directory,
-            )
-            creategitrepository(project_dir, template.name, template.revision)
-        except EmptyTemplateError:  # pragma: no cover
-            pass
+        project_dir, template = create(
+            projectconfig.template,
+            outputdir=worktree,
+            outputdirisproject=True,
+            extrabindings=extrabindings,
+            no_input=no_input,
+            checkout=checkout,
+            directory=directory,
+        )
+        creategitrepository(project_dir, template.name, template.revision)
 
     repository.cherrypick(branch.commit)
     repository.heads[LATEST_BRANCH] = branch.commit

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -90,3 +90,15 @@ def template(template_directory: Path) -> Path:
     repository = Repository.init(template_directory)
     repository.commit(message="Initial")
     return template_directory
+
+
+@pytest.fixture
+def emptytemplate(tmp_path: Path) -> Path:
+    """Fixture for a template without project files."""
+    template = tmp_path / "template"
+    template.mkdir()
+
+    (template / "cookiecutter.json").write_text('{"project": "project"}')
+    (template / "{{ cookiecutter.project }}").mkdir()
+
+    return template

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -126,13 +126,7 @@ def test_skip(runcutty: RunCutty, template: Path) -> None:
     assert readme.read_text() == ""
 
 
-def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
+def test_empty_template(emptytemplate: Path, runcutty: RunCutty) -> None:
     """It exits with a non-zero status code."""
-    template = tmp_path / "template"
-    template.mkdir()
-
-    (template / "cookiecutter.json").write_text('{"project": "project"}')
-    (template / "{{ cookiecutter.project }}").mkdir()
-
     with pytest.raises(RunCuttyError):
-        runcutty("cookiecutter", str(template))
+        runcutty("cookiecutter", str(emptytemplate))

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from cutty.services.create import EmptyTemplateError
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
@@ -123,3 +124,15 @@ def test_skip(runcutty: RunCutty, template: Path) -> None:
     )
 
     assert readme.read_text() == ""
+
+
+def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
+    """It prints an error message."""
+    template = tmp_path / "template"
+    template.mkdir()
+
+    (template / "cookiecutter.json").write_text('{"project": "project"}')
+    (template / "{{ cookiecutter.project }}").mkdir()
+
+    with pytest.raises(EmptyTemplateError):
+        runcutty("cookiecutter", str(template))

--- a/tests/functional/test_cookiecutter.py
+++ b/tests/functional/test_cookiecutter.py
@@ -3,10 +3,10 @@ from pathlib import Path
 
 import pytest
 
-from cutty.services.create import EmptyTemplateError
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
+from tests.functional.conftest import RunCuttyError
 from tests.util.files import project_files
 from tests.util.files import template_files
 from tests.util.git import move_repository_files_to_subdirectory
@@ -127,12 +127,12 @@ def test_skip(runcutty: RunCutty, template: Path) -> None:
 
 
 def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
-    """It prints an error message."""
+    """It exits with a non-zero status code."""
     template = tmp_path / "template"
     template.mkdir()
 
     (template / "cookiecutter.json").write_text('{"project": "project"}')
     (template / "{{ cookiecutter.project }}").mkdir()
 
-    with pytest.raises(EmptyTemplateError):
+    with pytest.raises(RunCuttyError):
         runcutty("cookiecutter", str(template))

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -100,13 +100,7 @@ def test_cutty_error(runcutty: RunCutty) -> None:
         runcutty("create", "invalid://location")
 
 
-def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
+def test_empty_template(emptytemplate: Path, runcutty: RunCutty) -> None:
     """It prints an error message."""
-    template = tmp_path / "template"
-    template.mkdir()
-
-    (template / "cookiecutter.json").write_text('{"project": "project"}')
-    (template / "{{ cookiecutter.project }}").mkdir()
-
     with pytest.raises(RunCuttyError):
-        runcutty("create", str(template))
+        runcutty("create", str(emptytemplate))

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -3,10 +3,10 @@ from pathlib import Path
 
 import pytest
 
-from cutty.services.create import EmptyTemplateError
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
+from tests.functional.conftest import RunCuttyError
 from tests.util.files import project_files
 from tests.util.files import template_files
 from tests.util.git import move_repository_files_to_subdirectory
@@ -108,5 +108,5 @@ def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
     (template / "cookiecutter.json").write_text('{"project": "project"}')
     (template / "{{ cookiecutter.project }}").mkdir()
 
-    with pytest.raises(EmptyTemplateError):
+    with pytest.raises(RunCuttyError):
         runcutty("create", str(template))

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -101,6 +101,6 @@ def test_cutty_error(runcutty: RunCutty) -> None:
 
 
 def test_empty_template(emptytemplate: Path, runcutty: RunCutty) -> None:
-    """It prints an error message."""
+    """It exits with a non-zero status code."""
     with pytest.raises(RunCuttyError):
         runcutty("create", str(emptytemplate))

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from cutty.services.create import EmptyTemplateError
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
@@ -97,3 +98,15 @@ def test_cutty_error(runcutty: RunCutty) -> None:
     """It prints an error message for known exceptions."""
     with pytest.raises(Exception, match="unknown location"):
         runcutty("create", "invalid://location")
+
+
+def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
+    """It prints an error message."""
+    template = tmp_path / "template"
+    template.mkdir()
+
+    (template / "cookiecutter.json").write_text('{"project": "project"}')
+    (template / "{{ cookiecutter.project }}").mkdir()
+
+    with pytest.raises(EmptyTemplateError):
+        runcutty("create", str(template))

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -200,21 +200,16 @@ def test_template_not_specified(
         runcutty("link", f"--cwd={project}")
 
 
-def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
+def test_empty_template(emptytemplate: Path, runcutty: RunCutty) -> None:
     """It prints an error message."""
-    template = tmp_path / "template"
-    template.mkdir()
+    (emptytemplate / "{{ cookiecutter.project }}" / "marker").touch()
 
-    (template / "cookiecutter.json").write_text('{"project": "project"}')
-    (template / "{{ cookiecutter.project }}").mkdir()
-    (template / "{{ cookiecutter.project }}" / "marker").touch()
+    runcutty("cookiecutter", str(emptytemplate))
 
-    runcutty("cookiecutter", str(template))
-
-    (template / "{{ cookiecutter.project }}" / "marker").unlink()
+    (emptytemplate / "{{ cookiecutter.project }}" / "marker").unlink()
 
     project = Repository.init(Path("project"))
     project.commit(message="Initial")
 
     with pytest.raises(RunCuttyError):
-        runcutty("link", "--cwd=project", str(template))
+        runcutty("link", "--cwd=project", str(emptytemplate))

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 
-from cutty.services.create import EmptyTemplateError
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
@@ -217,5 +216,5 @@ def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
     project = Repository.init(Path("project"))
     project.commit(message="Initial")
 
-    with pytest.raises(EmptyTemplateError):
+    with pytest.raises(RunCuttyError):
         runcutty("link", "--cwd=project", str(template))

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -201,7 +201,7 @@ def test_template_not_specified(
 
 
 def test_empty_template(emptytemplate: Path, runcutty: RunCutty) -> None:
-    """It prints an error message."""
+    """It exits with a non-zero status code."""
     (emptytemplate / "{{ cookiecutter.project }}" / "marker").touch()
 
     runcutty("cookiecutter", str(emptytemplate))

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -5,10 +5,10 @@ from typing import Any
 
 import pytest
 
-from cutty.services.create import EmptyTemplateError
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
+from tests.functional.conftest import RunCuttyError
 from tests.util.files import chdir
 from tests.util.git import appendfile
 from tests.util.git import move_repository_files_to_subdirectory
@@ -364,5 +364,5 @@ def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
 
     (template / "{{ cookiecutter.project }}" / "marker").unlink()
 
-    with pytest.raises(EmptyTemplateError):
+    with pytest.raises(RunCuttyError):
         runcutty("update", "--cwd=project")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -351,18 +351,13 @@ def test_skip(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
     assert (project / "INSTALL").is_file()
 
 
-def test_empty_template(tmp_path: Path, runcutty: RunCutty) -> None:
+def test_empty_template(emptytemplate: Path, runcutty: RunCutty) -> None:
     """It prints an error message."""
-    template = tmp_path / "template"
-    template.mkdir()
+    (emptytemplate / "{{ cookiecutter.project }}" / "marker").touch()
 
-    (template / "cookiecutter.json").write_text('{"project": "project"}')
-    (template / "{{ cookiecutter.project }}").mkdir()
-    (template / "{{ cookiecutter.project }}" / "marker").touch()
+    runcutty("create", str(emptytemplate))
 
-    runcutty("create", str(template))
-
-    (template / "{{ cookiecutter.project }}" / "marker").unlink()
+    (emptytemplate / "{{ cookiecutter.project }}" / "marker").unlink()
 
     with pytest.raises(RunCuttyError):
         runcutty("update", "--cwd=project")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -352,7 +352,7 @@ def test_skip(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
 
 
 def test_empty_template(emptytemplate: Path, runcutty: RunCutty) -> None:
-    """It prints an error message."""
+    """It exits with a non-zero status code."""
     (emptytemplate / "{{ cookiecutter.project }}" / "marker").touch()
 
     runcutty("create", str(emptytemplate))


### PR DESCRIPTION
- 🔨 [services] Derive `EmptyTemplateError` from `CuttyError`
- ✅ [functional] Add test for `cutty create` with empty template
- ✨ [entrypoints] Do not silently ignore empty templates in `cutty create`
- ✅ [functional] Add test for `cutty update` with empty template
- ✨ [services] Do not silently ignore empty templates in `cutty update`
- ✅ [functional] Add test for `cutty link` with empty template
- ✨ [services] Do not silently ignore empty templates in `cutty link`
- ✅ [functional] Add test for `cutty cookiecutter` with empty template
- ✨ [entrypoints] Do not silently ignore empty templates in `cutty cookiecutter`
- ✅ [functional] Change tests for empty templates to expect non-zero exit code
- ✨ [entrypoints] Improve error message when template contains no project files
- 🔨 [functional] Extract fixture `emptytemplate` from `create` test
- 🔨 [functional] Replace inline code in `update` test with `emptytemplate` fixture
- 🔨 [functional] Replace inline code in `link` test with `emptytemplate` fixture
- 🔨 [functional] Replace inline code in `cookiecutter` test with `emptytemplate` fixture
- 💡 [functional] Improve docstrings for empty template tests
