### PR TITLE
🔨 [services] Return `Template` from `loadtemplate` combining `Repository` with the function arguments

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -72,10 +72,10 @@ def cookiecutter(
         output_dir = Path.cwd()
 
     directory2 = PurePosixPath(directory) if directory is not None else None
-    template2 = loadtemplate(location, checkout, directory2)
+    template = loadtemplate(location, checkout, directory2)
 
     generate(
-        template2,
+        template,
         output_dir,
         extrabindings=extrabindings,
         no_input=no_input,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.generate import generate2
+from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
@@ -74,7 +74,7 @@ def cookiecutter(
     directory2 = PurePosixPath(directory) if directory is not None else None
     template2 = loadtemplate(template, checkout, directory2)
 
-    generate2(
+    generate(
         template2,
         output_dir,
         extrabindings=extrabindings,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -79,7 +79,6 @@ def cookiecutter(
         output_dir,
         extrabindings=extrabindings,
         no_input=no_input,
-        checkout=checkout,
         directory=directory2,
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -7,7 +7,7 @@ import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.generate import generate
-from cutty.services.loadtemplate import loadtemplate
+from cutty.services.loadtemplate import loadtemplate2
 from cutty.templates.domain.bindings import Binding
 
 
@@ -72,11 +72,11 @@ def cookiecutter(
         output_dir = Path.cwd()
 
     directory2 = PurePosixPath(directory) if directory is not None else None
-    template2 = loadtemplate(template, checkout, directory2)
+    template2 = loadtemplate2(template, checkout, directory2)
 
     generate(
         template,
-        template2,
+        template2.repository,
         output_dir,
         extrabindings=extrabindings,
         no_input=no_input,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -11,7 +11,7 @@ from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
 
-@click.argument("template")
+@click.argument("location", metavar="TEMPLATE")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
     "--no-input",
@@ -56,7 +56,7 @@ from cutty.templates.domain.bindings import Binding
     help="Skip the files in the corresponding directories if they already exist.",
 )
 def cookiecutter(
-    template: str,
+    location: str,
     extra_context: dict[str, str],
     no_input: bool,
     checkout: Optional[str],
@@ -72,7 +72,7 @@ def cookiecutter(
         output_dir = Path.cwd()
 
     directory2 = PurePosixPath(directory) if directory is not None else None
-    template2 = loadtemplate(template, checkout, directory2)
+    template2 = loadtemplate(location, checkout, directory2)
 
     generate(
         template2,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.generate import generate
+from cutty.services.generate import generate2
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
@@ -74,9 +74,8 @@ def cookiecutter(
     directory2 = PurePosixPath(directory) if directory is not None else None
     template2 = loadtemplate(template, checkout, directory2)
 
-    generate(
-        template,
-        template2.repository,
+    generate2(
+        template2,
         output_dir,
         extrabindings=extrabindings,
         no_input=no_input,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -7,7 +7,7 @@ import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.services.generate import generate
-from cutty.services.loadtemplate import loadtemplate2
+from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
 
@@ -72,7 +72,7 @@ def cookiecutter(
         output_dir = Path.cwd()
 
     directory2 = PurePosixPath(directory) if directory is not None else None
-    template2 = loadtemplate2(template, checkout, directory2)
+    template2 = loadtemplate(template, checkout, directory2)
 
     generate(
         template,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -79,7 +79,6 @@ def cookiecutter(
         output_dir,
         extrabindings=extrabindings,
         no_input=no_input,
-        directory=directory2,
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,
         outputdirisproject=False,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -8,7 +8,7 @@ from cutty.services.generate import (  # noqa: F401
     EmptyTemplateError as EmptyTemplateError,
 )
 from cutty.services.generate import generate
-from cutty.services.loadtemplate import loadtemplate
+from cutty.services.loadtemplate import loadtemplate2
 from cutty.templates.domain.bindings import Binding
 
 
@@ -25,11 +25,11 @@ def createproject(
     in_place: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
-    template = loadtemplate(location, checkout, directory)
+    template = loadtemplate2(location, checkout, directory)
 
     projectdir = generate(
         location,
-        template,
+        template.repository,
         outputdir,
         extrabindings=extrabindings,
         no_input=no_input,
@@ -41,4 +41,4 @@ def createproject(
         createconfigfile=True,
     )
 
-    creategitrepository(projectdir, template)
+    creategitrepository(projectdir, template.repository)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -7,7 +7,7 @@ from cutty.projects.create import creategitrepository
 from cutty.services.generate import (  # noqa: F401
     EmptyTemplateError as EmptyTemplateError,
 )
-from cutty.services.generate import generate
+from cutty.services.generate import generate2
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
@@ -27,9 +27,8 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = loadtemplate(location, checkout, directory)
 
-    projectdir = generate(
-        location,
-        template.repository,
+    projectdir = generate2(
+        template,
         outputdir,
         extrabindings=extrabindings,
         no_input=no_input,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -7,7 +7,7 @@ from cutty.projects.create import creategitrepository
 from cutty.services.generate import (  # noqa: F401
     EmptyTemplateError as EmptyTemplateError,
 )
-from cutty.services.generate import generate2
+from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
@@ -27,7 +27,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = loadtemplate(location, checkout, directory)
 
-    projectdir = generate2(
+    projectdir = generate(
         template,
         outputdir,
         extrabindings=extrabindings,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -32,7 +32,6 @@ def createproject(
         outputdir,
         extrabindings=extrabindings,
         no_input=no_input,
-        checkout=checkout,
         directory=directory,
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -32,7 +32,6 @@ def createproject(
         outputdir,
         extrabindings=extrabindings,
         no_input=no_input,
-        directory=directory,
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,
         outputdirisproject=in_place,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -8,7 +8,7 @@ from cutty.services.generate import (  # noqa: F401
     EmptyTemplateError as EmptyTemplateError,
 )
 from cutty.services.generate import generate
-from cutty.services.loadtemplate import loadtemplate2
+from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
 
 
@@ -25,7 +25,7 @@ def createproject(
     in_place: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
-    template = loadtemplate2(location, checkout, directory)
+    template = loadtemplate(location, checkout, directory)
 
     projectdir = generate(
         location,

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -2,7 +2,6 @@
 import itertools
 import pathlib
 from collections.abc import Sequence
-from typing import Optional
 
 from lazysequence import lazysequence
 
@@ -31,7 +30,6 @@ def generate(
     *,
     extrabindings: Sequence[Binding],
     no_input: bool,
-    directory: Optional[pathlib.PurePosixPath],
     overwrite_if_exists: bool,
     skip_if_file_exists: bool,
     outputdirisproject: bool,
@@ -48,7 +46,7 @@ def generate(
     )
 
     projectconfig = ProjectConfig(
-        template.metadata.location, bindings, directory=directory
+        template.metadata.location, bindings, directory=template.metadata.directory
     )
     projectfiles = lazysequence(
         renderfiles(findcookiecutterpaths(template.root, config), render, bindings)

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -39,10 +39,8 @@ def generate(
     createconfigfile: bool,
 ) -> pathlib.Path:
     """Generate a project from a project template."""
-    config = loadcookiecutterconfig(
-        template.metadata.location, template.repository.path
-    )
-    render = createcookiecutterrenderer(template.repository.path, config)
+    config = loadcookiecutterconfig(template.metadata.location, template.root)
+    render = createcookiecutterrenderer(template.root, config)
     bindings = bindcookiecuttervariables(
         config.variables,
         render,
@@ -54,9 +52,7 @@ def generate(
         template.metadata.location, bindings, directory=directory
     )
     projectfiles = lazysequence(
-        renderfiles(
-            findcookiecutterpaths(template.repository.path, config), render, bindings
-        )
+        renderfiles(findcookiecutterpaths(template.root, config), render, bindings)
     )
     if not projectfiles:
         raise EmptyTemplateError()
@@ -70,7 +66,7 @@ def generate(
         projectfiles2 = itertools.chain(projectfiles2, [projectconfigfile])
 
     hookfiles = lazysequence(
-        renderfiles(findcookiecutterhooks(template.repository.path), render, bindings)
+        renderfiles(findcookiecutterhooks(template.root), render, bindings)
     )
 
     projectdir = outputdir if outputdirisproject else outputdir / projectname

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -10,6 +10,7 @@ from cutty.errors import CuttyError
 from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.domain.repository import Repository as Template
+from cutty.services.loadtemplate import Template as Template2
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterhooks
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterpaths
@@ -23,6 +24,35 @@ from cutty.templates.domain.renderfiles import renderfiles
 
 class EmptyTemplateError(CuttyError):
     """The template contains no project files."""
+
+
+def generate2(
+    template: Template2,
+    outputdir: pathlib.Path,
+    *,
+    extrabindings: Sequence[Binding],
+    no_input: bool,
+    checkout: Optional[str],
+    directory: Optional[pathlib.PurePosixPath],
+    overwrite_if_exists: bool,
+    skip_if_file_exists: bool,
+    outputdirisproject: bool,
+    createconfigfile: bool,
+) -> pathlib.Path:
+    """Generate a project from a project template."""
+    return generate(
+        template.metadata.location,
+        template.repository,
+        outputdir,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        directory=directory,
+        overwrite_if_exists=overwrite_if_exists,
+        skip_if_file_exists=skip_if_file_exists,
+        outputdirisproject=outputdirisproject,
+        createconfigfile=createconfigfile,
+    )
 
 
 def generate(

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -31,7 +31,6 @@ def generate(
     *,
     extrabindings: Sequence[Binding],
     no_input: bool,
-    checkout: Optional[str],
     directory: Optional[pathlib.PurePosixPath],
     overwrite_if_exists: bool,
     skip_if_file_exists: bool,

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -25,7 +25,7 @@ class EmptyTemplateError(CuttyError):
     """The template contains no project files."""
 
 
-def generate2(
+def generate(
     template: Template2,
     outputdir: pathlib.Path,
     *,

--- a/src/cutty/services/generate.py
+++ b/src/cutty/services/generate.py
@@ -9,7 +9,7 @@ from lazysequence import lazysequence
 from cutty.errors import CuttyError
 from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.services.loadtemplate import Template as Template2
+from cutty.services.loadtemplate import Template
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterhooks
 from cutty.templates.adapters.cookiecutter.config import findcookiecutterpaths
@@ -26,7 +26,7 @@ class EmptyTemplateError(CuttyError):
 
 
 def generate(
-    template: Template2,
+    template: Template,
     outputdir: pathlib.Path,
     *,
     extrabindings: Sequence[Binding],

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -7,7 +7,7 @@ from typing import Optional
 from cutty.errors import CuttyError
 from cutty.projects.link import linkproject
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.generate import generate
+from cutty.services.generate import generate2
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
@@ -46,9 +46,8 @@ def link(
     def createproject(outputdir: pathlib.Path) -> Template:
         assert template is not None  # noqa: S101
 
-        generate(
-            template,
-            template2.repository,
+        generate2(
+            template2,
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -8,7 +8,7 @@ from cutty.errors import CuttyError
 from cutty.projects.link import linkproject
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.generate import generate
-from cutty.services.loadtemplate import loadtemplate2
+from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
@@ -41,7 +41,7 @@ def link(
     if template is None:
         raise TemplateNotSpecifiedError()
 
-    template2 = loadtemplate2(template, checkout, directory)
+    template2 = loadtemplate(template, checkout, directory)
 
     def createproject(outputdir: pathlib.Path) -> Template:
         assert template is not None  # noqa: S101

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -51,7 +51,6 @@ def link(
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
-            checkout=checkout,
             directory=directory,
             overwrite_if_exists=False,
             skip_if_file_exists=False,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -7,7 +7,7 @@ from typing import Optional
 from cutty.errors import CuttyError
 from cutty.projects.link import linkproject
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.generate import generate2
+from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
@@ -46,7 +46,7 @@ def link(
     def createproject(outputdir: pathlib.Path) -> Template:
         assert template is not None  # noqa: S101
 
-        generate2(
+        generate(
             template2,
             outputdir,
             extrabindings=extrabindings,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -51,7 +51,6 @@ def link(
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
-            directory=directory,
             overwrite_if_exists=False,
             skip_if_file_exists=False,
             outputdirisproject=True,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -8,7 +8,7 @@ from cutty.errors import CuttyError
 from cutty.projects.link import linkproject
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.generate import generate
-from cutty.services.loadtemplate import loadtemplate
+from cutty.services.loadtemplate import loadtemplate2
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
 from cutty.util.git import Repository
@@ -41,14 +41,14 @@ def link(
     if template is None:
         raise TemplateNotSpecifiedError()
 
-    template2 = loadtemplate(template, checkout, directory)
+    template2 = loadtemplate2(template, checkout, directory)
 
     def createproject(outputdir: pathlib.Path) -> Template:
         assert template is not None  # noqa: S101
 
         generate(
             template,
-            template2,
+            template2.repository,
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
@@ -59,6 +59,6 @@ def link(
             outputdirisproject=True,
             createconfigfile=True,
         )
-        return template2
+        return template2.repository
 
     linkproject(project, createproject)

--- a/src/cutty/services/loadtemplate.py
+++ b/src/cutty/services/loadtemplate.py
@@ -30,17 +30,17 @@ class Template:
     metadata: TemplateMetadata
     root: Path
 
+    @property
+    def repository(self) -> Repository:
+        """Convert to a Repository instance."""
+        return Repository(self.metadata.name, self.root, self.metadata.revision)
+
 
 def loadtemplate(
     template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
 ) -> Repository:
     """Load a template repository."""
-    template2 = loadtemplate2(template, checkout, directory)
-    return Repository(
-        template2.metadata.name,
-        template2.root,
-        template2.metadata.revision,
-    )
+    return loadtemplate2(template, checkout, directory).repository
 
 
 def loadtemplate2(

--- a/src/cutty/services/loadtemplate.py
+++ b/src/cutty/services/loadtemplate.py
@@ -35,6 +35,13 @@ def loadtemplate(
     template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
 ) -> Repository:
     """Load a template repository."""
+    return loadtemplate2(template, checkout, directory)
+
+
+def loadtemplate2(
+    template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
+) -> Repository:
+    """Load a template repository."""
     cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
     repositoryprovider = getdefaultrepositoryprovider(cachedir)
     return repositoryprovider(

--- a/src/cutty/services/loadtemplate.py
+++ b/src/cutty/services/loadtemplate.py
@@ -36,13 +36,6 @@ class Template:
         return Repository(self.metadata.name, self.root, self.metadata.revision)
 
 
-def loadtemplate(
-    template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
-) -> Repository:
-    """Load a template repository."""
-    return loadtemplate2(template, checkout, directory).repository
-
-
 def loadtemplate2(
     template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
 ) -> Template:

--- a/src/cutty/services/loadtemplate.py
+++ b/src/cutty/services/loadtemplate.py
@@ -35,17 +35,26 @@ def loadtemplate(
     template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
 ) -> Repository:
     """Load a template repository."""
-    return loadtemplate2(template, checkout, directory)
+    template2 = loadtemplate2(template, checkout, directory)
+    return Repository(
+        template2.metadata.name,
+        template2.root,
+        template2.metadata.revision,
+    )
 
 
 def loadtemplate2(
     template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
-) -> Repository:
-    """Load a template repository."""
+) -> Template:
+    """Load a project template."""
     cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
     repositoryprovider = getdefaultrepositoryprovider(cachedir)
-    return repositoryprovider(
+    repository = repositoryprovider(
         template,
         revision=checkout,
         directory=(PurePath(*directory.parts) if directory is not None else None),
     )
+    metadata = TemplateMetadata(
+        template, checkout, directory, repository.name, repository.revision
+    )
+    return Template(metadata, repository.path)

--- a/src/cutty/services/loadtemplate.py
+++ b/src/cutty/services/loadtemplate.py
@@ -36,7 +36,7 @@ class Template:
         return Repository(self.metadata.name, self.root, self.metadata.revision)
 
 
-def loadtemplate2(
+def loadtemplate(
     template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
 ) -> Template:
     """Load a project template."""

--- a/src/cutty/services/loadtemplate.py
+++ b/src/cutty/services/loadtemplate.py
@@ -1,17 +1,39 @@
 """Loading templates."""
 import pathlib
+from dataclasses import dataclass
 from typing import Optional
 
 import platformdirs
 
+from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
-from cutty.repositories.domain.repository import Repository as Template
+from cutty.repositories.domain.repository import Repository
+from cutty.repositories.domain.revisions import Revision
+
+
+@dataclass
+class TemplateMetadata:
+    """Metadata for a project template."""
+
+    location: str
+    checkout: Optional[str]
+    directory: Optional[pathlib.PurePosixPath]
+    name: str
+    revision: Optional[Revision]
+
+
+@dataclass
+class Template:
+    """Project template."""
+
+    metadata: TemplateMetadata
+    root: Path
 
 
 def loadtemplate(
     template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
-) -> Template:
+) -> Repository:
     """Load a template repository."""
     cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
     repositoryprovider = getdefaultrepositoryprovider(cachedir)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -35,7 +35,6 @@ def update(
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
-            directory=directory,
             overwrite_if_exists=False,
             skip_if_file_exists=False,
             outputdirisproject=True,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from cutty.projects.update import updateproject
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.generate import generate
+from cutty.services.generate import generate2
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
@@ -30,9 +30,8 @@ def update(
     template = loadtemplate(projectconfig.template, checkout, directory)
 
     def createproject(outputdir: Path) -> Template:
-        generate(
-            projectconfig.template,
-            template.repository,
+        generate2(
+            template,
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from cutty.projects.update import updateproject
 from cutty.repositories.domain.repository import Repository as Template
-from cutty.services.generate import generate2
+from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
@@ -30,7 +30,7 @@ def update(
     template = loadtemplate(projectconfig.template, checkout, directory)
 
     def createproject(outputdir: Path) -> Template:
-        generate2(
+        generate(
             template,
             outputdir,
             extrabindings=extrabindings,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -35,7 +35,6 @@ def update(
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
-            checkout=checkout,
             directory=directory,
             overwrite_if_exists=False,
             skip_if_file_exists=False,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -7,7 +7,7 @@ from typing import Optional
 from cutty.projects.update import updateproject
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.generate import generate
-from cutty.services.loadtemplate import loadtemplate
+from cutty.services.loadtemplate import loadtemplate2
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
@@ -27,12 +27,12 @@ def update(
     if directory is None:
         directory = projectconfig.directory
 
-    template = loadtemplate(projectconfig.template, checkout, directory)
+    template = loadtemplate2(projectconfig.template, checkout, directory)
 
     def createproject(outputdir: Path) -> Template:
         generate(
             projectconfig.template,
-            template,
+            template.repository,
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
@@ -43,6 +43,6 @@ def update(
             outputdirisproject=True,
             createconfigfile=True,
         )
-        return template
+        return template.repository
 
     updateproject(projectdir, createproject)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -7,7 +7,7 @@ from typing import Optional
 from cutty.projects.update import updateproject
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.generate import generate
-from cutty.services.loadtemplate import loadtemplate2
+from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
 
@@ -27,7 +27,7 @@ def update(
     if directory is None:
         directory = projectconfig.directory
 
-    template = loadtemplate2(projectconfig.template, checkout, directory)
+    template = loadtemplate(projectconfig.template, checkout, directory)
 
     def createproject(outputdir: Path) -> Template:
         generate(


### PR DESCRIPTION
- 🔨 [services] Add classes `Template` and `TemplateMetadata`
- 🔨 [services] Extract function `loadtemplate2`
- 🔨 [services] Change return type of `loadtemplate2` to `Template`
- 🔨 [services] Extract property `Template.repository`
- 🔨 [services] Inline function `loadtemplate`
- 🔨 [services] Rename function `loadtemplate2`
- 🔨 [services] Extract function `generate2` using `Template`
- 🔨 [services] Inline function `generate`
- 🔨 [services] Rename function `generate2`
- 🔨 [services] Rename import `Template2` to `Template`
- 🔨 [services] Replace `template.repository.path` with `template.root`
- 🔥 [services] Remove unused parameter `checkout` from `generate`
- 🔨 [entrypoints] Rename parameter `template` to `location`
- 🔨 [entrypoints] Rename variable `template2`
- 🔨 [services] Derive parameter `directory` in function `generate`
