### PR TITLE
🔨 [projects] Move class `TemplateMetadata` to `Template.Metadata`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pygit2
 
 from cutty.projects.common import GenerateProject
-from cutty.projects.template import TemplateMetadata
+from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Branch
 from cutty.util.git import Repository
@@ -22,7 +22,7 @@ class ProjectRepository:
         self.project = Repository.open(path)
 
     @classmethod
-    def create(cls, projectdir: Path, template: TemplateMetadata) -> None:
+    def create(cls, projectdir: Path, template: Template.Metadata) -> None:
         """Initialize the git repository for a project."""
         try:
             project = Repository.open(projectdir)
@@ -35,7 +35,7 @@ class ProjectRepository:
     def link(
         self,
         generateproject: GenerateProject,
-        template: TemplateMetadata,
+        template: Template.Metadata,
     ) -> None:
         """Link a project to a project template."""
         if latest := self.project.heads.get(LATEST_BRANCH):
@@ -71,7 +71,7 @@ class ProjectRepository:
         self.project.heads[LATEST_BRANCH] = update.commit
 
     def update(
-        self, generateproject: GenerateProject, template: TemplateMetadata
+        self, generateproject: GenerateProject, template: Template.Metadata
     ) -> None:
         """Update a project by applying changes between the generated trees."""
         latestbranch = self.project.branch(LATEST_BRANCH)
@@ -137,7 +137,7 @@ def _squash_branch(repository: Repository, branch: Branch) -> None:
     )
 
 
-def _createcommitmessage(template: TemplateMetadata) -> str:
+def _createcommitmessage(template: Template.Metadata) -> str:
     """Return the commit message for importing the template."""
     if template.revision:
         return f"Initial import from {template.name} {template.revision}"
@@ -145,7 +145,7 @@ def _createcommitmessage(template: TemplateMetadata) -> str:
         return f"Initial import from {template.name}"
 
 
-def _updatecommitmessage(template: TemplateMetadata) -> str:
+def _updatecommitmessage(template: Template.Metadata) -> str:
     """Return the commit message for updating the template."""
     if template.revision:
         return f"Update {template.name} to {template.revision}"
@@ -153,7 +153,7 @@ def _updatecommitmessage(template: TemplateMetadata) -> str:
         return f"Update {template.name}"
 
 
-def _linkcommitmessage(template: TemplateMetadata) -> str:
+def _linkcommitmessage(template: Template.Metadata) -> str:
     """Return the commit message for linking the template."""
     if template.revision:
         return f"Link to {template.name} {template.revision}"

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -49,16 +49,13 @@ class Template:
         return _createtemplate(template, checkout, directory, repository)
 
 
-TemplateMetadata = Template.Metadata
-
-
 def _createtemplate(
     template: str,
     checkout: Optional[str],
     directory: Optional[pathlib.PurePosixPath],
     repository: Repository,
 ) -> Template:
-    metadata = TemplateMetadata(
+    metadata = Template.Metadata(
         template, checkout, directory, repository.name, repository.revision
     )
     return Template(metadata, repository.path)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -15,21 +15,20 @@ from cutty.repositories.domain.revisions import Revision
 
 
 @dataclass
-class TemplateMetadata:
-    """Metadata for a project template."""
-
-    location: str
-    checkout: Optional[str]
-    directory: Optional[pathlib.PurePosixPath]
-    name: str
-    revision: Optional[Revision]
-
-
-@dataclass
 class Template:
     """Project template."""
 
-    metadata: TemplateMetadata
+    @dataclass
+    class Metadata:
+        """Metadata for a project template."""
+
+        location: str
+        checkout: Optional[str]
+        directory: Optional[pathlib.PurePosixPath]
+        name: str
+        revision: Optional[Revision]
+
+    metadata: Metadata
     root: Path
 
     @classmethod
@@ -48,6 +47,9 @@ class Template:
             directory=(PurePath(*directory.parts) if directory is not None else None),
         )
         return _createtemplate(template, checkout, directory, repository)
+
+
+TemplateMetadata = Template.Metadata
 
 
 def _createtemplate(

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -10,7 +10,6 @@ import platformdirs
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.repositories.adapters.storage import getdefaultrepositoryprovider
-from cutty.repositories.domain.repository import Repository
 from cutty.repositories.domain.revisions import Revision
 
 
@@ -46,16 +45,8 @@ class Template:
             revision=checkout,
             directory=(PurePath(*directory.parts) if directory is not None else None),
         )
