### PR TITLE
🔨 [projects] Use `Template` in `creategitrepository` and `*commitmessage` helpers

### DIFF
--- a/src/cutty/projects/common.py
+++ b/src/cutty/projects/common.py
@@ -2,7 +2,7 @@
 from collections.abc import Callable
 from pathlib import Path
 
-from cutty.repositories.domain.repository import Repository as Template
+from cutty.services.loadtemplate import TemplateMetadata
 
 
 LATEST_BRANCH = "cutty/latest"
@@ -12,7 +12,7 @@ UPDATE_BRANCH = "cutty/update"
 GenerateProject = Callable[[Path], None]
 
 
-def createcommitmessage(template: Template) -> str:
+def createcommitmessage(template: TemplateMetadata) -> str:
     """Return the commit message for importing the template."""
     if template.revision:
         return f"Initial import from {template.name} {template.revision}"
@@ -20,7 +20,7 @@ def createcommitmessage(template: Template) -> str:
         return f"Initial import from {template.name}"
 
 
-def updatecommitmessage(template: Template) -> str:
+def updatecommitmessage(template: TemplateMetadata) -> str:
     """Return the commit message for updating the template."""
     if template.revision:
         return f"Update {template.name} to {template.revision}"
@@ -28,7 +28,7 @@ def updatecommitmessage(template: Template) -> str:
         return f"Update {template.name}"
 
 
-def linkcommitmessage(template: Template) -> str:
+def linkcommitmessage(template: TemplateMetadata) -> str:
     """Return the commit message for linking the template."""
     if template.revision:
         return f"Link to {template.name} {template.revision}"

--- a/src/cutty/projects/create.py
+++ b/src/cutty/projects/create.py
@@ -9,7 +9,7 @@ from cutty.services.loadtemplate import Template as Template2
 from cutty.util import git
 
 
-def creategitrepository2(projectdir: Path, template: Template2) -> None:
+def creategitrepository(projectdir: Path, template: Template2) -> None:
     """Initialize the git repository for a project."""
     try:
         project = git.Repository.open(projectdir)

--- a/src/cutty/projects/create.py
+++ b/src/cutty/projects/create.py
@@ -6,6 +6,7 @@ import pygit2
 from cutty.projects.common import createcommitmessage
 from cutty.projects.common import LATEST_BRANCH
 from cutty.repositories.domain.repository import Repository as Template
+from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util import git
 
 
@@ -16,5 +17,7 @@ def creategitrepository(projectdir: Path, template: Template) -> None:
     except pygit2.GitError:
         project = git.Repository.init(projectdir)
 
-    project.commit(message=createcommitmessage(template))
+    metadata = TemplateMetadata("", None, None, template.name, template.revision)
+
+    project.commit(message=createcommitmessage(metadata))
     project.heads[LATEST_BRANCH] = project.head.commit

--- a/src/cutty/projects/create.py
+++ b/src/cutty/projects/create.py
@@ -5,11 +5,11 @@ import pygit2
 
 from cutty.projects.common import createcommitmessage
 from cutty.projects.common import LATEST_BRANCH
-from cutty.services.loadtemplate import Template as Template2
+from cutty.services.loadtemplate import Template
 from cutty.util import git
 
 
-def creategitrepository(projectdir: Path, template: Template2) -> None:
+def creategitrepository(projectdir: Path, template: Template) -> None:
     """Initialize the git repository for a project."""
     try:
         project = git.Repository.open(projectdir)

--- a/src/cutty/projects/create.py
+++ b/src/cutty/projects/create.py
@@ -5,25 +5,16 @@ import pygit2
 
 from cutty.projects.common import createcommitmessage
 from cutty.projects.common import LATEST_BRANCH
-from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.loadtemplate import Template as Template2
-from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util import git
 
 
 def creategitrepository2(projectdir: Path, template: Template2) -> None:
-    """Initialize the git repository for a project."""
-    creategitrepository(projectdir, template.repository)
-
-
-def creategitrepository(projectdir: Path, template: Template) -> None:
     """Initialize the git repository for a project."""
     try:
         project = git.Repository.open(projectdir)
     except pygit2.GitError:
         project = git.Repository.init(projectdir)
 
