### PR TITLE
🔨 [projects] Separate query and command in `createproject` parameter of `updateproject`

### DIFF
--- a/src/cutty/projects/common.py
+++ b/src/cutty/projects/common.py
@@ -9,7 +9,7 @@ LATEST_BRANCH = "cutty/latest"
 UPDATE_BRANCH = "cutty/update"
 
 
-CreateProject2 = Callable[[Path], None]
+CreateProject = Callable[[Path], None]
 
 
 def createcommitmessage(template: Template) -> str:

--- a/src/cutty/projects/common.py
+++ b/src/cutty/projects/common.py
@@ -9,7 +9,6 @@ LATEST_BRANCH = "cutty/latest"
 UPDATE_BRANCH = "cutty/update"
 
 
-CreateProject = Callable[[Path], Template]
 CreateProject2 = Callable[[Path], None]
 
 

--- a/src/cutty/projects/link.py
+++ b/src/cutty/projects/link.py
@@ -1,6 +1,6 @@
 """Linking projects to their templates."""
 from cutty.projects.common import createcommitmessage
-from cutty.projects.common import CreateProject2
+from cutty.projects.common import CreateProject
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import linkcommitmessage
 from cutty.projects.common import UPDATE_BRANCH
@@ -41,7 +41,7 @@ def _squash_branch(repository: Repository, branch: Branch) -> None:
 
 def linkproject(
     project: Repository,
-    createproject: CreateProject2,
+    createproject: CreateProject,
     template: Template,
 ) -> None:
     """Link a project to a project template."""

--- a/src/cutty/projects/update.py
+++ b/src/cutty/projects/update.py
@@ -1,12 +1,10 @@
 """Updating projects with changes from their templates."""
 from pathlib import Path
 
-from cutty.projects.common import CreateProject
 from cutty.projects.common import CreateProject2
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.common import updatecommitmessage
-from cutty.repositories.domain.repository import Repository as Repository2
 from cutty.services.loadtemplate import Template
 from cutty.util.git import Repository
 
@@ -15,25 +13,13 @@ def updateproject(
     projectdir: Path, createproject: CreateProject2, template: Template
 ) -> None:
     """Update a project by applying changes between the generated trees."""
-
-    def createproject2(projectdir: Path) -> Repository2:
-        createproject(projectdir)
-        return template.repository
-
-    updateproject2(projectdir, createproject2, template)
-
-
-def updateproject2(
-    projectdir: Path, createproject: CreateProject, template: Template
-) -> None:
-    """Update a project by applying changes between the generated trees."""
     project = Repository.open(projectdir)
 
     latestbranch = project.branch(LATEST_BRANCH)
     updatebranch = project.heads.create(UPDATE_BRANCH, latestbranch.commit, force=True)
 
     with project.worktree(updatebranch, checkout=False) as worktree:
-        _ = createproject(worktree)
+        createproject(worktree)
         Repository.open(worktree).commit(
             message=updatecommitmessage(template.repository)
         )

--- a/src/cutty/projects/update.py
+++ b/src/cutty/projects/update.py
@@ -2,11 +2,25 @@
 from pathlib import Path
 
 from cutty.projects.common import CreateProject
+from cutty.projects.common import CreateProject2
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.common import updatecommitmessage
+from cutty.repositories.domain.repository import Repository as Repository2
 from cutty.services.loadtemplate import Template
 from cutty.util.git import Repository