-        return _createtemplate(template, checkout, directory, repository)
 
-
-def _createtemplate(
-    template: str,
-    checkout: Optional[str],
-    directory: Optional[pathlib.PurePosixPath],
-    repository: Repository,
-) -> Template:
-    metadata = Template.Metadata(
-        template, checkout, directory, repository.name, repository.revision
-    )
-    return Template(metadata, repository.path)
+        metadata = cls.Metadata(
+            template, checkout, directory, repository.name, repository.revision
+        )
+        return cls(metadata, repository.path)

--- a/tests/unit/projects/conftest.py
+++ b/tests/unit/projects/conftest.py
@@ -4,14 +4,14 @@ import pathlib
 import pytest
 
 from cutty.projects.common import GenerateProject
-from cutty.projects.template import TemplateMetadata
+from cutty.projects.template import Template
 
 
 @pytest.fixture
-def template() -> TemplateMetadata:
+def template() -> Template.Metadata:
     """Fixture for a `Template` instance."""
     location = "https://example.com/template"
-    return TemplateMetadata(location, None, None, "template", None)
+    return Template.Metadata(location, None, None, "template", None)
 
 
 @pytest.fixture

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -10,11 +10,11 @@ from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.template import TemplateMetadata
+from cutty.projects.template import Template
 from cutty.util.git import Repository
 
 
-def creategitrepository(projectdir: pathlib.Path, template: TemplateMetadata) -> None:
+def creategitrepository(projectdir: pathlib.Path, template: Template.Metadata) -> None:
     """Initialize the git repository for a project."""
     ProjectRepository.create(projectdir, template)
 
