### PR TITLE
🔨 [util] Return `git.Repository` from `git.Repository.worktree`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -45,7 +45,7 @@ class ProjectRepository:
             # empty placeholder commit instead. We'll squash it after project creation.
             update = _create_orphan_branch(self.project, UPDATE_BRANCH)
 
-        with self.project.worktree2(update, checkout=False) as worktree:
+        with self.project.worktree(update, checkout=False) as worktree:
             generateproject(worktree.path)
             message = (
                 _createcommitmessage(template)
@@ -79,7 +79,7 @@ class ProjectRepository:
             UPDATE_BRANCH, latestbranch.commit, force=True
         )
 
-        with self.project.worktree2(updatebranch, checkout=False) as worktree:
+        with self.project.worktree(updatebranch, checkout=False) as worktree:
             generateproject(worktree.path)
             worktree.commit(message=_updatecommitmessage(template))
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -45,14 +45,14 @@ class ProjectRepository:
             # empty placeholder commit instead. We'll squash it after project creation.
             update = _create_orphan_branch(self.project, UPDATE_BRANCH)
 
-        with self.project.worktree(update, checkout=False) as worktree:
-            generateproject(worktree)
+        with self.project.worktree2(update, checkout=False) as worktree:
+            generateproject(worktree.path)
             message = (
                 _createcommitmessage(template)
                 if latest is None
                 else _updatecommitmessage(template)
             )
-            Repository.open(worktree).commit(message=message)
+            worktree.commit(message=message)
 
         if latest is None:
             # Squash the empty initial commit.
@@ -79,9 +79,9 @@ class ProjectRepository:
             UPDATE_BRANCH, latestbranch.commit, force=True
         )
 
-        with self.project.worktree(updatebranch, checkout=False) as worktree:
-            generateproject(worktree)
-            Repository.open(worktree).commit(message=_updatecommitmessage(template))
+        with self.project.worktree2(updatebranch, checkout=False) as worktree:
+            generateproject(worktree.path)
+            worktree.commit(message=_updatecommitmessage(template))
 
         self.project.cherrypick(updatebranch.commit)
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -218,12 +218,6 @@ class Repository:
         self, branch: Branch, *, checkout: bool = True
     ) -> Iterator[Repository]:
         """Create a worktree for the branch in the repository."""
-        with self.worktree(branch, checkout=checkout) as path:
-            yield self.open(path)
-
-    @contextmanager
-    def worktree(self, branch: Branch, *, checkout: bool = True) -> Iterator[Path]:
-        """Create a worktree for the branch in the repository."""
 
         def _hash(name: str) -> str:
             return hashlib.blake2b(name.encode(), digest_size=32).hexdigest()
@@ -240,7 +234,7 @@ class Repository:
                     # https://github.com/libgit2/libgit2/issues/5949
                     Repository.open(path)._checkoutemptytree()
 
-                yield path
+                yield self.open(path)
         finally:
             # Prune with `force=True` to work around libgit2 issue.
             # https://github.com/libgit2/libgit2/issues/5280

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -229,12 +229,14 @@ class Repository:
                     path.name, path, self._repository.branches[branch.name]
                 )
 
+                repository = Repository.open(path)
+
                 if not checkout:
                     # Emulate `--no-checkout` by checking out an empty tree.
                     # https://github.com/libgit2/libgit2/issues/5949
-                    Repository.open(path)._checkoutemptytree()
+                    repository._checkoutemptytree()
 
-                yield self.open(path)
+                yield repository
         finally:
             # Prune with `force=True` to work around libgit2 issue.
             # https://github.com/libgit2/libgit2/issues/5280

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -214,6 +214,14 @@ class Repository:
         repository.state_cleanup()
 
     @contextmanager
+    def worktree2(
+        self, branch: Branch, *, checkout: bool = True
+    ) -> Iterator[Repository]:
+        """Create a worktree for the branch in the repository."""
+        with self.worktree(branch, checkout=checkout) as path:
+            yield self.open(path)
+
+    @contextmanager
     def worktree(self, branch: Branch, *, checkout: bool = True) -> Iterator[Path]:
         """Create a worktree for the branch in the repository."""
 

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -214,7 +214,7 @@ class Repository:
         repository.state_cleanup()
 
     @contextmanager