+
+
+def updateproject(
+    projectdir: Path, createproject: CreateProject2, template: Template
+) -> None:
+    """Update a project by applying changes between the generated trees."""
+
+    def createproject2(projectdir: Path) -> Repository2:
+        createproject(projectdir)
+        return template.repository
+
+    updateproject2(projectdir, createproject2, template)
 
 
 def updateproject2(

--- a/src/cutty/projects/update.py
+++ b/src/cutty/projects/update.py
@@ -1,7 +1,7 @@
 """Updating projects with changes from their templates."""
 from pathlib import Path
 
-from cutty.projects.common import CreateProject2
+from cutty.projects.common import CreateProject
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.common import updatecommitmessage
@@ -10,7 +10,7 @@ from cutty.util.git import Repository
 
 
 def updateproject(
-    projectdir: Path, createproject: CreateProject2, template: Template
+    projectdir: Path, createproject: CreateProject, template: Template
 ) -> None:
     """Update a project by applying changes between the generated trees."""
     project = Repository.open(projectdir)

--- a/src/cutty/projects/update.py
+++ b/src/cutty/projects/update.py
@@ -5,7 +5,15 @@ from cutty.projects.common import CreateProject
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.common import updatecommitmessage
+from cutty.services.loadtemplate import Template
 from cutty.util.git import Repository
+
+
+def updateproject2(
+    projectdir: Path, createproject: CreateProject, template: Template
+) -> None:
+    """Update a project by applying changes between the generated trees."""
+    updateproject(projectdir, createproject)
 
 
 def updateproject(projectdir: Path, createproject: CreateProject) -> None:

--- a/src/cutty/projects/update.py
+++ b/src/cutty/projects/update.py
@@ -13,19 +13,16 @@ def updateproject2(
     projectdir: Path, createproject: CreateProject, template: Template
 ) -> None:
     """Update a project by applying changes between the generated trees."""
-    updateproject(projectdir, createproject)
-
-
-def updateproject(projectdir: Path, createproject: CreateProject) -> None:
-    """Update a project by applying changes between the generated trees."""
     project = Repository.open(projectdir)
 
     latestbranch = project.branch(LATEST_BRANCH)
     updatebranch = project.heads.create(UPDATE_BRANCH, latestbranch.commit, force=True)
 
     with project.worktree(updatebranch, checkout=False) as worktree:
-        template = createproject(worktree)
-        Repository.open(worktree).commit(message=updatecommitmessage(template))
+        _ = createproject(worktree)
+        Repository.open(worktree).commit(
+            message=updatecommitmessage(template.repository)
+        )
 
     project.cherrypick(updatebranch.commit)
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
 
-from cutty.projects.update import updateproject2
-from cutty.repositories.domain.repository import Repository as Template
+from cutty.projects.update import updateproject
 from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
@@ -29,7 +28,7 @@ def update(
 
     template = loadtemplate(projectconfig.template, checkout, directory)
 
-    def createproject(outputdir: Path) -> Template:
+    def createproject(outputdir: Path) -> None:
         generate(
             template,
             outputdir,
@@ -40,6 +39,5 @@ def update(
             outputdirisproject=True,
             createconfigfile=True,
         )
-        return template.repository
 
-    updateproject2(projectdir, createproject, template)
+    updateproject(projectdir, createproject, template)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
 
-from cutty.projects.update import updateproject
+from cutty.projects.update import updateproject2
 from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
@@ -42,4 +42,4 @@ def update(
         )
         return template.repository
 
-    updateproject(projectdir, createproject)
+    updateproject2(projectdir, createproject, template)

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -6,7 +6,7 @@ import pytest
 
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path as VirtualPath
-from cutty.projects.common import CreateProject2
+from cutty.projects.common import CreateProject
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.link import linkproject
@@ -35,7 +35,7 @@ def template() -> Template:
 
 
 @pytest.fixture
-def createproject() -> CreateProject2:
+def createproject() -> CreateProject:
     """Fixture for a `createproject` function."""
 
     def _(project: Path) -> None:
@@ -45,7 +45,7 @@ def createproject() -> CreateProject2:
 
 
 def test_linkproject_commit(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
@@ -56,7 +56,7 @@ def test_linkproject_commit(
 
 
 def test_linkproject_commit_message(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It uses a commit message indicating the linkage."""
     linkproject(project, createproject, template)
@@ -66,7 +66,7 @@ def test_linkproject_commit_message(
 
 def test_linkproject_commit_message_template(
     project: Repository,
-    createproject: CreateProject2,
+    createproject: CreateProject,
     template: Template,
 ) -> None:
     """It includes the template name in the commit message."""
@@ -92,7 +92,7 @@ def test_linkproject_commit_message_revision(
 
 
 def test_linkproject_latest_branch(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It creates the latest branch."""
     updatefile(project.path / "initial")
@@ -103,7 +103,7 @@ def test_linkproject_latest_branch(
 
 
 def test_linkproject_latest_branch_commit_message(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It uses a commit message indicating an initial import."""
     updatefile(project.path / "initial")
@@ -114,7 +114,7 @@ def test_linkproject_latest_branch_commit_message(
 
 
 def test_linkproject_latest_branch_commit_message_update(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It uses a commit message indicating an update if the branch exists."""
     project.heads.create(LATEST_BRANCH)
@@ -127,7 +127,7 @@ def test_linkproject_latest_branch_commit_message_update(
 
 
 def test_linkproject_update_branch(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It creates the update branch."""
     updatefile(project.path / "initial")

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -13,7 +13,6 @@ from cutty.projects.update import abortupdate
 from cutty.projects.update import continueupdate
 from cutty.projects.update import skipupdate
 from cutty.projects.update import updateproject
-from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.loadtemplate import Template as Template2
 from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
@@ -129,13 +128,6 @@ def project(repository: Repository) -> Repository:
 
 
 @pytest.fixture
-def template() -> Template:
-    """Fixture for a `Template` instance."""
-    templatepath = VirtualPath(filesystem=DictFilesystem({}))
-    return Template("template", templatepath, None)
-
-
-@pytest.fixture
 def template2() -> Template2:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
@@ -175,22 +167,18 @@ def test_updateproject_commit_message(
 
 
 def test_updateproject_commit_message_template(
-    project: Repository,
-    createproject: CreateProject2,
-    template2: Template2,
-    template: Template,
+    project: Repository, createproject: CreateProject2, template2: Template2
 ) -> None:
     """It includes the template name in the commit message."""
     updateproject(project.path, createproject, template2)
 
-    assert template.name in project.head.commit.message
+    assert template2.metadata.name in project.head.commit.message
 
 
 def test_updateproject_commit_message_revision(
-    project: Repository, template: Template, template2: Template2
+    project: Repository, template2: Template2
 ) -> None:
     """It includes the template name in the commit message."""
-    template = dataclasses.replace(template, revision="1.0.0")
     template2 = dataclasses.replace(
         template2, metadata=dataclasses.replace(template2.metadata, revision="1.0.0")
     )
@@ -200,7 +188,7 @@ def test_updateproject_commit_message_revision(
 
     updateproject(project.path, createproject, template2)
 
-    assert template.revision in project.head.commit.message
+    assert template2.metadata.revision in project.head.commit.message
 
 
 def test_updateproject_latest_branch(
@@ -225,9 +213,7 @@ def test_updateproject_update_branch(
     assert project.heads[LATEST_BRANCH] == project.heads[UPDATE_BRANCH]
 
 
-def test_updateproject_no_changes(
-    project: Repository, template: Template, template2: Template2
-) -> None:
+def test_updateproject_no_changes(project: Repository, template2: Template2) -> None:
     """It does not create an empty commit."""
     tip = project.head.commit
 

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -13,7 +13,7 @@ from cutty.projects.update import abortupdate
 from cutty.projects.update import continueupdate
 from cutty.projects.update import skipupdate
 from cutty.projects.update import updateproject
-from cutty.services.loadtemplate import Template as Template2
+from cutty.services.loadtemplate import Template
 from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
 from tests.util.git import createbranches
@@ -128,12 +128,12 @@ def project(repository: Repository) -> Repository:
 
 
 @pytest.fixture
-def template2() -> Template2:
+def template2() -> Template:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
     location = "https://example.com/template"
     metadata = TemplateMetadata(location, None, None, "template", None)
-    return Template2(metadata, templatepath)
+    return Template(metadata, templatepath)
 
 
 @pytest.fixture
@@ -147,7 +147,7 @@ def createproject() -> CreateProject2:
 
 
 def test_updateproject_commit(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template2: Template
 ) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
@@ -158,7 +158,7 @@ def test_updateproject_commit(
 
 
 def test_updateproject_commit_message(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template2: Template
 ) -> None:
     """It uses a commit message indicating an update."""
     updateproject(project.path, createproject, template2)
@@ -167,7 +167,7 @@ def test_updateproject_commit_message(
 
 
 def test_updateproject_commit_message_template(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template2: Template
 ) -> None:
     """It includes the template name in the commit message."""
     updateproject(project.path, createproject, template2)
@@ -176,7 +176,7 @@ def test_updateproject_commit_message_template(
 
 
 def test_updateproject_commit_message_revision(
-    project: Repository, template2: Template2
+    project: Repository, template2: Template
 ) -> None:
     """It includes the template name in the commit message."""
     template2 = dataclasses.replace(
@@ -192,7 +192,7 @@ def test_updateproject_commit_message_revision(
 
 
 def test_updateproject_latest_branch(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template2: Template
 ) -> None:
     """It updates the latest branch."""
     updatefile(project.path / "initial")
@@ -205,7 +205,7 @@ def test_updateproject_latest_branch(
 
 
 def test_updateproject_update_branch(
-    project: Repository, createproject: CreateProject2, template2: Template2
+    project: Repository, createproject: CreateProject2, template2: Template
 ) -> None:
     """It creates the update branch."""
     updateproject(project.path, createproject, template2)
@@ -213,7 +213,7 @@ def test_updateproject_update_branch(
     assert project.heads[LATEST_BRANCH] == project.heads[UPDATE_BRANCH]
 
 
-def test_updateproject_no_changes(project: Repository, template2: Template2) -> None:
+def test_updateproject_no_changes(project: Repository, template2: Template) -> None:
     """It does not create an empty commit."""
     tip = project.head.commit
 

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -14,6 +14,8 @@ from cutty.projects.update import continueupdate
 from cutty.projects.update import skipupdate
 from cutty.projects.update import updateproject
 from cutty.repositories.domain.repository import Repository as Template
+from cutty.services.loadtemplate import Template as Template2
+from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
 from tests.util.git import createbranches
 from tests.util.git import resolveconflicts
@@ -131,6 +133,15 @@ def template() -> Template:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
     return Template("template", templatepath, None)
+
+
+@pytest.fixture
+def template2() -> Template2:
+    """Fixture for a `Template` instance."""
+    templatepath = VirtualPath(filesystem=DictFilesystem({}))
+    location = "https://example.com/template"
+    metadata = TemplateMetadata(location, None, None, "template", None)
+    return Template2(metadata, templatepath)
 
 
 @pytest.fixture

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -6,7 +6,7 @@ import pytest
 
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path as VirtualPath
-from cutty.projects.common import CreateProject2
+from cutty.projects.common import CreateProject
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.common import UPDATE_BRANCH
 from cutty.projects.update import abortupdate
@@ -137,7 +137,7 @@ def template() -> Template:
 
 
 @pytest.fixture
-def createproject() -> CreateProject2:
+def createproject() -> CreateProject:
     """Fixture for a `createproject` function."""
 
     def _(project: Path) -> None:
@@ -147,7 +147,7 @@ def createproject() -> CreateProject2:
 
 
 def test_updateproject_commit(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
@@ -158,7 +158,7 @@ def test_updateproject_commit(
 
 
 def test_updateproject_commit_message(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It uses a commit message indicating an update."""
     updateproject(project.path, createproject, template)
@@ -167,7 +167,7 @@ def test_updateproject_commit_message(
 
 
 def test_updateproject_commit_message_template(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It includes the template name in the commit message."""
     updateproject(project.path, createproject, template)
@@ -192,7 +192,7 @@ def test_updateproject_commit_message_revision(
 
 
 def test_updateproject_latest_branch(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It updates the latest branch."""
     updatefile(project.path / "initial")
@@ -205,7 +205,7 @@ def test_updateproject_latest_branch(
 
 
 def test_updateproject_update_branch(
-    project: Repository, createproject: CreateProject2, template: Template
+    project: Repository, createproject: CreateProject, template: Template
 ) -> None:
     """It creates the update branch."""
     updateproject(project.path, createproject, template)

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -128,7 +128,7 @@ def project(repository: Repository) -> Repository:
 
 
 @pytest.fixture
-def template2() -> Template:
+def template() -> Template:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
     location = "https://example.com/template"
@@ -147,76 +147,76 @@ def createproject() -> CreateProject2:
 
 
 def test_updateproject_commit(
-    project: Repository, createproject: CreateProject2, template2: Template
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
 
-    updateproject(project.path, createproject, template2)
+    updateproject(project.path, createproject, template)
 
     assert [tip] == project.head.commit.parents
 
 
 def test_updateproject_commit_message(
-    project: Repository, createproject: CreateProject2, template2: Template
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It uses a commit message indicating an update."""
-    updateproject(project.path, createproject, template2)
+    updateproject(project.path, createproject, template)
 
     assert "update" in project.head.commit.message.lower()
 
 
 def test_updateproject_commit_message_template(
-    project: Repository, createproject: CreateProject2, template2: Template
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It includes the template name in the commit message."""
-    updateproject(project.path, createproject, template2)
+    updateproject(project.path, createproject, template)
 
-    assert template2.metadata.name in project.head.commit.message
+    assert template.metadata.name in project.head.commit.message
 
 
 def test_updateproject_commit_message_revision(
-    project: Repository, template2: Template
+    project: Repository, template: Template
 ) -> None:
     """It includes the template name in the commit message."""
-    template2 = dataclasses.replace(
-        template2, metadata=dataclasses.replace(template2.metadata, revision="1.0.0")
+    template = dataclasses.replace(
+        template, metadata=dataclasses.replace(template.metadata, revision="1.0.0")
     )
 
     def createproject(project: Path) -> None:
         (project / "marker").touch()
 
-    updateproject(project.path, createproject, template2)
+    updateproject(project.path, createproject, template)
 
-    assert template2.metadata.revision in project.head.commit.message
+    assert template.metadata.revision in project.head.commit.message
 
 
 def test_updateproject_latest_branch(
-    project: Repository, createproject: CreateProject2, template2: Template
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It updates the latest branch."""
     updatefile(project.path / "initial")
 
     tip = project.heads[LATEST_BRANCH]
 
-    updateproject(project.path, createproject, template2)
+    updateproject(project.path, createproject, template)
 
     assert [tip] == project.heads[LATEST_BRANCH].parents
 
 
 def test_updateproject_update_branch(
-    project: Repository, createproject: CreateProject2, template2: Template
+    project: Repository, createproject: CreateProject2, template: Template
 ) -> None:
     """It creates the update branch."""
-    updateproject(project.path, createproject, template2)
+    updateproject(project.path, createproject, template)
 
     assert project.heads[LATEST_BRANCH] == project.heads[UPDATE_BRANCH]
 
 
-def test_updateproject_no_changes(project: Repository, template2: Template) -> None:
+def test_updateproject_no_changes(project: Repository, template: Template) -> None:
     """It does not create an empty commit."""
     tip = project.head.commit
 
-    updateproject(project.path, lambda _: None, template2)
+    updateproject(project.path, lambda _: None, template)
 
     assert tip == project.head.commit


### PR DESCRIPTION
- 🔨 [projects] Add function `updateproject2` with `template` parameter
- 🔨 [projects] Add fixture `template2` in `test_update`
- 🔨 [projects] Replace `updateproject` with `updateproject2` in `test_update`
- 🔨 [services] Replace `updateproject` with `updateproject2` in `update`
- 🔨 [projects] Inline function `updateproject`
- 🔨 [projects] Add function `updateproject` with query-style `createproject`
- 🔨 [projects] Replace `updateproject2` with `updateproject` in `test_update`
- 🔨 [services] Replace `updateproject2` with `updateproject` in `update`
- 🔨 [projects] Inline fixture `template` in `test_update`
- 🔨 [projects] Rename import `Template2` to `Template` in `test_update`
- 🔨 [projects] Rename fixture `template2` to `template`
- 🔨 [projects] Inline function `updateproject2`
