### PR TITLE
🔨 [services] Extract `cookiecutter.createproject` and minor refactorings

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,8 +6,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.projects.generate import generate
-from cutty.projects.loadtemplate import loadtemplate
+from cutty.services.cookiecutter import createproject
 from cutty.templates.domain.bindings import Binding
 
 
@@ -72,15 +71,14 @@ def cookiecutter(
         output_dir = Path.cwd()
 
     directory2 = PurePosixPath(directory) if directory is not None else None
-    template = loadtemplate(location, checkout, directory2)
 
-    generate(
-        template,
+    createproject(
+        location,
         output_dir,
         extrabindings=extrabindings,
         no_input=no_input,
+        checkout=checkout,
+        directory=directory2,
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,
-        outputdirisproject=False,
-        createconfigfile=False,
     )

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -1,0 +1,34 @@
+"""Create a project from a Cookiecutter template."""
+import pathlib
+from collections.abc import Sequence
+from typing import Optional
+
+from cutty.projects.generate import generate
+from cutty.projects.loadtemplate import loadtemplate
+from cutty.templates.domain.bindings import Binding
+
+
+def createproject(
+    location: str,
+    outputdir: pathlib.Path,
+    *,
+    extrabindings: Sequence[Binding],
+    no_input: bool,
+    checkout: Optional[str],
+    directory: Optional[pathlib.PurePosixPath],
+    overwrite_if_exists: bool,
+    skip_if_file_exists: bool,
+) -> None:
+    """Generate projects from Cookiecutter templates."""
+    template = loadtemplate(location, checkout, directory)
+
+    generate(
+        template,
+        outputdir,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        overwrite_if_exists=overwrite_if_exists,
+        skip_if_file_exists=skip_if_file_exists,
+        outputdirisproject=False,
+        createconfigfile=False,
+    )

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -40,11 +40,11 @@ def link(
     if location is None:
         raise TemplateNotSpecifiedError()
 
-    template2 = loadtemplate(location, checkout, directory)
+    template = loadtemplate(location, checkout, directory)
 
     def generateproject(outputdir: pathlib.Path) -> None:
         generate(
-            template2,
+            template,
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
@@ -54,4 +54,4 @@ def link(
             createconfigfile=True,
         )
 
-    linkproject(project, generateproject, template2.metadata)
+    linkproject(project, generateproject, template.metadata)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -18,7 +18,7 @@ class TemplateNotSpecifiedError(CuttyError):
 
 
 def link(
-    template: Optional[str],
+    location: Optional[str],
     projectdir: pathlib.Path,
     /,
     *,
@@ -34,13 +34,13 @@ def link(
         projectconfig = readcookiecutterjson(project.path)
         extrabindings = list(projectconfig.bindings) + list(extrabindings)
 
-        if template is None:
-            template = projectconfig.template
+        if location is None:
+            location = projectconfig.template
 
-    if template is None:
+    if location is None:
         raise TemplateNotSpecifiedError()
 
-    template2 = loadtemplate(template, checkout, directory)
+    template2 = loadtemplate(location, checkout, directory)
 
     def generateproject(outputdir: pathlib.Path) -> None:
         generate(

--- a/tests/unit/projects/conftest.py
+++ b/tests/unit/projects/conftest.py
@@ -3,42 +3,8 @@ import pathlib
 
 import pytest
 
-from cutty.filestorage.adapters.disk import DiskFileStorage
-from cutty.filestorage.domain.files import RegularFile
-from cutty.filestorage.domain.storage import FileStorage
-from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.common import GenerateProject
 from cutty.projects.loadtemplate import TemplateMetadata
-
-
-@pytest.fixture
-def projectpath(tmp_path: pathlib.Path) -> pathlib.Path:
-    """Fixture for a project path."""
-    return tmp_path / "project"
-
-
-@pytest.fixture
-def storage(projectpath: pathlib.Path) -> FileStorage:
-    """Fixture for a storage."""
-    return DiskFileStorage(projectpath.parent)
-
-
-@pytest.fixture
-def file(projectpath: pathlib.Path) -> RegularFile:
-    """Fixture for a regular file."""
-    path = PurePath(projectpath.name, "README.md")
-    return RegularFile(path, b"")
-
-
-@pytest.fixture
-def project(
-    storage: FileStorage, file: RegularFile, projectpath: pathlib.Path
-) -> pathlib.Path:
-    """Fixture for a project path."""
-    with storage:
-        storage.add(file)
-
-    return projectpath
 
 
 @pytest.fixture

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -2,12 +2,46 @@
 import dataclasses
 import pathlib
 
+import pytest
+
+from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.storage import FileStorage
+from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.common import LATEST_BRANCH
 from cutty.projects.create import creategitrepository
 from cutty.projects.loadtemplate import TemplateMetadata
 from cutty.util.git import Repository
+
+
+@pytest.fixture
+def projectpath(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Fixture for a project path."""
+    return tmp_path / "project"
+
+
+@pytest.fixture
+def storage(projectpath: pathlib.Path) -> FileStorage:
+    """Fixture for a storage."""
+    return DiskFileStorage(projectpath.parent)
+
+
+@pytest.fixture
+def file(projectpath: pathlib.Path) -> RegularFile:
+    """Fixture for a regular file."""
+    path = PurePath(projectpath.name, "README.md")
+    return RegularFile(path, b"")
+
+
+@pytest.fixture
+def project(
+    storage: FileStorage, file: RegularFile, projectpath: pathlib.Path
+) -> pathlib.Path:
+    """Fixture for a project path."""
+    with storage:
+        storage.add(file)
+
+    return projectpath
 
 
 def test_repository(project: pathlib.Path, template: TemplateMetadata) -> None:


### PR DESCRIPTION
- 🔨 [projects] Move fixtures from `conftest.py` to `test_create`
- 🔨 [services] Extract function `createproject` from `cookiecutter` CLI
- 🔨 [services] Rename parameter `template` to `location` in `link` service
- 🔨 [services] Rename variable `template2` in `link` service
