### PR TITLE
🔨 [services] Move `Path.cwd()` fallback logic to `entrypoints.cli`

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.create import create
+from cutty.services.create import create2
 from cutty.templates.domain.bindings import Binding
 
 
@@ -66,12 +66,16 @@ def cookiecutter(
 ) -> None:
     """Generate projects from Cookiecutter templates."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-    create(
+
+    if output_dir is None:
+        output_dir = Path.cwd()
+
+    create2(
         template,
+        output_dir,
         extrabindings=extrabindings,
         no_input=no_input,
         checkout=checkout,
-        outputdir=output_dir,
         directory=PurePosixPath(directory) if directory is not None else None,
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.create import create2
+from cutty.services.create import create
 from cutty.templates.domain.bindings import Binding
 
 
@@ -70,7 +70,7 @@ def cookiecutter(
     if output_dir is None:
         output_dir = Path.cwd()
 
-    create2(
+    create(
         template,
         output_dir,
         extrabindings=extrabindings,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import click
 
-from cutty.services.create import create as service_create
+from cutty.services.create import create2 as service_create
 from cutty.services.git import creategitrepository
 from cutty.templates.domain.bindings import Binding
 
@@ -94,12 +94,15 @@ def create(
     """Generate projects from Cookiecutter templates."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
 