-    def worktree2(
+    def worktree(
         self, branch: Branch, *, checkout: bool = True
     ) -> Iterator[Repository]:
         """Create a worktree for the branch in the repository."""

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -308,18 +308,18 @@ def test_worktree_creates_worktree(repository: Repository) -> None:
     """It creates a worktree."""
     branch = repository.heads.create("branch")
 
-    with repository.worktree(branch) as worktree:
-        assert (worktree / ".git").is_file()
+    with repository.worktree2(branch) as worktree:
+        assert (worktree.path / ".git").is_file()
 
 
 def test_worktree_removes_worktree_on_exit(repository: Repository) -> None:
     """It removes the worktree on exit."""
     branch = repository.heads.create("branch")
 
-    with repository.worktree(branch) as worktree:
+    with repository.worktree2(branch) as worktree:
         pass
 
-    assert not worktree.is_dir()
+    assert not worktree.path.is_dir()
 
 
 def test_worktree_prunes_worktree_on_failure(repository: Repository) -> None:
@@ -327,10 +327,10 @@ def test_worktree_prunes_worktree_on_failure(repository: Repository) -> None:
     branch = repository.heads.create("branch")
 
     with pytest.raises(Exception, match="Boom"):
-        with repository.worktree(branch) as worktree:
+        with repository.worktree2(branch) as worktree:
             raise Exception("Boom")
 
-    privatedir = repository.path / ".git" / "worktrees" / worktree.name
+    privatedir = repository.path / ".git" / "worktrees" / worktree.path.name
     assert not privatedir.exists()
 
 
@@ -339,8 +339,8 @@ def test_worktree_does_checkout(repository: Repository, path: Path) -> None:
     updatefile(path)
     branch = repository.heads.create("branch")
 
-    with repository.worktree(branch) as worktree:
-        assert (worktree / path.name).is_file()
+    with repository.worktree2(branch) as worktree:
+        assert (worktree.path / path.name).is_file()
 
 
 def test_worktree_no_checkout(repository: Repository, path: Path) -> None:
@@ -348,8 +348,8 @@ def test_worktree_no_checkout(repository: Repository, path: Path) -> None:
     updatefile(path)
     branch = repository.heads.create("branch")
 
-    with repository.worktree(branch, checkout=False) as worktree:
-        assert not (worktree / path.name).is_file()
+    with repository.worktree2(branch, checkout=False) as worktree:
+        assert not (worktree.path / path.name).is_file()
 
 
 def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -308,7 +308,7 @@ def test_worktree_creates_worktree(repository: Repository) -> None:
     """It creates a worktree."""
     branch = repository.heads.create("branch")
 
-    with repository.worktree2(branch) as worktree:
+    with repository.worktree(branch) as worktree:
         assert (worktree.path / ".git").is_file()
 
 
@@ -316,7 +316,7 @@ def test_worktree_removes_worktree_on_exit(repository: Repository) -> None:
     """It removes the worktree on exit."""
     branch = repository.heads.create("branch")
 
-    with repository.worktree2(branch) as worktree:
+    with repository.worktree(branch) as worktree:
         pass
 
     assert not worktree.path.is_dir()
@@ -327,7 +327,7 @@ def test_worktree_prunes_worktree_on_failure(repository: Repository) -> None:
     branch = repository.heads.create("branch")
 
     with pytest.raises(Exception, match="Boom"):
-        with repository.worktree2(branch) as worktree:
+        with repository.worktree(branch) as worktree:
             raise Exception("Boom")
 
     privatedir = repository.path / ".git" / "worktrees" / worktree.path.name
@@ -339,7 +339,7 @@ def test_worktree_does_checkout(repository: Repository, path: Path) -> None:
     updatefile(path)
     branch = repository.heads.create("branch")
 
-    with repository.worktree2(branch) as worktree:
+    with repository.worktree(branch) as worktree:
         assert (worktree.path / path.name).is_file()
 
 
@@ -348,7 +348,7 @@ def test_worktree_no_checkout(repository: Repository, path: Path) -> None:
     updatefile(path)
     branch = repository.heads.create("branch")
 
-    with repository.worktree2(branch, checkout=False) as worktree:
+    with repository.worktree(branch, checkout=False) as worktree:
         assert not (worktree.path / path.name).is_file()
 
 


### PR DESCRIPTION
- 🔨 [util] Add function `git.Repository.worktree2`
- 🔨 [util] Replace `worktree` with `worktree2` in `test_git`
- 🔨 [projects] Replace `git.Repository.worktree` with `git.Repository.worktree2`
- 🔨 [util] Inline function `git.Repository.worktree`
- 🔨 [projects] Rename function `git.Repository.worktree2`
- 🔨 [util] Extract variable `repository` in `git.Repository.worktree`
