### PR TITLE
🐛 [util] Fix `UnboundLocalError` in `git.Repository.worktree` when worktree cannot be created

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -222,6 +222,8 @@ class Repository:
         def _hash(name: str) -> str:
             return hashlib.blake2b(name.encode(), digest_size=32).hexdigest()
 
+        worktree = None
+
         try:
             with tempfile.TemporaryDirectory() as directory:
                 path = Path(directory) / _hash(branch.name)
@@ -238,9 +240,10 @@ class Repository:
 
                 yield repository
         finally:
-            # Prune with `force=True` to work around libgit2 issue.
-            # https://github.com/libgit2/libgit2/issues/5280
-            worktree.prune(True)
+            if worktree is not None:
+                # Prune with `force=True` to work around libgit2 issue.
+                # https://github.com/libgit2/libgit2/issues/5280
+                worktree.prune(True)
 
     def _checkoutemptytree(self) -> None:
         """Check out an empty tree from the repository."""

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -352,6 +352,23 @@ def test_worktree_no_checkout(repository: Repository, path: Path) -> None:
         assert not (worktree.path / path.name).is_file()
 
 
+def test_worktree_tempfile_failure(
+    repository: Repository, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It does not crash when `tempfile` fails."""
+    import tempfile
+
+    def raise_() -> None:
+        raise Exception("boom")
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", raise_)
+    branch = repository.heads.create("branch")
+
+    with pytest.raises(Exception, match="boom"):
+        with repository.worktree(branch, checkout=False):
+            pass
+
+
 def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:
     """It cherry-picks the commit onto the current branch."""
     main = repository.head


### PR DESCRIPTION
- ✅ [util] Add test for `tempfile.TemporaryDirectory` failure in `git.Repository.worktree`
- :bug: [util] Fix `UnboundLocalError` in `git.Repository.worktree` when worktree cannot be created
