### PR TITLE
🔨 [projects] Separate query and command in `createproject` parameter of `linkproject`

### DIFF
--- a/src/cutty/projects/common.py
+++ b/src/cutty/projects/common.py
@@ -10,6 +10,7 @@ UPDATE_BRANCH = "cutty/update"
 
 
 CreateProject = Callable[[Path], Template]
+CreateProject2 = Callable[[Path], None]
 
 
 def createcommitmessage(template: Template) -> str:

--- a/src/cutty/projects/link.py
+++ b/src/cutty/projects/link.py
@@ -54,11 +54,10 @@ def linkproject2(
 
     with project.worktree(update, checkout=False) as worktree:
         _ = createproject(worktree)
-        template2 = template.repository
         message = (
-            createcommitmessage(template2)
+            createcommitmessage(template.repository)
             if latest is None
-            else updatecommitmessage(template2)
+            else updatecommitmessage(template.repository)
         )
         Repository.open(worktree).commit(message=message)
 
@@ -71,7 +70,7 @@ def linkproject2(
     )
 
     project.commit(
-        message=linkcommitmessage(template2),
+        message=linkcommitmessage(template.repository),
         author=update.commit.author,
         committer=project.default_signature,
     )

--- a/src/cutty/projects/link.py
+++ b/src/cutty/projects/link.py
@@ -53,7 +53,8 @@ def linkproject2(
         update = _create_orphan_branch(project, UPDATE_BRANCH)
 
     with project.worktree(update, checkout=False) as worktree:
-        template2 = createproject(worktree)
+        _ = createproject(worktree)
+        template2 = template.repository
         message = (
             createcommitmessage(template2)
             if latest is None

--- a/src/cutty/projects/link.py
+++ b/src/cutty/projects/link.py
@@ -5,6 +5,7 @@ from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import linkcommitmessage
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.common import updatecommitmessage
+from cutty.services.loadtemplate import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Branch
 from cutty.util.git import Repository
@@ -71,3 +72,12 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
     )
 
     project.heads[LATEST_BRANCH] = update.commit
+
+
+def linkproject2(
+    project: Repository,
+    createproject: CreateProject,
+    template: Template,
+) -> None:
+    """Link a project to a Cookiecutter template."""
+    linkproject(project, createproject)

--- a/src/cutty/projects/link.py
+++ b/src/cutty/projects/link.py
@@ -1,14 +1,10 @@
 """Linking projects to their templates."""
-import pathlib
-
 from cutty.projects.common import createcommitmessage
-from cutty.projects.common import CreateProject
 from cutty.projects.common import CreateProject2
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import linkcommitmessage
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.common import updatecommitmessage
-from cutty.repositories.domain.repository import Repository as Repository2
 from cutty.services.loadtemplate import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Branch
@@ -49,20 +45,6 @@ def linkproject(
     template: Template,
 ) -> None:
     """Link a project to a project template."""
-
-    def createproject2(outputdir: pathlib.Path) -> Repository2:
-        createproject(outputdir)
-        return template.repository
-
-    linkproject2(project, createproject2, template)
-
-
-def linkproject2(
-    project: Repository,
-    createproject: CreateProject,
-    template: Template,
-) -> None:
-    """Link a project to a Cookiecutter template."""
     if latest := project.heads.get(LATEST_BRANCH):
         update = project.heads.create(UPDATE_BRANCH, latest, force=True)
     else:
@@ -71,7 +53,7 @@ def linkproject2(
         update = _create_orphan_branch(project, UPDATE_BRANCH)
 
     with project.worktree(update, checkout=False) as worktree:
-        _ = createproject(worktree)
+        createproject(worktree)
         message = (
             createcommitmessage(template.repository)
             if latest is None

--- a/src/cutty/projects/link.py
+++ b/src/cutty/projects/link.py
@@ -39,7 +39,11 @@ def _squash_branch(repository: Repository, branch: Branch) -> None:
     )
 
 
-def linkproject(project: Repository, createproject: CreateProject) -> None:
+def linkproject2(
+    project: Repository,
+    createproject: CreateProject,
+    template: Template,
+) -> None:
     """Link a project to a Cookiecutter template."""
     if latest := project.heads.get(LATEST_BRANCH):
         update = project.heads.create(UPDATE_BRANCH, latest, force=True)
@@ -49,11 +53,11 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
         update = _create_orphan_branch(project, UPDATE_BRANCH)
 
     with project.worktree(update, checkout=False) as worktree:
-        template = createproject(worktree)
+        template2 = createproject(worktree)
         message = (
-            createcommitmessage(template)
+            createcommitmessage(template2)
             if latest is None
-            else updatecommitmessage(template)
+            else updatecommitmessage(template2)
         )
         Repository.open(worktree).commit(message=message)
 
@@ -66,18 +70,9 @@ def linkproject(project: Repository, createproject: CreateProject) -> None:
     )
 
     project.commit(
-        message=linkcommitmessage(template),
+        message=linkcommitmessage(template2),
         author=update.commit.author,
         committer=project.default_signature,
     )
 
     project.heads[LATEST_BRANCH] = update.commit
-
-
-def linkproject2(
-    project: Repository,
-    createproject: CreateProject,
-    template: Template,
-) -> None:
-    """Link a project to a Cookiecutter template."""
-    linkproject(project, createproject)

--- a/src/cutty/projects/link.py
+++ b/src/cutty/projects/link.py
@@ -1,10 +1,14 @@
 """Linking projects to their templates."""
+import pathlib
+
 from cutty.projects.common import createcommitmessage
 from cutty.projects.common import CreateProject
+from cutty.projects.common import CreateProject2
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import linkcommitmessage
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.common import updatecommitmessage
+from cutty.repositories.domain.repository import Repository as Repository2
 from cutty.services.loadtemplate import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Branch
@@ -37,6 +41,20 @@ def _squash_branch(repository: Repository, branch: Branch) -> None:
         commit.tree.id,
         [],
     )
+
+
+def linkproject(
+    project: Repository,
+    createproject: CreateProject2,
+    template: Template,
+) -> None:
+    """Link a project to a project template."""
+
+    def createproject2(outputdir: pathlib.Path) -> Repository2:
+        createproject(outputdir)
+        return template.repository
+
+    linkproject2(project, createproject2, template)
 
 
 def linkproject2(

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,8 +5,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.projects.link import linkproject2
-from cutty.repositories.domain.repository import Repository as Template
+from cutty.projects.link import linkproject
 from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
@@ -43,9 +42,7 @@ def link(
 
     template2 = loadtemplate(template, checkout, directory)
 
-    def createproject(outputdir: pathlib.Path) -> Template:
-        assert template is not None  # noqa: S101
-
+    def createproject(outputdir: pathlib.Path) -> None:
         generate(
             template2,
             outputdir,
@@ -56,6 +53,5 @@ def link(
             outputdirisproject=True,
             createconfigfile=True,
         )
-        return template2.repository
 
-    linkproject2(project, createproject, template2)
+    linkproject(project, createproject, template2)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.projects.link import linkproject
+from cutty.projects.link import linkproject2
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
@@ -58,4 +58,4 @@ def link(
         )
         return template2.repository
 
-    linkproject(project, createproject)
+    linkproject2(project, createproject, template2)

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -10,7 +10,6 @@ from cutty.projects.common import CreateProject2
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.link import linkproject
-from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.loadtemplate import Template as Template2
 from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
@@ -27,15 +26,10 @@ def project(repository: Repository) -> Repository:
 
 
 @pytest.fixture
-def template() -> Template:
+def template() -> Template2:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
-    return Template("template", templatepath, None)
-
-
-@pytest.fixture
-def template2(template: Template) -> Template2:
-    """Fixture for a `Template` instance."""
+    template = Template("template", templatepath, None)
     location = "https://example.com/template"
     metadata = TemplateMetadata(location, None, None, template.name, template.revision)
     return Template2(metadata, template.path)
@@ -75,19 +69,17 @@ def test_linkproject_commit_message_template(
     project: Repository,
     createproject: CreateProject2,
     template2: Template2,
-    template: Template,
 ) -> None:
     """It includes the template name in the commit message."""
     linkproject(project, createproject, template2)
 
-    assert template.name in project.head.commit.message
+    assert template2.metadata.name in project.head.commit.message
 
 
 def test_linkproject_commit_message_revision(
-    project: Repository, template2: Template2, template: Template
+    project: Repository, template2: Template2
 ) -> None:
     """It includes the template name in the commit message."""
-    template = dataclasses.replace(template, revision="1.0.0")
     template2 = dataclasses.replace(
         template2, metadata=dataclasses.replace(template2.metadata, revision="1.0.0")
     )
@@ -97,7 +89,7 @@ def test_linkproject_commit_message_revision(
 
     linkproject(project, createproject, template2)
 
-    assert template.revision in project.head.commit.message
+    assert template2.metadata.revision in project.head.commit.message
 
 
 def test_linkproject_latest_branch(

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -10,7 +10,7 @@ from cutty.projects.common import CreateProject2
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.link import linkproject
-from cutty.services.loadtemplate import Template as Template2
+from cutty.services.loadtemplate import Template
 from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
 from tests.util.git import updatefile
@@ -26,12 +26,12 @@ def project(repository: Repository) -> Repository:
 
 
 @pytest.fixture
-def template() -> Template2:
+def template() -> Template:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
     location = "https://example.com/template"
     metadata = TemplateMetadata(location, None, None, "template", None)
-    return Template2(metadata, templatepath)
+    return Template(metadata, templatepath)
 
 
 @pytest.fixture
@@ -45,7 +45,7 @@ def createproject() -> CreateProject2:
 
 
 def test_linkproject_commit(
-    project: Repository, createproject: CreateProject2, template: Template2
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
@@ -56,7 +56,7 @@ def test_linkproject_commit(
 
 
 def test_linkproject_commit_message(
-    project: Repository, createproject: CreateProject2, template: Template2
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It uses a commit message indicating the linkage."""
     linkproject(project, createproject, template)
@@ -67,7 +67,7 @@ def test_linkproject_commit_message(
 def test_linkproject_commit_message_template(
     project: Repository,
     createproject: CreateProject2,
-    template: Template2,
+    template: Template,
 ) -> None:
     """It includes the template name in the commit message."""
     linkproject(project, createproject, template)
@@ -76,7 +76,7 @@ def test_linkproject_commit_message_template(
 
 
 def test_linkproject_commit_message_revision(
-    project: Repository, template: Template2
+    project: Repository, template: Template
 ) -> None:
     """It includes the template name in the commit message."""
     template = dataclasses.replace(
@@ -92,7 +92,7 @@ def test_linkproject_commit_message_revision(
 
 
 def test_linkproject_latest_branch(
-    project: Repository, createproject: CreateProject2, template: Template2
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It creates the latest branch."""
     updatefile(project.path / "initial")
@@ -103,7 +103,7 @@ def test_linkproject_latest_branch(
 
 
 def test_linkproject_latest_branch_commit_message(
-    project: Repository, createproject: CreateProject2, template: Template2
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It uses a commit message indicating an initial import."""
     updatefile(project.path / "initial")
@@ -114,7 +114,7 @@ def test_linkproject_latest_branch_commit_message(
 
 
 def test_linkproject_latest_branch_commit_message_update(
-    project: Repository, createproject: CreateProject2, template: Template2
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It uses a commit message indicating an update if the branch exists."""
     project.heads.create(LATEST_BRANCH)
@@ -127,7 +127,7 @@ def test_linkproject_latest_branch_commit_message_update(
 
 
 def test_linkproject_update_branch(
-    project: Repository, createproject: CreateProject2, template: Template2
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It creates the update branch."""
     updatefile(project.path / "initial")

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -29,10 +29,9 @@ def project(repository: Repository) -> Repository:
 def template() -> Template2:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
-    template = Template("template", templatepath, None)
     location = "https://example.com/template"
-    metadata = TemplateMetadata(location, None, None, template.name, template.revision)
-    return Template2(metadata, template.path)
+    metadata = TemplateMetadata(location, None, None, "template", None)
+    return Template2(metadata, templatepath)
 
 
 @pytest.fixture

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -45,21 +45,21 @@ def createproject() -> CreateProject2:
 
 
 def test_linkproject_commit(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template: Template2
 ) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
 
-    linkproject(project, createproject, template2)
+    linkproject(project, createproject, template)
 
     assert [tip] == project.head.commit.parents
 
 
 def test_linkproject_commit_message(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template: Template2
 ) -> None:
     """It uses a commit message indicating the linkage."""
-    linkproject(project, createproject, template2)
+    linkproject(project, createproject, template)
 
     assert "link" in project.head.commit.message.lower()
 
@@ -67,71 +67,71 @@ def test_linkproject_commit_message(
 def test_linkproject_commit_message_template(
     project: Repository,
     createproject: CreateProject2,
-    template2: Template2,
+    template: Template2,
 ) -> None:
     """It includes the template name in the commit message."""
-    linkproject(project, createproject, template2)
+    linkproject(project, createproject, template)
 
-    assert template2.metadata.name in project.head.commit.message
+    assert template.metadata.name in project.head.commit.message
 
 
 def test_linkproject_commit_message_revision(
-    project: Repository, template2: Template2
+    project: Repository, template: Template2
 ) -> None:
     """It includes the template name in the commit message."""
-    template2 = dataclasses.replace(
-        template2, metadata=dataclasses.replace(template2.metadata, revision="1.0.0")
+    template = dataclasses.replace(
+        template, metadata=dataclasses.replace(template.metadata, revision="1.0.0")
     )
 
     def createproject(project: Path) -> None:
         (project / "cutty.json").touch()
 
-    linkproject(project, createproject, template2)
+    linkproject(project, createproject, template)
 
-    assert template2.metadata.revision in project.head.commit.message
+    assert template.metadata.revision in project.head.commit.message
 
 
 def test_linkproject_latest_branch(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template: Template2
 ) -> None:
     """It creates the latest branch."""
     updatefile(project.path / "initial")
 
-    linkproject(project, createproject, template2)
+    linkproject(project, createproject, template)
 
     assert LATEST_BRANCH in project.heads
 
 
 def test_linkproject_latest_branch_commit_message(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template: Template2
 ) -> None:
     """It uses a commit message indicating an initial import."""
     updatefile(project.path / "initial")
 
-    linkproject(project, createproject, template2)
+    linkproject(project, createproject, template)
 
     assert "initial" in project.heads[LATEST_BRANCH].message.lower()
 
 
 def test_linkproject_latest_branch_commit_message_update(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template: Template2
 ) -> None:
     """It uses a commit message indicating an update if the branch exists."""
     project.heads.create(LATEST_BRANCH)
 
     updatefile(project.path / "initial")
 
-    linkproject(project, createproject, template2)
+    linkproject(project, createproject, template)
 
     assert "update" in project.heads[LATEST_BRANCH].message.lower()
 
 
 def test_linkproject_update_branch(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template: Template2
 ) -> None:
     """It creates the update branch."""
     updatefile(project.path / "initial")
 
-    linkproject(project, createproject, template2)
+    linkproject(project, createproject, template)
 
     assert UPDATE_BRANCH in project.heads

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -6,10 +6,10 @@ import pytest
 
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path as VirtualPath
-from cutty.projects.common import CreateProject
+from cutty.projects.common import CreateProject2
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import UPDATE_BRANCH
-from cutty.projects.link import linkproject2
+from cutty.projects.link import linkproject
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.loadtemplate import Template as Template2
 from cutty.services.loadtemplate import TemplateMetadata
@@ -42,49 +42,48 @@ def template2(template: Template) -> Template2:
 
 
 @pytest.fixture
-def createproject(template: Template) -> CreateProject:
+def createproject() -> CreateProject2:
     """Fixture for a `createproject` function."""
 
-    def _(project: Path) -> Template:
+    def _(project: Path) -> None:
         (project / "cutty.json").touch()
-        return template
 
     return _
 
 
-def test_linkproject2_commit(
-    project: Repository, createproject: CreateProject, template2: Template2
+def test_linkproject_commit(
+    project: Repository, createproject: CreateProject2, template2: Template2
 ) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
 
-    linkproject2(project, createproject, template2)
+    linkproject(project, createproject, template2)
 
     assert [tip] == project.head.commit.parents
 
 
-def test_linkproject2_commit_message(
-    project: Repository, createproject: CreateProject, template2: Template2
+def test_linkproject_commit_message(
+    project: Repository, createproject: CreateProject2, template2: Template2
 ) -> None:
     """It uses a commit message indicating the linkage."""
-    linkproject2(project, createproject, template2)
+    linkproject(project, createproject, template2)
 
     assert "link" in project.head.commit.message.lower()
 
 
-def test_linkproject2_commit_message_template(
+def test_linkproject_commit_message_template(
     project: Repository,
-    createproject: CreateProject,
+    createproject: CreateProject2,
     template2: Template2,
     template: Template,
 ) -> None:
     """It includes the template name in the commit message."""
-    linkproject2(project, createproject, template2)
+    linkproject(project, createproject, template2)
 
     assert template.name in project.head.commit.message
 
 
-def test_linkproject2_commit_message_revision(
+def test_linkproject_commit_message_revision(
     project: Repository, template2: Template2, template: Template
 ) -> None:
     """It includes the template name in the commit message."""
@@ -93,56 +92,55 @@ def test_linkproject2_commit_message_revision(
         template2, metadata=dataclasses.replace(template2.metadata, revision="1.0.0")
     )
 
-    def createproject(project: Path) -> Template:
+    def createproject(project: Path) -> None:
         (project / "cutty.json").touch()
-        return template
 
-    linkproject2(project, createproject, template2)
+    linkproject(project, createproject, template2)
 
     assert template.revision in project.head.commit.message
 
 
-def test_linkproject2_latest_branch(
-    project: Repository, createproject: CreateProject, template2: Template2
+def test_linkproject_latest_branch(
+    project: Repository, createproject: CreateProject2, template2: Template2
 ) -> None:
     """It creates the latest branch."""
     updatefile(project.path / "initial")
 
-    linkproject2(project, createproject, template2)
+    linkproject(project, createproject, template2)
 
     assert LATEST_BRANCH in project.heads
 
 
-def test_linkproject2_latest_branch_commit_message(
-    project: Repository, createproject: CreateProject, template2: Template2
+def test_linkproject_latest_branch_commit_message(
+    project: Repository, createproject: CreateProject2, template2: Template2
 ) -> None:
     """It uses a commit message indicating an initial import."""
     updatefile(project.path / "initial")
 
-    linkproject2(project, createproject, template2)
+    linkproject(project, createproject, template2)
 
     assert "initial" in project.heads[LATEST_BRANCH].message.lower()
 
 
-def test_linkproject2_latest_branch_commit_message_update(
-    project: Repository, createproject: CreateProject, template2: Template2
+def test_linkproject_latest_branch_commit_message_update(
+    project: Repository, createproject: CreateProject2, template2: Template2
 ) -> None:
     """It uses a commit message indicating an update if the branch exists."""
     project.heads.create(LATEST_BRANCH)
 
     updatefile(project.path / "initial")
 
-    linkproject2(project, createproject, template2)
+    linkproject(project, createproject, template2)
 
     assert "update" in project.heads[LATEST_BRANCH].message.lower()
 
 
-def test_linkproject2_update_branch(
-    project: Repository, createproject: CreateProject, template2: Template2
+def test_linkproject_update_branch(
+    project: Repository, createproject: CreateProject2, template2: Template2
 ) -> None:
     """It creates the update branch."""
     updatefile(project.path / "initial")
 
-    linkproject2(project, createproject, template2)
+    linkproject(project, createproject, template2)
 
     assert UPDATE_BRANCH in project.heads


### PR DESCRIPTION
- 🔨 [projects] Add function `linkproject2` with `template` parameter
- 🔨 [projects] Replace `linkproject` with `linkproject2` in `test_link`
- 🔨 [services] Replace `linkproject` with `linkproject2` in `link`
- 🔨 [projects] Inline function `linkproject`
- 🔨 [projects] Derive `template2` from `template` in `linkproject2`
- 🔨 [projects] Inline variable `template2`
- 🔨 [projects] Add type alias `CreateProject2` returning None
- 🔨 [projects] Add delegator `linkproject` accepting `CreateProject2`
- 🔨 [services] Replace `linkproject2` with `linkproject` in `link`
- 🔨 [projects] Replace `linkproject2` with `linkproject` in `test_link`
- 🔨 [projects] Inline fixture `template`
- 🔨 [projects] Inline variable `template` in `template2`
- 🔨 [projects] Rename `template` to `template2`
- 🔨 [projects] Rename import `Template2` in `test_link`
- 🔨 [projects] Inline function `linkproject2`
