### PR TITLE
🔨 [services] Consolidate git operations in `link` service

### DIFF
--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -117,9 +117,7 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
         except pygit2.GitError:
             repository = Repository.init(worktree)
 
-        message = _commitmessage(template, latest is not None)
-
-        repository.commit(message=message)
+        repository.commit(message=_commitmessage(template, latest is not None))
         repository.heads.setdefault(LATEST_BRANCH, repository.head.commit)
 
     if latest is None:

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -112,7 +112,6 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
 
         repository = Repository.open(worktree)
         repository.commit(message=_commitmessage(template, latest is not None))
-        repository.heads.setdefault(LATEST_BRANCH, repository.head.commit)
 
     if latest is None:
         # Squash the empty initial commit.

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -109,8 +109,8 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
         update = _create_orphan_branch(project, UPDATE_BRANCH)
 
     with project.worktree(update, checkout=False) as worktree:
-        template2 = createproject(worktree)
-        creategitrepository(worktree, template2.name, template2.revision)
+        template = createproject(worktree)
+        creategitrepository(worktree, template.name, template.revision)
 
     if latest is None:
         # Squash the empty initial commit.

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -104,9 +104,7 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
     with project.worktree(update, checkout=False) as worktree:
         template = createproject(worktree)
         Repository.open(worktree).commit(
-            message=_commitmessage(
-                template, "update" if latest is not None else "import"
-            )
+            message=_commitmessage(template, action="update" if latest else "import")
         )
 
     if latest is None:

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -117,11 +117,9 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
         except pygit2.GitError:
             repository = Repository.init(worktree)
 
-        update2 = LATEST_BRANCH in repository.heads
-
-        if update2 and template.revision:
+        if latest and template.revision:
             message = f"Update {template.name} to {template.revision}"
