### PR TITLE
🔨 [services] Separate template loading from project generation

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -7,7 +7,7 @@ import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.generate import generate
-from cutty.services.generate import loadtemplate
+from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
 

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,8 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.generate import generate
+from cutty.services.generate import generate2
+from cutty.services.generate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
 
@@ -70,13 +71,17 @@ def cookiecutter(
     if output_dir is None:
         output_dir = Path.cwd()
 
-    generate(
+    directory2 = PurePosixPath(directory) if directory is not None else None
+    template2 = loadtemplate(template, checkout, directory2)
+
+    generate2(
         template,
+        template2,
         output_dir,
         extrabindings=extrabindings,
         no_input=no_input,
         checkout=checkout,
-        directory=PurePosixPath(directory) if directory is not None else None,
+        directory=directory2,
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,
         outputdirisproject=False,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.generate import generate2
+from cutty.services.generate import generate
 from cutty.services.generate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
@@ -74,7 +74,7 @@ def cookiecutter(
     directory2 = PurePosixPath(directory) if directory is not None else None
     template2 = loadtemplate(template, checkout, directory2)
 
-    generate2(
+    generate(
         template,
         template2,
         output_dir,

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -25,7 +25,7 @@ def fileexistspolicy(
 
 def createcookiecutterstorage(
     outputdir: pathlib.Path,
-    project_dir: pathlib.Path,
+    projectdir: pathlib.Path,
     overwrite_if_exists: bool,
     skip_if_file_exists: bool,
     hookfiles: Sequence[File],
@@ -36,7 +36,7 @@ def createcookiecutterstorage(
 
     if hookfiles:  # pragma: no branch
         observer = CookiecutterHooksObserver(
-            hookfiles=hookfiles, project=project_dir, fileexists=fileexists
+            hookfiles=hookfiles, project=projectdir, fileexists=fileexists
         )
         storage = observe(storage, observer)
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -7,7 +7,7 @@ from cutty.projects.create import creategitrepository
 from cutty.services.generate import (  # noqa: F401
     EmptyTemplateError as EmptyTemplateError,
 )
-from cutty.services.generate import generate2
+from cutty.services.generate import generate
 from cutty.services.generate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
@@ -27,7 +27,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = loadtemplate(location, checkout, directory)
 
-    projectdir = generate2(
+    projectdir = generate(
         location,
         template,
         outputdir,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -7,7 +7,8 @@ from cutty.projects.create import creategitrepository
 from cutty.services.generate import (  # noqa: F401
     EmptyTemplateError as EmptyTemplateError,
 )
-from cutty.services.generate import generate
+from cutty.services.generate import generate2
+from cutty.services.generate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
 
@@ -24,8 +25,11 @@ def createproject(
     in_place: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
-    projectdir, template = generate(
+    template = loadtemplate(location, checkout, directory)
+
+    projectdir = generate2(
         location,
+        template,
         outputdir,
         extrabindings=extrabindings,
         no_input=no_input,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -8,7 +8,7 @@ from cutty.services.generate import (  # noqa: F401
     EmptyTemplateError as EmptyTemplateError,
 )
 from cutty.services.generate import generate
-from cutty.services.generate import loadtemplate
+from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
 

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -27,37 +27,6 @@ class EmptyTemplateError(CuttyError):
     """The template contains no project files."""
 
 
-def generate(
-    location: str,
-    outputdir: pathlib.Path,
-    *,
-    extrabindings: Sequence[Binding],
-    no_input: bool,
-    checkout: Optional[str],
-    directory: Optional[pathlib.PurePosixPath],
-    overwrite_if_exists: bool,
-    skip_if_file_exists: bool,
-    outputdirisproject: bool,
-    createconfigfile: bool,
-) -> tuple[pathlib.Path, Template]:
-    """Generate a project from a Cookiecutter template."""
-    template = loadtemplate(location, checkout, directory)
-    projectdir = generate2(
-        location,
-        template,
-        outputdir,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        checkout=checkout,
-        directory=directory,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
-        outputdirisproject=outputdirisproject,
-        createconfigfile=createconfigfile,
-    )
-    return projectdir, template
-
-
 def generate2(
     location: str,
     template: Template,

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -4,13 +4,11 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
-import platformdirs
 from lazysequence import lazysequence
 
 from cutty.errors import CuttyError
 from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterhooks
@@ -84,16 +82,3 @@ def generate(
             storage.add(projectfile)
 
     return project_dir
-
-
-def loadtemplate(
-    template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
-) -> Template:
-    """Load a template repository."""
-    cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
-    repositoryprovider = getdefaultrepositoryprovider(cachedir)
-    return repositoryprovider(
-        template,
-        revision=checkout,
-        directory=(PurePath(*directory.parts) if directory is not None else None),
-    )

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -27,7 +27,7 @@ class EmptyTemplateError(CuttyError):
     """The template contains no project files."""
 
 
-def generate2(
+def generate(
     location: str,
     template: Template,
     outputdir: pathlib.Path,

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -68,9 +68,9 @@ def generate(
         renderfiles(findcookiecutterhooks(template.path), render, bindings)
     )
 
-    project_dir = outputdir if outputdirisproject else outputdir / projectname
+    projectdir = outputdir if outputdirisproject else outputdir / projectname
     storage = createcookiecutterstorage(
-        outputdir, project_dir, overwrite_if_exists, skip_if_file_exists, hookfiles
+        outputdir, projectdir, overwrite_if_exists, skip_if_file_exists, hookfiles
     )
 
     with storage:
@@ -81,4 +81,4 @@ def generate(
 
             storage.add(projectfile)
 
-    return project_dir
+    return projectdir

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -42,6 +42,37 @@ def generate(
 ) -> tuple[pathlib.Path, Template]:
     """Generate a project from a Cookiecutter template."""
     template = loadtemplate(location, checkout, directory)
+    projectdir = generate2(
+        location,
+        template,
+        outputdir,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        directory=directory,
+        overwrite_if_exists=overwrite_if_exists,
+        skip_if_file_exists=skip_if_file_exists,
+        outputdirisproject=outputdirisproject,
+        createconfigfile=createconfigfile,
+    )
+    return projectdir, template
+
+
+def generate2(
+    location: str,
+    template: Template,
+    outputdir: pathlib.Path,
+    *,
+    extrabindings: Sequence[Binding],
+    no_input: bool,
+    checkout: Optional[str],
+    directory: Optional[pathlib.PurePosixPath],
+    overwrite_if_exists: bool,
+    skip_if_file_exists: bool,
+    outputdirisproject: bool,
+    createconfigfile: bool,
+) -> pathlib.Path:
+    """Generate a project from a Cookiecutter template."""
     config = loadcookiecutterconfig(location, template.path)
     render = createcookiecutterrenderer(template.path, config)
     bindings = bindcookiecuttervariables(
@@ -83,7 +114,7 @@ def generate(
 
             storage.add(projectfile)
 
-    return project_dir, template
+    return project_dir
 
 
 def loadtemplate(

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -8,7 +8,7 @@ from cutty.errors import CuttyError
 from cutty.projects.link import linkproject
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.generate import generate
-from cutty.services.generate import loadtemplate
+from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -7,7 +7,8 @@ from typing import Optional
 from cutty.errors import CuttyError
 from cutty.projects.link import linkproject
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.generate import generate
+from cutty.services.generate import generate2
+from cutty.services.generate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
@@ -43,8 +44,10 @@ def link(
     def createproject(outputdir: pathlib.Path) -> Template:
         assert template is not None  # noqa: S101
 
-        _, template2 = generate(
+        template2 = loadtemplate(template, checkout, directory)
+        generate2(
             template,
+            template2,
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -41,10 +41,11 @@ def link(
     if template is None:
         raise TemplateNotSpecifiedError()
 
+    template2 = loadtemplate(template, checkout, directory)
+
     def createproject(outputdir: pathlib.Path) -> Template:
         assert template is not None  # noqa: S101
 
-        template2 = loadtemplate(template, checkout, directory)
         generate(
             template,
             template2,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -7,7 +7,7 @@ from typing import Optional
 from cutty.errors import CuttyError
 from cutty.projects.link import linkproject
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.generate import generate2
+from cutty.services.generate import generate
 from cutty.services.generate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
@@ -45,7 +45,7 @@ def link(
         assert template is not None  # noqa: S101
 
         template2 = loadtemplate(template, checkout, directory)
-        generate2(
+        generate(
             template,
             template2,
             outputdir,

--- a/src/cutty/services/loadtemplate.py
+++ b/src/cutty/services/loadtemplate.py
@@ -1,0 +1,22 @@
+"""Loading templates."""
+import pathlib
+from typing import Optional
+
+import platformdirs
+
+from cutty.filesystems.domain.purepath import PurePath
+from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
+from cutty.repositories.domain.repository import Repository as Template
+
+
+def loadtemplate(
+    template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
+) -> Template:
+    """Load a template repository."""
+    cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
+    repositoryprovider = getdefaultrepositoryprovider(cachedir)
+    return repositoryprovider(
+        template,
+        revision=checkout,
+        directory=(PurePath(*directory.parts) if directory is not None else None),
+    )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from cutty.projects.update import updateproject
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.generate import generate2
+from cutty.services.generate import generate
 from cutty.services.generate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
@@ -29,7 +29,7 @@ def update(
 
     def createproject(outputdir: Path) -> Template:
         template = loadtemplate(projectconfig.template, checkout, directory)
-        generate2(
+        generate(
             projectconfig.template,
             template,
             outputdir,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -7,7 +7,7 @@ from typing import Optional
 from cutty.projects.update import updateproject
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.generate import generate
-from cutty.services.generate import loadtemplate
+from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -6,7 +6,8 @@ from typing import Optional
 
 from cutty.projects.update import updateproject
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.generate import generate
+from cutty.services.generate import generate2
+from cutty.services.generate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
@@ -27,8 +28,10 @@ def update(
         directory = projectconfig.directory
 
     def createproject(outputdir: Path) -> Template:
-        _, template = generate(
+        template = loadtemplate(projectconfig.template, checkout, directory)
+        generate2(
             projectconfig.template,
+            template,
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -27,8 +27,9 @@ def update(
     if directory is None:
         directory = projectconfig.directory
 
+    template = loadtemplate(projectconfig.template, checkout, directory)
+
     def createproject(outputdir: Path) -> Template:
-        template = loadtemplate(projectconfig.template, checkout, directory)
         generate(
             projectconfig.template,
             template,


### PR DESCRIPTION
- 🔨 [services] Extract function `generate2` without template loading
- 🔨 [services] Inline function `generate`
- 🔨 [services] Rename function `generate2` to `generate`
- 🔨 [services] Invoke `loadtemplate` before `updateproject`
- 🔨 [services] Invoke `loadtemplate` before `linkproject`
- 🔨 [services] Move function `loadtemplate` from `generate` to `loadtemplate`
- 🔨 [services] Rename variable `project_dir` to `projectdir`
- 🔨 [filestorage] Rename parameter `project_dir` to `projectdir`