+    if output_dir is None:
+        output_dir = pathlib.Path.cwd()
+
     project_dir, template2 = service_create(
         template,
+        output_dir,
         extrabindings=extrabindings,
         no_input=no_input,
         checkout=checkout,
-        outputdir=output_dir,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import click
 
-from cutty.services.create import create2 as service_create
+from cutty.services.create import create as service_create
 from cutty.services.git import creategitrepository
 from cutty.templates.domain.bindings import Binding
 

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.link import link2 as service_link
+from cutty.services.link import link as service_link
 from cutty.templates.domain.bindings import Binding
 
 

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.link import link as service_link
+from cutty.services.link import link2 as service_link
 from cutty.templates.domain.bindings import Binding
 
 
@@ -50,12 +50,16 @@ def link(
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
+    if cwd is None:
+        cwd = pathlib.Path.cwd()
+
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+
     service_link(
         template,
+        cwd,
         extrabindings=extrabindings,
         no_input=no_input,
-        projectdir=cwd,
         checkout=checkout,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -8,7 +8,7 @@ from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import skipupdate
-from cutty.services.update import update as service_update
+from cutty.services.update import update2 as service_update
 from cutty.templates.domain.bindings import Binding
 
 
@@ -86,6 +86,10 @@ def update(
         return
 
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
+
+    if cwd is None:
+        cwd = pathlib.Path.cwd()
+
     service_update(
         extrabindings=extrabindings,
         no_input=no_input,

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -8,7 +8,7 @@ from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import skipupdate
-from cutty.services.update import update2 as service_update
+from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
 
 

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -91,9 +91,9 @@ def update(
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
 
     service_update(
+        cwd,
         extrabindings=extrabindings,
         no_input=no_input,
-        projectdir=cwd,
         checkout=checkout,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -73,31 +73,22 @@ def update(
     abort: bool,
 ) -> None:
     """Update a project with changes from its template."""
-    if continue_:
-        if cwd is None:
-            cwd = pathlib.Path.cwd()
+    if cwd is None:
+        cwd = pathlib.Path.cwd()
 
+    if continue_:
         continueupdate(cwd)
         return
 
     if skip:
-        if cwd is None:
-            cwd = pathlib.Path.cwd()
-
         skipupdate(cwd)
         return
 
     if abort:
-        if cwd is None:
-            cwd = pathlib.Path.cwd()
-
         abortupdate(cwd)
         return
 
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
-
-    if cwd is None:
-        cwd = pathlib.Path.cwd()
 
     service_update(
         extrabindings=extrabindings,

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -7,7 +7,7 @@ import click
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
-from cutty.services.update import skipupdate2
+from cutty.services.update import skipupdate
 from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
 
@@ -84,7 +84,7 @@ def update(
         if cwd is None:
             cwd = pathlib.Path.cwd()
 
-        skipupdate2(cwd)
+        skipupdate(cwd)
         return
 
     if abort:

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.update import abortupdate
+from cutty.services.update import abortupdate2
 from cutty.services.update import continueupdate
 from cutty.services.update import skipupdate
 from cutty.services.update import update as service_update
@@ -88,7 +88,10 @@ def update(
         return
 
     if abort:
-        abortupdate(projectdir=cwd)
+        if cwd is None:
+            cwd = pathlib.Path.cwd()
+
+        abortupdate2(cwd)
         return
 
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -6,7 +6,7 @@ import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.update import abortupdate
-from cutty.services.update import continueupdate
+from cutty.services.update import continueupdate2
 from cutty.services.update import skipupdate
 from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
@@ -74,7 +74,10 @@ def update(
 ) -> None:
     """Update a project with changes from its template."""
     if continue_:
-        continueupdate(projectdir=cwd)
+        if cwd is None:
+            cwd = pathlib.Path.cwd()
+
+        continueupdate2(cwd)
         return
 
     if skip:

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -7,7 +7,7 @@ import click
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
-from cutty.services.update import skipupdate
+from cutty.services.update import skipupdate2
 from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
 
@@ -81,7 +81,10 @@ def update(
         return
 
     if skip:
-        skipupdate(projectdir=cwd)
+        if cwd is None:
+            cwd = pathlib.Path.cwd()
+
+        skipupdate2(cwd)
         return
 
     if abort:

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -6,7 +6,7 @@ import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.update import abortupdate
-from cutty.services.update import continueupdate2
+from cutty.services.update import continueupdate
 from cutty.services.update import skipupdate
 from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
@@ -77,7 +77,7 @@ def update(
         if cwd is None:
             cwd = pathlib.Path.cwd()
 
-        continueupdate2(cwd)
+        continueupdate(cwd)
         return
 
     if skip:

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.update import abortupdate2
+from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import skipupdate
 from cutty.services.update import update as service_update
@@ -91,7 +91,7 @@ def update(
         if cwd is None:
             cwd = pathlib.Path.cwd()
 
-        abortupdate2(cwd)
+        abortupdate(cwd)
         return
 
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -40,39 +40,6 @@ class EmptyTemplateError(CuttyError):
     """The template contains no project files."""
 
 
-def create(
-    location: str,
-    *,
-    extrabindings: Sequence[Binding] = (),
-    no_input: bool = False,
-    checkout: Optional[str] = None,
-    outputdir: Optional[pathlib.Path] = None,
-    directory: Optional[pathlib.PurePosixPath] = None,
-    overwrite_if_exists: bool = False,
-    skip_if_file_exists: bool = False,
-    outputdirisproject: bool = False,
-    createrepository: bool = True,
-    createconfigfile: bool = True,
-) -> tuple[pathlib.Path, Repository]:
-    """Generate a project from a Cookiecutter template."""
-    if outputdir is None:
-        outputdir = pathlib.Path.cwd()
-
-    return create2(
-        location,
-        outputdir,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        checkout=checkout,
-        directory=directory,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
-        outputdirisproject=outputdirisproject,
-        createrepository=createrepository,
-        createconfigfile=createconfigfile,
-    )
-
-
 def create2(
     location: str,
     outputdir: pathlib.Path,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -40,7 +40,7 @@ class EmptyTemplateError(CuttyError):
     """The template contains no project files."""
 
 
-def create2(
+def create(
     location: str,
     outputdir: pathlib.Path,
     *,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -58,6 +58,36 @@ def create(
     if outputdir is None:
         outputdir = pathlib.Path.cwd()
 
+    return create2(
+        location,
+        outputdir,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        directory=directory,
+        overwrite_if_exists=overwrite_if_exists,
+        skip_if_file_exists=skip_if_file_exists,
+        outputdirisproject=outputdirisproject,
+        createrepository=createrepository,
+        createconfigfile=createconfigfile,
+    )
+
+
+def create2(
+    location: str,
+    outputdir: pathlib.Path,
+    *,
+    extrabindings: Sequence[Binding] = (),
+    no_input: bool = False,
+    checkout: Optional[str] = None,
+    directory: Optional[pathlib.PurePosixPath] = None,
+    overwrite_if_exists: bool = False,
+    skip_if_file_exists: bool = False,
+    outputdirisproject: bool = False,
+    createrepository: bool = True,
+    createconfigfile: bool = True,
+) -> tuple[pathlib.Path, Repository]:
+    """Generate a project from a Cookiecutter template."""
     template = loadtemplate(location, checkout, directory)
     config = loadcookiecutterconfig(location, template.path)
     render = createcookiecutterrenderer(template.path, config)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -54,30 +54,6 @@ def _transform_commit_message(message: str) -> str:
     return message.replace("Initial import from ", "Link to ")
 
 
-def link(
-    template: Optional[str] = None,
-    /,
-    *,
-    extrabindings: Sequence[Binding] = (),
-    no_input: bool = False,
-    checkout: Optional[str] = None,
-    directory: Optional[pathlib.PurePosixPath] = None,
-    projectdir: Optional[pathlib.Path] = None,
-) -> None:
-    """Link project to a Cookiecutter template."""
-    if projectdir is None:
-        projectdir = pathlib.Path.cwd()
-
-    link2(
-        template,
-        projectdir,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        checkout=checkout,
-        directory=directory,
-    )
-
-
 def link2(
     template: Optional[str],
     projectdir: pathlib.Path,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.services.create import create
+from cutty.services.create import create2
 from cutty.services.git import creategitrepository
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
@@ -88,9 +88,9 @@ def link(
         update = _create_orphan_branch(project, UPDATE_BRANCH)
 
     with project.worktree(update, checkout=False) as worktree:
-        project_dir, template2 = create(
+        project_dir, template2 = create2(
             template,
-            outputdir=worktree,
+            worktree,
             outputdirisproject=True,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.services.create import create2
+from cutty.services.create import create
 from cutty.services.git import creategitrepository
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
@@ -88,7 +88,7 @@ def link(
         update = _create_orphan_branch(project, UPDATE_BRANCH)
 
     with project.worktree(update, checkout=False) as worktree:
-        project_dir, template2 = create2(
+        project_dir, template2 = create(
             template,
             worktree,
             outputdirisproject=True,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -54,7 +54,7 @@ def _transform_commit_message(message: str) -> str:
     return message.replace("Initial import from ", "Link to ")
 
 
-def link2(
+def link(
     template: Optional[str],
     projectdir: pathlib.Path,
     /,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -68,6 +68,27 @@ def link(
     if projectdir is None:
         projectdir = pathlib.Path.cwd()
 
+    link2(
+        template,
+        projectdir,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        directory=directory,
+    )
+
+
+def link2(
+    template: Optional[str],
+    projectdir: pathlib.Path,
+    /,
+    *,
+    extrabindings: Sequence[Binding] = (),
+    no_input: bool = False,
+    checkout: Optional[str] = None,
+    directory: Optional[pathlib.PurePosixPath] = None,
+) -> None:
+    """Link project to a Cookiecutter template."""
     project = Repository.open(projectdir)
 
     with contextlib.suppress(FileNotFoundError):

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -96,7 +96,11 @@ def abortupdate(*, projectdir: Optional[Path] = None) -> None:
     """Abort an update with conflicts."""
     if projectdir is None:
         projectdir = Path.cwd()
+    abortupdate2(projectdir)
 
+
+def abortupdate2(projectdir: Path) -> None:
+    """Abort an update with conflicts."""
     repository = Repository.open(projectdir)
     repository.resetcherrypick()
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -92,13 +92,6 @@ def skipupdate(projectdir: Path) -> None:
     repository.heads[LATEST_BRANCH] = repository.heads[UPDATE_BRANCH]
 
 
-def abortupdate(*, projectdir: Optional[Path] = None) -> None:
-    """Abort an update with conflicts."""
-    if projectdir is None:
-        projectdir = Path.cwd()
-    abortupdate2(projectdir)
-
-
 def abortupdate2(projectdir: Path) -> None:
     """Abort an update with conflicts."""
     repository = Repository.open(projectdir)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -14,7 +14,7 @@ from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
 
 
-def update2(
+def update(
     projectdir: Path,
     *,
     extrabindings: Sequence[Binding] = (),

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -75,6 +75,11 @@ def continueupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
+    continueupdate2(projectdir)
+
+
+def continueupdate2(projectdir: Path) -> None:
+    """Continue an update after conflict resolution."""
     repository = Repository.open(projectdir)
 
     if commit := repository.cherrypickhead:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -72,29 +72,29 @@ def _commitmessage(template: Template) -> str:
 
 def continueupdate(projectdir: Path) -> None:
     """Continue an update after conflict resolution."""
-    repository = Repository.open(projectdir)
+    project = Repository.open(projectdir)
 
-    if commit := repository.cherrypickhead:
-        repository.commit(
+    if commit := project.cherrypickhead:
+        project.commit(
             message=commit.message,
             author=commit.author,
-            committer=repository.default_signature,
+            committer=project.default_signature,
         )
 
-    repository.heads[LATEST_BRANCH] = repository.heads[UPDATE_BRANCH]
+    project.heads[LATEST_BRANCH] = project.heads[UPDATE_BRANCH]
 
 
 def skipupdate(projectdir: Path) -> None:
     """Skip an update with conflicts."""
-    repository = Repository.open(projectdir)
-    repository.resetcherrypick()
+    project = Repository.open(projectdir)
+    project.resetcherrypick()
 
-    repository.heads[LATEST_BRANCH] = repository.heads[UPDATE_BRANCH]
+    project.heads[LATEST_BRANCH] = project.heads[UPDATE_BRANCH]
 
 
 def abortupdate(projectdir: Path) -> None:
     """Abort an update with conflicts."""
-    repository = Repository.open(projectdir)
-    repository.resetcherrypick()
+    project = Repository.open(projectdir)
+    project.resetcherrypick()
 
-    repository.heads[UPDATE_BRANCH] = repository.heads[LATEST_BRANCH]
+    project.heads[UPDATE_BRANCH] = project.heads[LATEST_BRANCH]

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -14,27 +14,6 @@ from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
 
 
-def update(
-    *,
-    projectdir: Optional[Path] = None,
-    extrabindings: Sequence[Binding] = (),
-    no_input: bool = False,
-    checkout: Optional[str] = None,
-    directory: Optional[PurePosixPath] = None,
-) -> None:
-    """Update a project with changes from its Cookiecutter template."""
-    if projectdir is None:
-        projectdir = Path.cwd()
-
-    update2(
-        projectdir,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        checkout=checkout,
-        directory=directory,
-    )
-
-
 def update2(
     projectdir: Path,
     *,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -6,7 +6,7 @@ from pathlib import PurePosixPath
 from typing import Optional
 
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.create import create
+from cutty.services.create import create2
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
@@ -30,9 +30,9 @@ def update(
         directory = projectconfig.directory
 
     def createproject(outputdir: Path) -> Template:
-        _, template = create(
+        _, template = create2(
             projectconfig.template,
-            outputdir=outputdir,
+            outputdir,
             outputdirisproject=True,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -92,7 +92,7 @@ def skipupdate(projectdir: Path) -> None:
     repository.heads[LATEST_BRANCH] = repository.heads[UPDATE_BRANCH]
 
 
-def abortupdate2(projectdir: Path) -> None:
+def abortupdate(projectdir: Path) -> None:
     """Abort an update with conflicts."""
     repository = Repository.open(projectdir)
     repository.resetcherrypick()

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -89,6 +89,11 @@ def skipupdate(*, projectdir: Optional[Path] = None) -> None:
     if projectdir is None:
         projectdir = Path.cwd()
 
+    skipupdate2(projectdir)
+
+
+def skipupdate2(projectdir: Path) -> None:
+    """Skip an update with conflicts."""
     repository = Repository.open(projectdir)
     repository.resetcherrypick()
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -70,14 +70,6 @@ def _commitmessage(template: Template) -> str:
         return f"Update {template.name}"
 
 
-def continueupdate(*, projectdir: Optional[Path] = None) -> None:
-    """Continue an update after conflict resolution."""
-    if projectdir is None:
-        projectdir = Path.cwd()
-
-    continueupdate2(projectdir)
-
-
 def continueupdate2(projectdir: Path) -> None:
     """Continue an update after conflict resolution."""
     repository = Repository.open(projectdir)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -84,14 +84,6 @@ def continueupdate(projectdir: Path) -> None:
     repository.heads[LATEST_BRANCH] = repository.heads[UPDATE_BRANCH]
 
 
-def skipupdate(*, projectdir: Optional[Path] = None) -> None:
-    """Skip an update with conflicts."""
-    if projectdir is None:
-        projectdir = Path.cwd()
-
-    skipupdate2(projectdir)
-
-
 def skipupdate2(projectdir: Path) -> None:
     """Skip an update with conflicts."""
     repository = Repository.open(projectdir)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -26,6 +26,24 @@ def update(
     if projectdir is None:
         projectdir = Path.cwd()
 
+    update2(
+        projectdir,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        directory=directory,
+    )
+
+
+def update2(
+    projectdir: Path,
+    *,
+    extrabindings: Sequence[Binding] = (),
+    no_input: bool = False,
+    checkout: Optional[str] = None,
+    directory: Optional[PurePosixPath] = None,
+) -> None:
+    """Update a project with changes from its Cookiecutter template."""
     projectconfig = readprojectconfigfile(projectdir)
     extrabindings = list(projectconfig.bindings) + list(extrabindings)
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -6,7 +6,7 @@ from pathlib import PurePosixPath
 from typing import Optional
 
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.create import create2
+from cutty.services.create import create
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
@@ -30,7 +30,7 @@ def update(
         directory = projectconfig.directory
 
     def createproject(outputdir: Path) -> Template:
-        _, template = create2(
+        _, template = create(
             projectconfig.template,
             outputdir,
             outputdirisproject=True,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -70,7 +70,7 @@ def _commitmessage(template: Template) -> str:
         return f"Update {template.name}"
 
 
-def continueupdate2(projectdir: Path) -> None:
+def continueupdate(projectdir: Path) -> None:
     """Continue an update after conflict resolution."""
     repository = Repository.open(projectdir)
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -84,7 +84,7 @@ def continueupdate(projectdir: Path) -> None:
     repository.heads[LATEST_BRANCH] = repository.heads[UPDATE_BRANCH]
 
 
-def skipupdate2(projectdir: Path) -> None:
+def skipupdate(projectdir: Path) -> None:
     """Skip an update with conflicts."""
     repository = Repository.open(projectdir)
     repository.resetcherrypick()

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -57,6 +57,16 @@ def test_cutty_json_already_exists(runcutty: RunCutty, template: Path) -> None:
         runcutty("create", str(template))
 
 
+def test_output_dir(runcutty: RunCutty, template: Path) -> None:
+    """It creates the project directory in the output directory."""
+    outputdir = Path("output")
+    outputdir.mkdir()
+
+    runcutty("create", f"--output-dir={outputdir}", str(template))
+
+    assert template_files(template) == project_files(outputdir / "example") - EXTRA
+
+
 def test_inplace(runcutty: RunCutty, template: Path) -> None:
     """It generates the project files in the current directory."""
     runcutty("create", "--no-input", "--in-place", str(template))

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -9,13 +9,12 @@ from cutty.filesystems.domain.path import Path as VirtualPath
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
-from cutty.services.update import abortupdate
+from cutty.services.update import abortupdate2
 from cutty.services.update import continueupdate
 from cutty.services.update import CreateProject
 from cutty.services.update import skipupdate
 from cutty.services.update import updateproject
 from cutty.util.git import Repository
-from tests.util.files import chdir
 from tests.util.git import createbranches
 from tests.util.git import resolveconflicts
 from tests.util.git import Side
@@ -113,8 +112,7 @@ def test_abortupdate_rewinds_update_branch(repository: Repository, path: Path) -
 
     latesthead = repository.heads[LATEST_BRANCH]
 
-    with chdir(repository.path):
-        abortupdate()
+    abortupdate2(repository.path)
 
     assert (
         repository.heads[LATEST_BRANCH] == latesthead == repository.heads[UPDATE_BRANCH]

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -10,7 +10,7 @@ from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
 from cutty.services.update import abortupdate
-from cutty.services.update import continueupdate2
+from cutty.services.update import continueupdate
 from cutty.services.update import CreateProject
 from cutty.services.update import skipupdate
 from cutty.services.update import updateproject
@@ -47,7 +47,7 @@ def test_continueupdate_commits_changes(repository: Repository, path: Path) -> N
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository.path, path, Side.THEIRS)
 
-    continueupdate2(repository.path)
+    continueupdate(repository.path)
 
     blob = repository.head.commit.tree / path.name
     assert blob.data == b"b"
@@ -58,7 +58,7 @@ def test_continueupdate_preserves_metainfo(repository: Repository, path: Path) -
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository.path, path, Side.THEIRS)
 
-    continueupdate2(repository.path)
+    continueupdate(repository.path)
 
     assert repository.heads[UPDATE_BRANCH].message == repository.head.commit.message
 
@@ -68,7 +68,7 @@ def test_continueupdate_fastforwards_latest(repository: Repository, path: Path) 
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository.path, path, Side.THEIRS)
 
-    continueupdate2(repository.path)
+    continueupdate(repository.path)
 
     assert repository.heads[LATEST_BRANCH] == repository.heads[UPDATE_BRANCH]
 
@@ -81,7 +81,7 @@ def test_continueupdate_works_after_commit(repository: Repository, path: Path) -
     # The user invokes `git cherry-pick --continue` before `cutty update --continue`.
     repository.commit()
 
-    continueupdate2(repository.path)
+    continueupdate(repository.path)
 
     assert repository.heads[LATEST_BRANCH] == repository.heads[UPDATE_BRANCH]
 
@@ -91,7 +91,7 @@ def test_continueupdate_state_cleanup(repository: Repository, path: Path) -> Non
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository.path, path, Side.THEIRS)
 
-    continueupdate2(repository.path)
+    continueupdate(repository.path)
 
     assert repository.cherrypickhead is None
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -12,7 +12,7 @@ from cutty.services.git import UPDATE_BRANCH
 from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import CreateProject
-from cutty.services.update import skipupdate
+from cutty.services.update import skipupdate2
 from cutty.services.update import updateproject
 from cutty.util.git import Repository
 from tests.util.files import chdir
@@ -102,8 +102,7 @@ def test_skipupdate_fastforwards_latest(repository: Repository, path: Path) -> N
 
     updatehead = repository.heads[UPDATE_BRANCH]
 
-    with chdir(repository.path):
-        skipupdate()
+    skipupdate2(repository.path)
 
     assert repository.heads[LATEST_BRANCH] == updatehead
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -12,7 +12,7 @@ from cutty.services.git import UPDATE_BRANCH
 from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import CreateProject
-from cutty.services.update import skipupdate2
+from cutty.services.update import skipupdate
 from cutty.services.update import updateproject
 from cutty.util.git import Repository
 from tests.util.files import chdir
@@ -102,7 +102,7 @@ def test_skipupdate_fastforwards_latest(repository: Repository, path: Path) -> N
 
     updatehead = repository.heads[UPDATE_BRANCH]
 
-    skipupdate2(repository.path)
+    skipupdate(repository.path)
 
     assert repository.heads[LATEST_BRANCH] == updatehead
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -10,7 +10,7 @@ from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
 from cutty.services.update import abortupdate
-from cutty.services.update import continueupdate
+from cutty.services.update import continueupdate2
 from cutty.services.update import CreateProject
 from cutty.services.update import skipupdate
 from cutty.services.update import updateproject
@@ -47,8 +47,7 @@ def test_continueupdate_commits_changes(repository: Repository, path: Path) -> N
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository.path, path, Side.THEIRS)
 
-    with chdir(repository.path):
-        continueupdate()
+    continueupdate2(repository.path)
 
     blob = repository.head.commit.tree / path.name
     assert blob.data == b"b"
@@ -59,8 +58,7 @@ def test_continueupdate_preserves_metainfo(repository: Repository, path: Path) -
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository.path, path, Side.THEIRS)
 
-    with chdir(repository.path):
-        continueupdate()
+    continueupdate2(repository.path)
 
     assert repository.heads[UPDATE_BRANCH].message == repository.head.commit.message
 
@@ -70,8 +68,7 @@ def test_continueupdate_fastforwards_latest(repository: Repository, path: Path) 
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository.path, path, Side.THEIRS)
 
-    with chdir(repository.path):
-        continueupdate()
+    continueupdate2(repository.path)
 
     assert repository.heads[LATEST_BRANCH] == repository.heads[UPDATE_BRANCH]
 
@@ -84,8 +81,7 @@ def test_continueupdate_works_after_commit(repository: Repository, path: Path) -
     # The user invokes `git cherry-pick --continue` before `cutty update --continue`.
     repository.commit()
 
-    with chdir(repository.path):
-        continueupdate()
+    continueupdate2(repository.path)
 
     assert repository.heads[LATEST_BRANCH] == repository.heads[UPDATE_BRANCH]
 
@@ -95,8 +91,7 @@ def test_continueupdate_state_cleanup(repository: Repository, path: Path) -> Non
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository.path, path, Side.THEIRS)
 
-    with chdir(repository.path):
-        continueupdate()
+    continueupdate2(repository.path)
 
     assert repository.cherrypickhead is None
 

--- a/tests/unit/services/test_update.py
+++ b/tests/unit/services/test_update.py
@@ -9,7 +9,7 @@ from cutty.filesystems.domain.path import Path as VirtualPath
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.git import LATEST_BRANCH
 from cutty.services.git import UPDATE_BRANCH
-from cutty.services.update import abortupdate2
+from cutty.services.update import abortupdate
 from cutty.services.update import continueupdate
 from cutty.services.update import CreateProject
 from cutty.services.update import skipupdate
@@ -112,7 +112,7 @@ def test_abortupdate_rewinds_update_branch(repository: Repository, path: Path) -
 
     latesthead = repository.heads[LATEST_BRANCH]
 
-    abortupdate2(repository.path)
+    abortupdate(repository.path)
 
     assert (
         repository.heads[LATEST_BRANCH] == latesthead == repository.heads[UPDATE_BRANCH]


### PR DESCRIPTION
- 🔨 [services] Extract function `update2` with required `projectdir`
- 🔨 [services] Inline function `update`
- 🔨 [services] Rename function `update2` to `update`
- 🔨 [services] Extract function `continueupdate2` with required `projectdir`
- 🔨 [services] Inline function `continueupdate`
- 🔨 [services] Rename function `continueupdate2` to `continueupdate`
- 🔨 [services] Extract function `skipupdate2` with required `projectdir`
- 🔨 [services] Inline function `skipupdate`
- 🔨 [services] Rename function `skipupdate2` to `skipupdate`
- 🔨 [services] Extract function `abortupdate2` with required `projectdir`
- 🔨 [services] Inline function `abortupdate`
- 🔨 [services] Rename function `abortupdate2` to `abortupdate`
- 🔨 [entrypoints] Slide assignment of `cwd`
- 🔨 [entrypoints] Slide arguments in `update` call
- 🔨 [services] Rename variable `repository` to `project`
- 🔨 [services] Extract function `create2` with required `outputdir`
- 🔨 [services] Inline function `create`
- 🔨 [services] Rename function `create2` to `create`
- ✅ [functional] Add test for `cutty create --output-dir=<directory>`
- 🔨 [services] Extract function `link2` with required `projectdir`
- 🔨 [services] Inline function `link`
- 🔨 [services] Rename function `link2` to `link`