@@ -49,14 +49,14 @@ def project(
     return projectpath
 
 
-def test_repository(project: pathlib.Path, template: TemplateMetadata) -> None:
+def test_repository(project: pathlib.Path, template: Template.Metadata) -> None:
     """It creates a repository."""
     creategitrepository(project, template)
 
     Repository.open(project)  # does not raise
 
 
-def test_commit(project: pathlib.Path, template: TemplateMetadata) -> None:
+def test_commit(project: pathlib.Path, template: Template.Metadata) -> None:
     """It creates a commit."""
     creategitrepository(project, template)
 
@@ -65,7 +65,7 @@ def test_commit(project: pathlib.Path, template: TemplateMetadata) -> None:
 
 
 def test_commit_message_template(
-    project: pathlib.Path, template: TemplateMetadata
+    project: pathlib.Path, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
     creategitrepository(project, template)
@@ -75,7 +75,7 @@ def test_commit_message_template(
 
 
 def test_commit_message_revision(
-    project: pathlib.Path, template: TemplateMetadata
+    project: pathlib.Path, template: Template.Metadata
 ) -> None:
     """It includes the revision in the commit message."""
     template = dataclasses.replace(template, revision="1.0.0")
@@ -89,7 +89,7 @@ def test_existing_repository(
     storage: FileStorage,
     file: RegularFile,
     projectpath: pathlib.Path,
-    template: TemplateMetadata,
+    template: Template.Metadata,
 ) -> None:
     """It creates the commit in an existing repository."""
     repository = Repository.init(projectpath)
@@ -103,7 +103,7 @@ def test_existing_repository(
     assert file.path.name in repository.head.commit.tree
 
 
-def test_branch(project: pathlib.Path, template: TemplateMetadata) -> None:
+def test_branch(project: pathlib.Path, template: Template.Metadata) -> None:
     """It creates a branch pointing to the initial commit."""
     creategitrepository(project, template)
 
@@ -112,7 +112,7 @@ def test_branch(project: pathlib.Path, template: TemplateMetadata) -> None:
 
 
 def test_branch_not_checked_out(
-    project: pathlib.Path, template: TemplateMetadata
+    project: pathlib.Path, template: Template.Metadata
 ) -> None:
     """It does not check out the `latest` branch."""
     creategitrepository(project, template)

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -7,7 +7,7 @@ from cutty.projects.common import GenerateProject
 from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.repository import UPDATE_BRANCH
-from cutty.projects.template import TemplateMetadata
+from cutty.projects.template import Template
 from cutty.util.git import Repository
 from tests.util.git import updatefile
 
@@ -18,7 +18,7 @@ pytest_plugins = ["tests.fixtures.git"]
 def linkproject(
     project: Repository,
     generateproject: GenerateProject,
-    template: TemplateMetadata,
+    template: Template.Metadata,
 ) -> None:
     """Link a project to a project template."""
     repository = ProjectRepository(project.path)
@@ -32,7 +32,7 @@ def project(repository: Repository) -> Repository:
 
 
 def test_linkproject_commit(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
@@ -43,7 +43,7 @@ def test_linkproject_commit(
 
 
 def test_linkproject_commit_message(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It uses a commit message indicating the linkage."""
     linkproject(project, generateproject, template)
@@ -54,7 +54,7 @@ def test_linkproject_commit_message(
 def test_linkproject_commit_message_template(
     project: Repository,
     generateproject: GenerateProject,
-    template: TemplateMetadata,
+    template: Template.Metadata,
 ) -> None:
     """It includes the template name in the commit message."""
     linkproject(project, generateproject, template)
@@ -63,7 +63,7 @@ def test_linkproject_commit_message_template(
 
 
 def test_linkproject_commit_message_revision(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
     template = dataclasses.replace(template, revision="1.0.0")
@@ -74,7 +74,7 @@ def test_linkproject_commit_message_revision(
 
 
 def test_linkproject_latest_branch(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It creates the latest branch."""
     updatefile(project.path / "initial")
@@ -85,7 +85,7 @@ def test_linkproject_latest_branch(
 
 
 def test_linkproject_latest_branch_commit_message(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It uses a commit message indicating an initial import."""
     updatefile(project.path / "initial")
@@ -96,7 +96,7 @@ def test_linkproject_latest_branch_commit_message(
 
 
 def test_linkproject_latest_branch_commit_message_update(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It uses a commit message indicating an update if the branch exists."""
     project.heads.create(LATEST_BRANCH)
@@ -109,7 +109,7 @@ def test_linkproject_latest_branch_commit_message_update(
 
 
 def test_linkproject_update_branch(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It creates the update branch."""
     updatefile(project.path / "initial")

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -8,7 +8,7 @@ from cutty.projects.common import GenerateProject
 from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.repository import UPDATE_BRANCH
-from cutty.projects.template import TemplateMetadata
+from cutty.projects.template import Template
 from cutty.util.git import Repository
 from tests.util.git import createbranches
 from tests.util.git import resolveconflicts
@@ -20,7 +20,7 @@ pytest_plugins = ["tests.fixtures.git"]
 
 
 def updateproject(
-    projectdir: Path, generateproject: GenerateProject, template: TemplateMetadata
+    projectdir: Path, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
@@ -148,7 +148,7 @@ def project(repository: Repository) -> Repository:
 
 
 def test_updateproject_commit(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
@@ -159,7 +159,7 @@ def test_updateproject_commit(
 
 
 def test_updateproject_commit_message(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It uses a commit message indicating an update."""
     updateproject(project.path, generateproject, template)
@@ -168,7 +168,7 @@ def test_updateproject_commit_message(
 
 
 def test_updateproject_commit_message_template(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
     updateproject(project.path, generateproject, template)
@@ -177,7 +177,7 @@ def test_updateproject_commit_message_template(
 
 
 def test_updateproject_commit_message_revision(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
     template = dataclasses.replace(template, revision="1.0.0")
@@ -188,7 +188,7 @@ def test_updateproject_commit_message_revision(
 
 
 def test_updateproject_latest_branch(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It updates the latest branch."""
     updatefile(project.path / "initial")
@@ -201,7 +201,7 @@ def test_updateproject_latest_branch(
 
 
 def test_updateproject_update_branch(
-    project: Repository, generateproject: GenerateProject, template: TemplateMetadata
+    project: Repository, generateproject: GenerateProject, template: Template.Metadata
 ) -> None:
     """It creates the update branch."""
     updateproject(project.path, generateproject, template)
@@ -210,7 +210,7 @@ def test_updateproject_update_branch(
 
 
 def test_updateproject_no_changes(
-    project: Repository, template: TemplateMetadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It does not create an empty commit."""
     tip = project.head.commit


### PR DESCRIPTION
- 🔨 [projects] Move class `TemplateMetadata` to `Template.Metadata`
- 🔨 [projects] Inline type alias `TemplateMetadata`
- 🔨 [projects] Inline function `_createtemplate`