-        elif update2:
+        elif latest:
             message = f"Update {template.name}"
         elif template.revision:
             message = f"Initial import from {template.name} {template.revision}"

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -78,13 +78,6 @@ def link(
     if template is None:
         raise TemplateNotSpecifiedError()
 
-    if latest := project.heads.get(LATEST_BRANCH):
-        update = project.heads.create(UPDATE_BRANCH, latest, force=True)
-    else:
-        # Unborn branches cannot have worktrees. Create an orphan branch with an
-        # empty placeholder commit instead. We'll squash it after project creation.
-        update = _create_orphan_branch(project, UPDATE_BRANCH)
-
     def createproject(outputdir: pathlib.Path) -> Template:
         assert template is not None  # noqa: S101
 
@@ -98,6 +91,13 @@ def link(
             directory=directory,
         )
         return template2
+
+    if latest := project.heads.get(LATEST_BRANCH):
+        update = project.heads.create(UPDATE_BRANCH, latest, force=True)
+    else:
+        # Unborn branches cannot have worktrees. Create an orphan branch with an
+        # empty placeholder commit instead. We'll squash it after project creation.
+        update = _create_orphan_branch(project, UPDATE_BRANCH)
 
     with project.worktree(update, checkout=False) as worktree:
         template2 = createproject(worktree)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -85,7 +85,7 @@ def link(
         update = _create_orphan_branch(project, UPDATE_BRANCH)
 
     with project.worktree(update, checkout=False) as worktree:
-        project_dir, template2 = create(
+        _, template2 = create(
             template,
             worktree,
             outputdirisproject=True,
@@ -94,7 +94,7 @@ def link(
             checkout=checkout,
             directory=directory,
         )
-        creategitrepository(project_dir, template2.name, template2.revision)
+        creategitrepository(worktree, template2.name, template2.revision)
 
     if latest is None:
         # Squash the empty initial commit.

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -125,19 +125,22 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
 
 
 def _commitmessage(template: Template, action: str) -> str:
-    if action == "link" and template.revision:
-        return f"Link to {template.name} {template.revision}"
-
     if action == "link":
-        return f"Link to {template.name}"
-
-    if action == "update" and template.revision:
-        return f"Update {template.name} to {template.revision}"
+        return (
+            f"Link to {template.name} {template.revision}"
+            if template.revision
+            else f"Link to {template.name}"
+        )
 
     if action == "update":
-        return f"Update {template.name}"
+        return (
+            f"Update {template.name} to {template.revision}"
+            if template.revision
+            else f"Update {template.name}"
+        )
 
-    if template.revision:
-        return f"Initial import from {template.name} {template.revision}"
-
-    return f"Initial import from {template.name}"
+    return (
+        f"Initial import from {template.name} {template.revision}"
+        if template.revision
+        else f"Initial import from {template.name}"
+    )

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -1,6 +1,7 @@
 """Link a project to a Cookiecutter template."""
 import contextlib
 import pathlib
+from collections.abc import Callable
 from collections.abc import Sequence
 from typing import Optional
 
@@ -55,6 +56,9 @@ def _transform_commit_message(message: str) -> str:
     return message.replace("Initial import from ", "Link to ")
 
 
+CreateProject = Callable[[pathlib.Path], Template]
+
+
 def link(
     template: Optional[str],
     projectdir: pathlib.Path,
@@ -92,6 +96,11 @@ def link(
         )
         return template2
 
+    linkproject(project, createproject)
+
+
+def linkproject(project: Repository, createproject: CreateProject) -> None:
+    """Link a project to a Cookiecutter template."""
     if latest := project.heads.get(LATEST_BRANCH):
         update = project.heads.create(UPDATE_BRANCH, latest, force=True)
     else:

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -117,14 +117,7 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
         except pygit2.GitError:
             repository = Repository.init(worktree)
 
-        if latest and template.revision:
-            message = f"Update {template.name} to {template.revision}"
-        elif latest:
-            message = f"Update {template.name}"
-        elif template.revision:
-            message = f"Initial import from {template.name} {template.revision}"
-        else:
-            message = f"Initial import from {template.name}"
+        message = _commitmessage(template, latest is not None)
 
         repository.commit(message=message)
         repository.heads.setdefault(LATEST_BRANCH, repository.head.commit)
@@ -145,3 +138,15 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
     )
 
     project.heads[LATEST_BRANCH] = update.commit
+
+
+def _commitmessage(template: Template, latest: bool) -> str:
+    if latest and template.revision:
+        message = f"Update {template.name} to {template.revision}"
+    elif latest:
+        message = f"Update {template.name}"
+    elif template.revision:
+        message = f"Initial import from {template.name} {template.revision}"
+    else:
+        message = f"Initial import from {template.name}"
+    return message

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -117,7 +117,7 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
         (update.commit.tree / PROJECT_CONFIG_FILE).data
     )
 
-    message = _transform_commit_message(update.commit.message)
+    message = _commitmessage(template, action="link")
     project.commit(
         message=message,
         author=update.commit.author,
@@ -127,13 +127,13 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
     project.heads[LATEST_BRANCH] = update.commit
 
 
-def _transform_commit_message(message: str) -> str:
-    if message.startswith("Update"):
-        return message.replace(" to ", " ").replace("Update ", "Link to ")
-    return message.replace("Initial import from ", "Link to ")
-
-
 def _commitmessage(template: Template, action: str) -> str:
+    if action == "link" and template.revision:
+        return f"Link to {template.name} {template.revision}"
+
+    if action == "link":
+        return f"Link to {template.name}"
+
     if action == "update" and template.revision:
         return f"Update {template.name} to {template.revision}"
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -117,9 +117,8 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
         (update.commit.tree / PROJECT_CONFIG_FILE).data
     )
 
-    message = _commitmessage(template, action="link")
     project.commit(
-        message=message,
+        message=_commitmessage(template, action="link"),
         author=update.commit.author,
         committer=project.default_signature,
     )

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -110,7 +110,9 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
     with project.worktree(update, checkout=False) as worktree:
         template = createproject(worktree)
         Repository.open(worktree).commit(
-            message=_commitmessage(template, latest is not None)
+            message=_commitmessage(
+                template, "update" if latest is not None else "import"
+            )
         )
 
     if latest is None:
@@ -131,11 +133,11 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
     project.heads[LATEST_BRANCH] = update.commit
 
 
-def _commitmessage(template: Template, latest: bool) -> str:
-    if latest and template.revision:
+def _commitmessage(template: Template, action: str) -> str:
+    if action == "update" and template.revision:
         return f"Update {template.name} to {template.revision}"
 
-    if latest:
+    if action == "update":
         return f"Update {template.name}"
 
     if template.revision:

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -109,9 +109,9 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
 
     with project.worktree(update, checkout=False) as worktree:
         template = createproject(worktree)
-
-        repository = Repository.open(worktree)
-        repository.commit(message=_commitmessage(template, latest is not None))
+        Repository.open(worktree).commit(
+            message=_commitmessage(template, latest is not None)
+        )
 
     if latest is None:
         # Squash the empty initial commit.

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -117,12 +117,6 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
         except pygit2.GitError:
             repository = Repository.init(worktree)
 
-        if UPDATE_BRANCH in repository.heads:
-            # HEAD must point to update branch if it exists.
-            head = repository.head.name
-            if head != UPDATE_BRANCH:
-                raise RuntimeError(f"unexpected HEAD: {head}")
-
         update2 = LATEST_BRANCH in repository.heads
 
         if update2 and template.revision:

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -49,12 +49,6 @@ def _squash_branch(repository: Repository, branch: Branch) -> None:
     )
 
 
-def _transform_commit_message(message: str) -> str:
-    if message.startswith("Update"):
-        return message.replace(" to ", " ").replace("Update ", "Link to ")
-    return message.replace("Initial import from ", "Link to ")
-
-
 CreateProject = Callable[[pathlib.Path], Template]
 
 
@@ -131,6 +125,12 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
     )
 
     project.heads[LATEST_BRANCH] = update.commit
+
+
+def _transform_commit_message(message: str) -> str:
+    if message.startswith("Update"):
+        return message.replace(" to ", " ").replace("Update ", "Link to ")
+    return message.replace("Initial import from ", "Link to ")
 
 
 def _commitmessage(template: Template, action: str) -> str:

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,8 +5,6 @@ from collections.abc import Callable
 from collections.abc import Sequence
 from typing import Optional
 
-import pygit2
-
 from cutty.errors import CuttyError
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.create import create
@@ -112,11 +110,7 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
     with project.worktree(update, checkout=False) as worktree:
         template = createproject(worktree)
 
-        try:
-            repository = Repository.open(worktree)
-        except pygit2.GitError:
-            repository = Repository.init(worktree)
-
+        repository = Repository.open(worktree)
         repository.commit(message=_commitmessage(template, latest is not None))
         repository.heads.setdefault(LATEST_BRANCH, repository.head.commit)
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -142,11 +142,12 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
 
 def _commitmessage(template: Template, latest: bool) -> str:
     if latest and template.revision:
-        message = f"Update {template.name} to {template.revision}"
-    elif latest:
-        message = f"Update {template.name}"
-    elif template.revision:
-        message = f"Initial import from {template.name} {template.revision}"
-    else:
-        message = f"Initial import from {template.name}"
-    return message
+        return f"Update {template.name} to {template.revision}"
+
+    if latest:
+        return f"Update {template.name}"
+
+    if template.revision:
+        return f"Initial import from {template.name} {template.revision}"
+
+    return f"Initial import from {template.name}"

--- a/tests/unit/services/test_link.py
+++ b/tests/unit/services/test_link.py
@@ -95,6 +95,17 @@ def test_linkproject_latest_branch(
     assert LATEST_BRANCH in project.heads
 
 
+def test_linkproject_latest_branch_commit_message(
+    project: Repository, createproject: CreateProject
+) -> None:
+    """It uses a commit message indicating an initial import."""
+    updatefile(project.path / "initial")
+
+    linkproject(project, createproject)
+
+    assert "initial" in project.heads[LATEST_BRANCH].message.lower()
+
+
 def test_linkproject_update_branch(
     project: Repository, createproject: CreateProject
 ) -> None:

--- a/tests/unit/services/test_link.py
+++ b/tests/unit/services/test_link.py
@@ -45,3 +45,12 @@ def test_linkproject_commit(project: Repository, createproject: CreateProject) -
     linkproject(project, createproject)
 
     assert [tip] == project.head.commit.parents
+
+
+def test_linkproject_commit_message(
+    project: Repository, createproject: CreateProject
+) -> None:
+    """It uses a commit message indicating the linkage."""
+    linkproject(project, createproject)
+
+    assert "link" in project.head.commit.message.lower()

--- a/tests/unit/services/test_link.py
+++ b/tests/unit/services/test_link.py
@@ -106,6 +106,19 @@ def test_linkproject_latest_branch_commit_message(
     assert "initial" in project.heads[LATEST_BRANCH].message.lower()
 
 
+def test_linkproject_latest_branch_commit_message_update(
+    project: Repository, createproject: CreateProject
+) -> None:
+    """It uses a commit message indicating an update if the branch exists."""
+    project.heads.create(LATEST_BRANCH)
+
+    updatefile(project.path / "initial")
+
+    linkproject(project, createproject)
+
+    assert "update" in project.heads[LATEST_BRANCH].message.lower()
+
+
 def test_linkproject_update_branch(
     project: Repository, createproject: CreateProject
 ) -> None:

--- a/tests/unit/services/test_link.py
+++ b/tests/unit/services/test_link.py
@@ -8,6 +8,7 @@ from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path as VirtualPath
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.git import LATEST_BRANCH
+from cutty.services.git import UPDATE_BRANCH
 from cutty.services.link import CreateProject
 from cutty.services.link import linkproject
 from cutty.util.git import Repository
@@ -92,3 +93,14 @@ def test_linkproject_latest_branch(
     linkproject(project, createproject)
 
     assert LATEST_BRANCH in project.heads
+
+
+def test_linkproject_update_branch(
+    project: Repository, createproject: CreateProject
+) -> None:
+    """It creates the update branch."""
+    updatefile(project.path / "initial")
+
+    linkproject(project, createproject)
+
+    assert UPDATE_BRANCH in project.heads

--- a/tests/unit/services/test_link.py
+++ b/tests/unit/services/test_link.py
@@ -54,3 +54,12 @@ def test_linkproject_commit_message(
     linkproject(project, createproject)
 
     assert "link" in project.head.commit.message.lower()
+
+
+def test_linkproject_commit_message_template(
+    project: Repository, createproject: CreateProject, template: Template
+) -> None:
+    """It includes the template name in the commit message."""
+    linkproject(project, createproject)
+
+    assert template.name in project.head.commit.message

--- a/tests/unit/services/test_link.py
+++ b/tests/unit/services/test_link.py
@@ -1,0 +1,47 @@
+"""Unit tests for cutty.services.link."""
+from pathlib import Path
+
+import pytest
+
+from cutty.filesystems.adapters.dict import DictFilesystem
+from cutty.filesystems.domain.path import Path as VirtualPath
+from cutty.repositories.domain.repository import Repository as Template
+from cutty.services.link import CreateProject
+from cutty.services.link import linkproject
+from cutty.util.git import Repository
+
+
+pytest_plugins = ["tests.fixtures.git"]
+
+
+@pytest.fixture
+def project(repository: Repository) -> Repository:
+    """Fixture for a project repository."""
+    return repository
+
+
+@pytest.fixture
+def template() -> Template:
+    """Fixture for a `Template` instance."""
+    templatepath = VirtualPath(filesystem=DictFilesystem({}))
+    return Template("template", templatepath, None)
+
+
+@pytest.fixture
+def createproject(template: Template) -> CreateProject:
+    """Fixture for a `createproject` function."""
+
+    def _(project: Path) -> Template:
+        (project / "cutty.json").touch()
+        return template
+
+    return _
+
+
+def test_linkproject_commit(project: Repository, createproject: CreateProject) -> None:
+    """It creates a commit on the current branch."""
+    tip = project.head.commit
+
+    linkproject(project, createproject)
+
+    assert [tip] == project.head.commit.parents

--- a/tests/unit/services/test_link.py
+++ b/tests/unit/services/test_link.py
@@ -1,4 +1,5 @@
 """Unit tests for cutty.services.link."""
+import dataclasses
 from pathlib import Path
 
 import pytest
@@ -63,3 +64,18 @@ def test_linkproject_commit_message_template(
     linkproject(project, createproject)
 
     assert template.name in project.head.commit.message
+
+
+def test_linkproject_commit_message_revision(
+    project: Repository, template: Template
+) -> None:
+    """It includes the template name in the commit message."""
+    template = dataclasses.replace(template, revision="1.0.0")
+
+    def createproject(project: Path) -> Template:
+        (project / "cutty.json").touch()
+        return template
+
+    linkproject(project, createproject)
+
+    assert template.revision in project.head.commit.message

--- a/tests/unit/services/test_link.py
+++ b/tests/unit/services/test_link.py
@@ -7,9 +7,11 @@ import pytest
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path as VirtualPath
 from cutty.repositories.domain.repository import Repository as Template
+from cutty.services.git import LATEST_BRANCH
 from cutty.services.link import CreateProject
 from cutty.services.link import linkproject
 from cutty.util.git import Repository
+from tests.util.git import updatefile
 
 
 pytest_plugins = ["tests.fixtures.git"]
@@ -79,3 +81,14 @@ def test_linkproject_commit_message_revision(
     linkproject(project, createproject)
 
     assert template.revision in project.head.commit.message
+
+
+def test_linkproject_latest_branch(
+    project: Repository, createproject: CreateProject
+) -> None:
+    """It creates the latest branch."""
+    updatefile(project.path / "initial")
+
+    linkproject(project, createproject)
+
+    assert LATEST_BRANCH in project.heads


### PR DESCRIPTION
- 🔨 [services] Inline variable `project_dir`
- 🔨 [services] Extract function `createproject`
- 🔨 [services] Slide definition of `createproject`
- 🔨 [services] Extract function `linkproject`
- 🔨 [services] Rename variable `template2` to `template`
- ✅ [services] Add test for `linkproject` creating a commit
- ✅ [services] Add test for `linkproject` commit message
- ✅ [services] Add test for `linkproject` commit message with template
- ✅ [services] Add test for `linkproject` commit message with revision
- ✅ [services] Add test for `linkproject` creating latest branch
- ✅ [services] Add test for `linkproject` creating update branch
- 🔨 [services] Inline function `creategitrepository` in `linkproject`
- 🔥 [services] Remove redundant HEAD check in `linkproject`
- ✅ [services] Add test for `linkproject` commit message on latest branch
- ✅ [services] Add test for `linkproject` commit message when latest branch exists
- 🔨 [services] Inline variable `update2`
- 🔨 [services] Extract function `_commitmessage`
- 🔨 [services] Replace nested conditional with guard clauses
- 🔨 [services] Inline variable `message`
- 🔥 [services] Remove dead code in `linkproject` creating a repository
- :fire: [services] Remove dead code in `linkproject` initializing latest branch
- 🔨 [services] Inline variable `repository`
- 🔨 [services] Replace flag `update` with `action` str in `_commitmessage`
- 🔨 [services] Slide definition of `_transform_commit_message`
- 🔨 [services] Replace `_transform_commit_message` with generalized `_commitmessage`
- 🔨 [services] Inline variable `message`
- 🔨 [link] Improve readability of `_commitmessage` call
- 🔨 [services] Use ternaries in `_commitmessage`
