### PR TITLE
🔨 [services] Pass `FileExistsPolicy` to services

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,8 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
-from cutty.services.cookiecutter import createproject
+from cutty.projects.generate import fileexistspolicy
+from cutty.services.cookiecutter import createproject2
 from cutty.templates.domain.bindings import Binding
 
 
@@ -71,14 +72,14 @@ def cookiecutter(
         output_dir = Path.cwd()
 
     directory2 = PurePosixPath(directory) if directory is not None else None
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
 
-    createproject(
+    createproject2(
         location,
         output_dir,
         extrabindings=extrabindings,
         no_input=no_input,
         checkout=checkout,
         directory=directory2,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
+        fileexists=fileexists,
     )

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import click
 
-from cutty.projects.generate import fileexistspolicy
+from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.services.cookiecutter import createproject
 from cutty.templates.domain.bindings import Binding
 
@@ -28,6 +28,19 @@ def extra_context_callback(
                 )
 
     return dict(_generate())
+
+
+def fileexistspolicy(
+    overwrite_if_exists: bool, skip_if_file_exists: bool
+) -> FileExistsPolicy:
+    """Return the policy for overwriting existing files."""
+    return (
+        FileExistsPolicy.RAISE
+        if not overwrite_if_exists
+        else FileExistsPolicy.SKIP
+        if skip_if_file_exists
+        else FileExistsPolicy.OVERWRITE
+    )
 
 
 @click.argument("location", metavar="TEMPLATE")

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -7,7 +7,7 @@ import click
 
 from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.projects.generate import fileexistspolicy
-from cutty.services.cookiecutter import createproject2
+from cutty.services.cookiecutter import createproject
 from cutty.templates.domain.bindings import Binding
 
 
@@ -74,7 +74,7 @@ def cookiecutter(
     directory2 = PurePosixPath(directory) if directory is not None else None
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
 
-    createproject2(
+    createproject(
         location,
         output_dir,
         extrabindings=extrabindings,

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -1,14 +1,33 @@
 """Command-line interface for creating projects from Cookiecutter templates."""
+from collections.abc import Iterator
 from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
 
 import click
 
-from cutty.entrypoints.cli.create import extra_context_callback
 from cutty.projects.generate import fileexistspolicy
 from cutty.services.cookiecutter import createproject
 from cutty.templates.domain.bindings import Binding
+
+
+def extra_context_callback(
+    context: click.Context, parameter: click.Parameter, args: tuple[str, ...]
+) -> dict[str, str]:
+    """Callback for the EXTRA_CONTEXT argument."""
+
+    def _generate() -> Iterator[tuple[str, str]]:
+        for arg in args:
+            try:
+                key, value = arg.split("=", 1)
+                yield key, value
+            except ValueError:
+                raise click.BadParameter(
+                    "EXTRA_CONTEXT should contain items of the form key=value; "
+                    f"'{arg}' doesn't match that form"
+                )
+
+    return dict(_generate())
 
 
 @click.argument("location", metavar="TEMPLATE")

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.projects.generate import fileexistspolicy
-from cutty.services.create import createproject2
+from cutty.services.create import createproject
 from cutty.templates.domain.bindings import Binding
 
 
@@ -100,7 +100,7 @@ def create(
     directory2 = pathlib.PurePosixPath(directory) if directory is not None else None
 
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
-    createproject2(
+    createproject(
         template,
         output_dir,
         extrabindings=extrabindings,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 import click
 
-from cutty.services.create import createproject
+from cutty.projects.generate import fileexistspolicy
+from cutty.services.create import createproject2
 from cutty.templates.domain.bindings import Binding
 
 
@@ -98,14 +99,14 @@ def create(
 
     directory2 = pathlib.PurePosixPath(directory) if directory is not None else None
 
-    createproject(
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    createproject2(
         template,
         output_dir,
         extrabindings=extrabindings,
         no_input=no_input,
         checkout=checkout,
         directory=directory2,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
+        fileexists=fileexists,
         in_place=in_place,
     )

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.cookiecutter import extra_context_callback
-from cutty.projects.generate import fileexistspolicy
+from cutty.entrypoints.cli.cookiecutter import fileexistspolicy
 from cutty.services.create import createproject
 from cutty.templates.domain.bindings import Binding
 

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -1,32 +1,13 @@
 """Command-line interface for creating projects from Cookiecutter templates."""
 import pathlib
-from typing import Iterator
 from typing import Optional
 
 import click
 
+from cutty.entrypoints.cli.cookiecutter import extra_context_callback
 from cutty.projects.generate import fileexistspolicy
 from cutty.services.create import createproject
 from cutty.templates.domain.bindings import Binding
-
-
-def extra_context_callback(
-    context: click.Context, parameter: click.Parameter, args: tuple[str, ...]
-) -> dict[str, str]:
-    """Callback for the EXTRA_CONTEXT argument."""
-
-    def _generate() -> Iterator[tuple[str, str]]:
-        for arg in args:
-            try:
-                key, value = arg.split("=", 1)
-                yield key, value
-            except ValueError:
-                raise click.BadParameter(
-                    "EXTRA_CONTEXT should contain items of the form key=value; "
-                    f"'{arg}' doesn't match that form"
-                )
-
-    return dict(_generate())
 
 
 @click.argument("template")

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import click
 
-from cutty.entrypoints.cli.create import extra_context_callback
+from cutty.entrypoints.cli.cookiecutter import extra_context_callback
 from cutty.services.link import link as service_link
 from cutty.templates.domain.bindings import Binding
 

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import click
 
-from cutty.entrypoints.cli.create import extra_context_callback
+from cutty.entrypoints.cli.cookiecutter import extra_context_callback
 from cutty.projects.repository import ProjectRepository
 from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -23,18 +23,6 @@ def fileexistspolicy(
     )
 
 
-def createcookiecutterstorage(
-    outputdir: pathlib.Path,
-    projectdir: pathlib.Path,
-    overwrite_if_exists: bool,
-    skip_if_file_exists: bool,
-    hookfiles: Iterable[File],
-) -> FileStorage:
-    """Create storage for Cookiecutter project files."""
-    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
-    return createcookiecutterstorage2(outputdir, projectdir, fileexists, hookfiles)
-
-
 def createcookiecutterstorage2(
     outputdir: pathlib.Path,
     projectdir: pathlib.Path,

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -32,6 +32,16 @@ def createcookiecutterstorage(
 ) -> FileStorage:
     """Create storage for Cookiecutter project files."""
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    return createcookiecutterstorage2(outputdir, projectdir, fileexists, hookfiles)
+
+
+def createcookiecutterstorage2(
+    outputdir: pathlib.Path,
+    projectdir: pathlib.Path,
+    fileexists: FileExistsPolicy,
+    hookfiles: Iterable[File],
+) -> FileStorage:
+    """Create storage for Cookiecutter project files."""
     storage: FileStorage = DiskFileStorage(outputdir, fileexists=fileexists)
 
     if hookfiles:  # pragma: no branch

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -10,19 +10,6 @@ from cutty.filestorage.domain.observers import observe
 from cutty.filestorage.domain.storage import FileStorage
 
 
-def fileexistspolicy(
-    overwrite_if_exists: bool, skip_if_file_exists: bool
-) -> FileExistsPolicy:
-    """Return the policy for overwriting existing files."""
-    return (
-        FileExistsPolicy.RAISE
-        if not overwrite_if_exists
-        else FileExistsPolicy.SKIP
-        if skip_if_file_exists
-        else FileExistsPolicy.OVERWRITE
-    )
-
-
 def createcookiecutterstorage(
     outputdir: pathlib.Path,
     projectdir: pathlib.Path,

--- a/src/cutty/filestorage/adapters/cookiecutter.py
+++ b/src/cutty/filestorage/adapters/cookiecutter.py
@@ -23,7 +23,7 @@ def fileexistspolicy(
     )
 
 
-def createcookiecutterstorage2(
+def createcookiecutterstorage(
     outputdir: pathlib.Path,
     projectdir: pathlib.Path,
     fileexists: FileExistsPolicy,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -39,6 +39,29 @@ def generate(
     createconfigfile: bool,
 ) -> pathlib.Path:
     """Generate a project from a project template."""
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    return generate2(
+        template,
+        outputdir,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        fileexists=fileexists,
+        outputdirisproject=outputdirisproject,
+        createconfigfile=createconfigfile,
+    )
+
+
+def generate2(
+    template: Template,
+    outputdir: pathlib.Path,
+    *,
+    extrabindings: Sequence[Binding],
+    no_input: bool,
+    fileexists: FileExistsPolicy,
+    outputdirisproject: bool,
+    createconfigfile: bool,
+) -> pathlib.Path:
+    """Generate a project from a project template."""
     config = loadcookiecutterconfig(template.metadata.location, template.root)
     render = createcookiecutterrenderer(template.root, config)
     bindings = bindcookiecuttervariables(
@@ -66,7 +89,6 @@ def generate(
         projectfiles2 = itertools.chain(projectfiles2, [projectconfigfile])
 
     hookfiles = renderfiles(findcookiecutterhooks(template.root), render, bindings)
-    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
 
     return storeproject(
         projectname,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -8,7 +8,7 @@ from lazysequence import lazysequence
 
 from cutty.errors import CuttyError
 from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
-from cutty.filestorage.adapters.cookiecutter import fileexistspolicy
+from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.filestorage.domain.files import File
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.template import Template
@@ -75,6 +75,19 @@ def generate(
         outputdirisproject,
         overwrite_if_exists,
         skip_if_file_exists,
+    )
+
+
+def fileexistspolicy(
+    overwrite_if_exists: bool, skip_if_file_exists: bool
+) -> FileExistsPolicy:
+    """Return the policy for overwriting existing files."""
+    return (
+        FileExistsPolicy.RAISE
+        if not overwrite_if_exists
+        else FileExistsPolicy.SKIP
+        if skip_if_file_exists
+        else FileExistsPolicy.OVERWRITE
     )
 
 

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -27,7 +27,7 @@ class EmptyTemplateError(CuttyError):
     """The template contains no project files."""
 
 
-def generate2(
+def generate(
     template: Template,
     outputdir: pathlib.Path,
     *,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from lazysequence import lazysequence
 
 from cutty.errors import CuttyError
-from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage2
+from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filestorage.adapters.cookiecutter import fileexistspolicy
 from cutty.filestorage.domain.files import File
 from cutty.filesystems.domain.purepath import PurePath
@@ -90,7 +90,7 @@ def storeproject(
     """Store a project in the output directory."""
     projectdir = outputdir if outputdirisproject else outputdir / projectname
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
-    storage = createcookiecutterstorage2(outputdir, projectdir, fileexists, hookfiles)
+    storage = createcookiecutterstorage(outputdir, projectdir, fileexists, hookfiles)
 
     with storage:
         for projectfile in projectfiles:

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -7,7 +7,8 @@ from collections.abc import Sequence
 from lazysequence import lazysequence
 
 from cutty.errors import CuttyError
-from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
+from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage2
+from cutty.filestorage.adapters.cookiecutter import fileexistspolicy
 from cutty.filestorage.domain.files import File
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.template import Template
@@ -88,9 +89,8 @@ def storeproject(
 ) -> pathlib.Path:
     """Store a project in the output directory."""
     projectdir = outputdir if outputdirisproject else outputdir / projectname
-    storage = createcookiecutterstorage(
-        outputdir, projectdir, overwrite_if_exists, skip_if_file_exists, hookfiles
-    )
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    storage = createcookiecutterstorage2(outputdir, projectdir, fileexists, hookfiles)
 
     with storage:
         for projectfile in projectfiles:

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -66,6 +66,7 @@ def generate(
         projectfiles2 = itertools.chain(projectfiles2, [projectconfigfile])
 
     hookfiles = renderfiles(findcookiecutterhooks(template.root), render, bindings)
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
 
     return storeproject(
         projectname,
@@ -73,8 +74,7 @@ def generate(
         hookfiles,
         outputdir,
         outputdirisproject,
-        overwrite_if_exists,
-        skip_if_file_exists,
+        fileexists,
     )
 
 
@@ -97,12 +97,10 @@ def storeproject(
     hookfiles: Iterable[File],
     outputdir: pathlib.Path,
     outputdirisproject: bool,
-    overwrite_if_exists: bool,
-    skip_if_file_exists: bool,
+    fileexists: FileExistsPolicy,
 ) -> pathlib.Path:
     """Store a project in the output directory."""
     projectdir = outputdir if outputdirisproject else outputdir / projectname
-    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     storage = createcookiecutterstorage(outputdir, projectdir, fileexists, hookfiles)
 
     with storage:

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -76,19 +76,6 @@ def generate(
     )
 
 
-def fileexistspolicy(
-    overwrite_if_exists: bool, skip_if_file_exists: bool
-) -> FileExistsPolicy:
-    """Return the policy for overwriting existing files."""
-    return (
-        FileExistsPolicy.RAISE
-        if not overwrite_if_exists
-        else FileExistsPolicy.SKIP
-        if skip_if_file_exists
-        else FileExistsPolicy.OVERWRITE
-    )
-
-
 def storeproject(
     projectname: str,
     projectfiles: Iterable[File],

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -27,30 +27,6 @@ class EmptyTemplateError(CuttyError):
     """The template contains no project files."""
 
 
-def generate(
-    template: Template,
-    outputdir: pathlib.Path,
-    *,
-    extrabindings: Sequence[Binding],
-    no_input: bool,
-    overwrite_if_exists: bool,
-    skip_if_file_exists: bool,
-    outputdirisproject: bool,
-    createconfigfile: bool,
-) -> pathlib.Path:
-    """Generate a project from a project template."""
-    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
-    return generate2(
-        template,
-        outputdir,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        fileexists=fileexists,
-        outputdirisproject=outputdirisproject,
-        createconfigfile=createconfigfile,
-    )
-
-
 def generate2(
     template: Template,
     outputdir: pathlib.Path,

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.projects.generate import fileexistspolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -24,7 +24,7 @@ def createproject(
     template = Template.load(location, checkout, directory)
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
 
-    generate2(
+    generate(
         template,
         outputdir,
         extrabindings=extrabindings,

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -3,7 +3,8 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
-from cutty.projects.generate import generate
+from cutty.projects.generate import fileexistspolicy
+from cutty.projects.generate import generate2
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -21,14 +22,14 @@ def createproject(
 ) -> None:
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
 
-    generate(
+    generate2(
         template,
         outputdir,
         extrabindings=extrabindings,
         no_input=no_input,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
+        fileexists=fileexists,
         outputdirisproject=False,
         createconfigfile=False,
     )

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -4,34 +4,9 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import fileexistspolicy
 from cutty.projects.generate import generate
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
-
-
-def createproject(
-    location: str,
-    outputdir: pathlib.Path,
-    *,
-    extrabindings: Sequence[Binding],
-    no_input: bool,
-    checkout: Optional[str],
-    directory: Optional[pathlib.PurePosixPath],
-    overwrite_if_exists: bool,
-    skip_if_file_exists: bool,
-) -> None:
-    """Generate projects from Cookiecutter templates."""
-    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
-    createproject2(
-        location,
-        outputdir,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        checkout=checkout,
-        directory=directory,
-        fileexists=fileexists,
-    )
 
 
 def createproject2(

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -3,6 +3,7 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
+from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import fileexistspolicy
 from cutty.projects.generate import generate
 from cutty.projects.template import Template
@@ -21,8 +22,30 @@ def createproject(
     skip_if_file_exists: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
-    template = Template.load(location, checkout, directory)
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    createproject2(
+        location,
+        outputdir,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        directory=directory,
+        fileexists=fileexists,
+    )
+
+
+def createproject2(
+    location: str,
+    outputdir: pathlib.Path,
+    *,
+    extrabindings: Sequence[Binding],
+    no_input: bool,
+    checkout: Optional[str],
+    directory: Optional[pathlib.PurePosixPath],
+    fileexists: FileExistsPolicy,
+) -> None:
+    """Generate projects from Cookiecutter templates."""
+    template = Template.load(location, checkout, directory)
 
     generate(
         template,

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -9,7 +9,7 @@ from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
 
-def createproject2(
+def createproject(
     location: str,
     outputdir: pathlib.Path,
     *,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -10,7 +10,7 @@ from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
 
-def createproject2(
+def createproject(
     location: str,
     outputdir: pathlib.Path,
     *,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -3,6 +3,7 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
+from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import fileexistspolicy
 from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
@@ -23,9 +24,33 @@ def createproject(
     in_place: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    createproject2(
+        location,
+        outputdir,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        checkout=checkout,
+        directory=directory,
+        fileexists=fileexists,
+        in_place=in_place,
+    )
+
+
+def createproject2(
+    location: str,
+    outputdir: pathlib.Path,
+    *,
+    extrabindings: Sequence[Binding],
+    no_input: bool,
+    checkout: Optional[str],
+    directory: Optional[pathlib.PurePosixPath],
+    fileexists: FileExistsPolicy,
+    in_place: bool,
+) -> None:
+    """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     projectdir = generate(
         template,
         outputdir,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -3,7 +3,8 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
-from cutty.projects.generate import generate
+from cutty.projects.generate import fileexistspolicy
+from cutty.projects.generate import generate2
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
@@ -24,13 +25,13 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    projectdir = generate(
+    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    projectdir = generate2(
         template,
         outputdir,
         extrabindings=extrabindings,
         no_input=no_input,
-        overwrite_if_exists=overwrite_if_exists,
-        skip_if_file_exists=skip_if_file_exists,
+        fileexists=fileexists,
         outputdirisproject=in_place,
         createconfigfile=True,
     )

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,37 +4,10 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import fileexistspolicy
 from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
-
-
-def createproject(
-    location: str,
-    outputdir: pathlib.Path,
-    *,
-    extrabindings: Sequence[Binding],
-    no_input: bool,
-    checkout: Optional[str],
-    directory: Optional[pathlib.PurePosixPath],
-    overwrite_if_exists: bool,
-    skip_if_file_exists: bool,
-    in_place: bool,
-) -> None:
-    """Generate projects from Cookiecutter templates."""
-    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
-    createproject2(
-        location,
-        outputdir,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        checkout=checkout,
-        directory=directory,
-        fileexists=fileexists,
-        in_place=in_place,
-    )
 
 
 def createproject2(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.projects.generate import fileexistspolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
@@ -26,7 +26,7 @@ def createproject(
     template = Template.load(location, checkout, directory)
 
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
-    projectdir = generate2(
+    projectdir = generate(
         template,
         outputdir,
         extrabindings=extrabindings,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from cutty.errors import CuttyError
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
@@ -41,7 +41,7 @@ def link(
     template = Template.load(location, checkout, directory)
 
     def generateproject(outputdir: pathlib.Path) -> None:
-        generate2(
+        generate(
             template,
             outputdir,
             extrabindings=extrabindings,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,7 +5,8 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.projects.generate import generate
+from cutty.filestorage.adapters.disk import FileExistsPolicy
+from cutty.projects.generate import generate2
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
@@ -40,13 +41,12 @@ def link(
     template = Template.load(location, checkout, directory)
 
     def generateproject(outputdir: pathlib.Path) -> None:
-        generate(
+        generate2(
             template,
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
-            overwrite_if_exists=False,
-            skip_if_file_exists=False,
+            fileexists=FileExistsPolicy.RAISE,
             outputdirisproject=True,
             createconfigfile=True,
         )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
 
-from cutty.projects.generate import generate
+from cutty.filestorage.adapters.disk import FileExistsPolicy
+from cutty.projects.generate import generate2
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
@@ -29,13 +30,12 @@ def update(
     template = Template.load(projectconfig.template, checkout, directory)
 
     def generateproject(outputdir: Path) -> None:
-        generate(
+        generate2(
             template,
             outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
-            overwrite_if_exists=False,
-            skip_if_file_exists=False,
+            fileexists=FileExistsPolicy.RAISE,
             outputdirisproject=True,
             createconfigfile=True,
         )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -5,7 +5,7 @@ from pathlib import PurePosixPath
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
@@ -30,7 +30,7 @@ def update(
     template = Template.load(projectconfig.template, checkout, directory)
 
     def generateproject(outputdir: Path) -> None:
-        generate2(
+        generate(
             template,
             outputdir,
             extrabindings=extrabindings,


### PR DESCRIPTION
- 🔨 [filestorage] Extract function `createcookiecutterstorage2` with `FileExistsPolicy`
- 🔨 [filestorage] Inline function `createcookiecutterstorage`
- 🔨 [filestorage] Rename function `createcookiecutterstorage2`
- 🔨 [filestorage] Move function `fileexistspolicy` to `projects.generate`
- 🔨 [projects] Pass `FileExistsPolicy` to `storeproject`
- 🔨 [projects] Extract function `generate2` with `FileExistsPolicy`
- 🔨 [services] Inline function `generate` in `cookiecutter`
- 🔨 [services] Inline function `generate` in `create`
- 🔨 [services] Inline function `generate2` in `link`
- 🔨 [services] Inline function `generate` in `update`
- 🔥 [projects] Remove function `generate`
- 🔨 [projects] Rename function `generate2`
- 🔨 [services] Extract function `cookiecutter.createproject2` with `FileExistsPolicy`
- 🔨 [services] Inline function `cookiecutter.createproject`
- 🔨 [services] Rename function `cookiecutter.createproject2`
- 🔨 [services] Extract function `createproject2` with `FileExistsPolicy`
- 🔨 [services] Inline function `createproject`
- 🔨 [services] Rename function `createproject2`
- 🔨 [entrypoints] Move function `extra_context_callback` to `cookiecutter`
- 🔨 [entrypoints] Move function `fileexistspolicy` to `cookiecutter`