-    metadata = TemplateMetadata("", None, None, template.name, template.revision)
-
-    project.commit(message=createcommitmessage(metadata))
+    project.commit(message=createcommitmessage(template.metadata))
     project.heads[LATEST_BRANCH] = project.head.commit

--- a/src/cutty/projects/create.py
+++ b/src/cutty/projects/create.py
@@ -6,8 +6,14 @@ import pygit2
 from cutty.projects.common import createcommitmessage
 from cutty.projects.common import LATEST_BRANCH
 from cutty.repositories.domain.repository import Repository as Template
+from cutty.services.loadtemplate import Template as Template2
 from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util import git
+
+
+def creategitrepository2(projectdir: Path, template: Template2) -> None:
+    """Initialize the git repository for a project."""
+    creategitrepository(projectdir, template.repository)
 
 
 def creategitrepository(projectdir: Path, template: Template) -> None:

--- a/src/cutty/projects/link.py
+++ b/src/cutty/projects/link.py
@@ -55,9 +55,9 @@ def linkproject(
     with project.worktree(update, checkout=False) as worktree:
         generateproject(worktree)
         message = (
-            createcommitmessage(template.repository)
+            createcommitmessage(template.metadata)
             if latest is None
-            else updatecommitmessage(template.repository)
+            else updatecommitmessage(template.metadata)
         )
         Repository.open(worktree).commit(message=message)
 
@@ -70,7 +70,7 @@ def linkproject(
     )
 
     project.commit(
-        message=linkcommitmessage(template.repository),
+        message=linkcommitmessage(template.metadata),
         author=update.commit.author,
         committer=project.default_signature,
     )

--- a/src/cutty/projects/update.py
+++ b/src/cutty/projects/update.py
@@ -20,9 +20,7 @@ def updateproject(
 
     with project.worktree(updatebranch, checkout=False) as worktree:
         generateproject(worktree)
-        Repository.open(worktree).commit(
-            message=updatecommitmessage(template.repository)
-        )
+        Repository.open(worktree).commit(message=updatecommitmessage(template.metadata))
 
     project.cherrypick(updatebranch.commit)
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -3,7 +3,7 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
-from cutty.projects.create import creategitrepository2
+from cutty.projects.create import creategitrepository
 from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
@@ -35,4 +35,4 @@ def createproject(
         createconfigfile=True,
     )
 
-    creategitrepository2(projectdir, template)
+    creategitrepository(projectdir, template)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,9 +4,6 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.projects.create import creategitrepository
-from cutty.services.generate import (  # noqa: F401
-    EmptyTemplateError as EmptyTemplateError,
-)
 from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -3,7 +3,7 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
-from cutty.projects.create import creategitrepository
+from cutty.projects.create import creategitrepository2
 from cutty.services.generate import generate
 from cutty.services.loadtemplate import loadtemplate
 from cutty.templates.domain.bindings import Binding
@@ -35,4 +35,4 @@ def createproject(
         createconfigfile=True,
     )
 
-    creategitrepository(projectdir, template.repository)
+    creategitrepository2(projectdir, template)

--- a/src/cutty/services/loadtemplate.py
+++ b/src/cutty/services/loadtemplate.py
@@ -8,7 +8,6 @@ import platformdirs
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
-from cutty.repositories.domain.repository import Repository
 from cutty.repositories.domain.revisions import Revision
 
 
@@ -29,11 +28,6 @@ class Template:
 
     metadata: TemplateMetadata
     root: Path
-
-    @property
-    def repository(self) -> Repository:
-        """Convert to a Repository instance."""
-        return Repository(self.metadata.name, self.root, self.metadata.revision)
 
 
 def loadtemplate(

--- a/src/cutty/services/loadtemplate.py
+++ b/src/cutty/services/loadtemplate.py
@@ -8,6 +8,7 @@ import platformdirs
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
+from cutty.repositories.domain.repository import Repository
 from cutty.repositories.domain.revisions import Revision
 
 
@@ -30,6 +31,18 @@ class Template:
     root: Path
 
 
+def _createtemplate(
+    template: str,
+    checkout: Optional[str],
+    directory: Optional[pathlib.PurePosixPath],
+    repository: Repository,
+) -> Template:
+    metadata = TemplateMetadata(
+        template, checkout, directory, repository.name, repository.revision
+    )
+    return Template(metadata, repository.path)
+
+
 def loadtemplate(
     template: str, checkout: Optional[str], directory: Optional[pathlib.PurePosixPath]
 ) -> Template:
@@ -41,7 +54,4 @@ def loadtemplate(
         revision=checkout,
         directory=(PurePath(*directory.parts) if directory is not None else None),
     )
-    metadata = TemplateMetadata(
-        template, checkout, directory, repository.name, repository.revision
-    )
-    return Template(metadata, repository.path)
+    return _createtemplate(template, checkout, directory, repository)

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -12,7 +12,6 @@ from cutty.filesystems.domain.path import Path as VirtualPath
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.create import creategitrepository2
-from cutty.repositories.domain.repository import Repository as Template
 from cutty.services.loadtemplate import Template as Template2
 from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
@@ -46,13 +45,6 @@ def project(
         storage.add(file)
 
     return projectpath
-
-
-@pytest.fixture
-def template() -> Template:
-    """Fixture for a `Template` instance."""
-    templatepath = VirtualPath(filesystem=DictFilesystem({}))
-    return Template("template", templatepath, None)
 
 
 @pytest.fixture

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -12,7 +12,7 @@ from cutty.filesystems.domain.path import Path as VirtualPath
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.create import creategitrepository2
-from cutty.services.loadtemplate import Template as Template2
+from cutty.services.loadtemplate import Template
 from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
 
@@ -48,22 +48,22 @@ def project(
 
 
 @pytest.fixture
-def template2() -> Template2:
+def template2() -> Template:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
     location = "https://example.com/template"
     metadata = TemplateMetadata(location, None, None, "template", None)
-    return Template2(metadata, templatepath)
+    return Template(metadata, templatepath)
 
 
-def test_repository(project: pathlib.Path, template2: Template2) -> None:
+def test_repository(project: pathlib.Path, template2: Template) -> None:
     """It creates a repository."""
     creategitrepository2(project, template2)
 
     Repository.open(project)  # does not raise
 
 
-def test_commit(project: pathlib.Path, template2: Template2) -> None:
+def test_commit(project: pathlib.Path, template2: Template) -> None:
     """It creates a commit."""
     creategitrepository2(project, template2)
 
@@ -71,7 +71,7 @@ def test_commit(project: pathlib.Path, template2: Template2) -> None:
     repository.head.commit  # does not raise
 
 
-def test_commit_message_template(project: pathlib.Path, template2: Template2) -> None:
+def test_commit_message_template(project: pathlib.Path, template2: Template) -> None:
     """It includes the template name in the commit message."""
     creategitrepository2(project, template2)
 
@@ -79,7 +79,7 @@ def test_commit_message_template(project: pathlib.Path, template2: Template2) ->
     assert template2.metadata.name in repository.head.commit.message
 
 
-def test_commit_message_revision(project: pathlib.Path, template2: Template2) -> None:
+def test_commit_message_revision(project: pathlib.Path, template2: Template) -> None:
     """It includes the revision in the commit message."""
     template2 = dataclasses.replace(
         template2, metadata=dataclasses.replace(template2.metadata, revision="1.0.0")
@@ -94,7 +94,7 @@ def test_existing_repository(
     storage: FileStorage,
     file: RegularFile,
     projectpath: pathlib.Path,
-    template2: Template2,
+    template2: Template,
 ) -> None:
     """It creates the commit in an existing repository."""
     repository = Repository.init(projectpath)
@@ -108,7 +108,7 @@ def test_existing_repository(
     assert file.path.name in repository.head.commit.tree
 
 
-def test_branch(project: pathlib.Path, template2: Template2) -> None:
+def test_branch(project: pathlib.Path, template2: Template) -> None:
     """It creates a branch pointing to the initial commit."""
     creategitrepository2(project, template2)
 
@@ -116,7 +116,7 @@ def test_branch(project: pathlib.Path, template2: Template2) -> None:
     assert repository.head.commit == repository.heads[LATEST_BRANCH]
 
 
-def test_branch_not_checked_out(project: pathlib.Path, template2: Template2) -> None:
+def test_branch_not_checked_out(project: pathlib.Path, template2: Template) -> None:
     """It does not check out the `latest` branch."""
     creategitrepository2(project, template2)
 

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -13,6 +13,8 @@ from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.create import creategitrepository
 from cutty.repositories.domain.repository import Repository as Template
+from cutty.services.loadtemplate import Template as Template2
+from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
 
 
@@ -51,6 +53,15 @@ def template() -> Template:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
     return Template("template", templatepath, None)
+
+
+@pytest.fixture
+def template2() -> Template2:
+    """Fixture for a `Template` instance."""
+    templatepath = VirtualPath(filesystem=DictFilesystem({}))
+    location = "https://example.com/template"
+    metadata = TemplateMetadata(location, None, None, "template", None)
+    return Template2(metadata, templatepath)
 
 
 def test_repository(project: pathlib.Path, template: Template) -> None:

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -11,7 +11,7 @@ from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path as VirtualPath
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.common import LATEST_BRANCH
-from cutty.projects.create import creategitrepository2
+from cutty.projects.create import creategitrepository
 from cutty.services.loadtemplate import Template
 from cutty.services.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
@@ -58,14 +58,14 @@ def template() -> Template:
 
 def test_repository(project: pathlib.Path, template: Template) -> None:
     """It creates a repository."""
-    creategitrepository2(project, template)
+    creategitrepository(project, template)
 
     Repository.open(project)  # does not raise
 
 
 def test_commit(project: pathlib.Path, template: Template) -> None:
     """It creates a commit."""
-    creategitrepository2(project, template)
+    creategitrepository(project, template)
 
     repository = Repository.open(project)
     repository.head.commit  # does not raise
@@ -73,7 +73,7 @@ def test_commit(project: pathlib.Path, template: Template) -> None:
 
 def test_commit_message_template(project: pathlib.Path, template: Template) -> None:
     """It includes the template name in the commit message."""
-    creategitrepository2(project, template)
+    creategitrepository(project, template)
 
     repository = Repository.open(project)
     assert template.metadata.name in repository.head.commit.message
@@ -84,7 +84,7 @@ def test_commit_message_revision(project: pathlib.Path, template: Template) -> N
     template = dataclasses.replace(
         template, metadata=dataclasses.replace(template.metadata, revision="1.0.0")
     )
-    creategitrepository2(project, template)
+    creategitrepository(project, template)
 
     repository = Repository.open(project)
     assert template.metadata.revision in repository.head.commit.message
@@ -103,14 +103,14 @@ def test_existing_repository(
     with storage:
         storage.add(file)
 
-    creategitrepository2(projectpath, template)
+    creategitrepository(projectpath, template)
 
     assert file.path.name in repository.head.commit.tree
 
 
 def test_branch(project: pathlib.Path, template: Template) -> None:
     """It creates a branch pointing to the initial commit."""
-    creategitrepository2(project, template)
+    creategitrepository(project, template)
 
     repository = Repository.open(project)
     assert repository.head.commit == repository.heads[LATEST_BRANCH]
@@ -118,7 +118,7 @@ def test_branch(project: pathlib.Path, template: Template) -> None:
 
 def test_branch_not_checked_out(project: pathlib.Path, template: Template) -> None:
     """It does not check out the `latest` branch."""
-    creategitrepository2(project, template)
+    creategitrepository(project, template)
 
     repository = Repository.open(project)
     assert repository.head.name != LATEST_BRANCH

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -48,7 +48,7 @@ def project(
 
 
 @pytest.fixture
-def template2() -> Template:
+def template() -> Template:
     """Fixture for a `Template` instance."""
     templatepath = VirtualPath(filesystem=DictFilesystem({}))
     location = "https://example.com/template"
@@ -56,45 +56,45 @@ def template2() -> Template:
     return Template(metadata, templatepath)
 
 
-def test_repository(project: pathlib.Path, template2: Template) -> None:
+def test_repository(project: pathlib.Path, template: Template) -> None:
     """It creates a repository."""
-    creategitrepository2(project, template2)
+    creategitrepository2(project, template)
 
     Repository.open(project)  # does not raise
 
 
-def test_commit(project: pathlib.Path, template2: Template) -> None:
+def test_commit(project: pathlib.Path, template: Template) -> None:
     """It creates a commit."""
-    creategitrepository2(project, template2)
+    creategitrepository2(project, template)
 
     repository = Repository.open(project)
     repository.head.commit  # does not raise
 
 
-def test_commit_message_template(project: pathlib.Path, template2: Template) -> None:
+def test_commit_message_template(project: pathlib.Path, template: Template) -> None:
     """It includes the template name in the commit message."""
-    creategitrepository2(project, template2)
+    creategitrepository2(project, template)
 
     repository = Repository.open(project)
-    assert template2.metadata.name in repository.head.commit.message
+    assert template.metadata.name in repository.head.commit.message
 
 
-def test_commit_message_revision(project: pathlib.Path, template2: Template) -> None:
+def test_commit_message_revision(project: pathlib.Path, template: Template) -> None:
     """It includes the revision in the commit message."""
-    template2 = dataclasses.replace(
-        template2, metadata=dataclasses.replace(template2.metadata, revision="1.0.0")
+    template = dataclasses.replace(
+        template, metadata=dataclasses.replace(template.metadata, revision="1.0.0")
     )
-    creategitrepository2(project, template2)
+    creategitrepository2(project, template)
 
     repository = Repository.open(project)
-    assert template2.metadata.revision in repository.head.commit.message
+    assert template.metadata.revision in repository.head.commit.message
 
 
 def test_existing_repository(
     storage: FileStorage,
     file: RegularFile,
     projectpath: pathlib.Path,
-    template2: Template,
+    template: Template,
 ) -> None:
     """It creates the commit in an existing repository."""
     repository = Repository.init(projectpath)
@@ -103,22 +103,22 @@ def test_existing_repository(
     with storage:
         storage.add(file)
 
-    creategitrepository2(projectpath, template2)
+    creategitrepository2(projectpath, template)
 
     assert file.path.name in repository.head.commit.tree
 
 
-def test_branch(project: pathlib.Path, template2: Template) -> None:
+def test_branch(project: pathlib.Path, template: Template) -> None:
     """It creates a branch pointing to the initial commit."""
-    creategitrepository2(project, template2)
+    creategitrepository2(project, template)
 
     repository = Repository.open(project)
     assert repository.head.commit == repository.heads[LATEST_BRANCH]
 
 
-def test_branch_not_checked_out(project: pathlib.Path, template2: Template) -> None:
+def test_branch_not_checked_out(project: pathlib.Path, template: Template) -> None:
     """It does not check out the `latest` branch."""
-    creategitrepository2(project, template2)
+    creategitrepository2(project, template)
 
     repository = Repository.open(project)
     assert repository.head.name != LATEST_BRANCH


### PR DESCRIPTION
- 🔨 [projects] Pass `TemplateMetadata` to `*commitmessage` functions
- 🔨 [projects] Extract function `creategitrepository2` using `Template`
- 🔥 [services] Remove unused import for `EmptyTemplateError`
- 🔨 [services] Replace `creategitrepository` with `creategitrepository2` in `createproject`
- 🔨 [projects] Add fixture `template2` in `test_create`
- 🔨 [projects] Replace `creategitrepository` with `creategitrepository2` in `test_create`
- 🔥 [projects] Remove fixture `template`
- 🔨 [projects] Rename import `Template2` in `test_create`
- 🔨 [projects] Rename fixture `template2`
- 🔨 [projects] Inline function `creategitrepository`
- 🔨 [projects] Rename function `creategitrepository2`
- 🔥 [services] Remove function `Template.repository`
- 🔨 [services] Extract function `_createtemplate`
- 🔨 [projects] Rename import `Template2` in `create`
