### PR TITLE
🔨 [projects] Extract function `ProjectGenerator.addconfig`

### DIFF
--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -65,6 +65,7 @@ class Project:
 class ProjectGenerator:
     """A project generator."""
 
+    template: Template
     config: Config
     render: Renderer
     paths: Iterable[Path]
@@ -77,11 +78,9 @@ class ProjectGenerator:
         render = createcookiecutterrenderer(template.root, config)
         paths = findcookiecutterpaths(template.root, config)
         hooks = findcookiecutterhooks(template.root)
-        return cls(config, render, paths, hooks)
+        return cls(template, config, render, paths, hooks)
 
-    def generate(
-        self, bindings: Sequence[Binding], template: Template, createconfigfile: bool
-    ) -> Project:
+    def generate(self, bindings: Sequence[Binding], createconfigfile: bool) -> Project:
         """Generate a project using the given bindings."""
         projectfiles = renderfiles(
             self.paths,
@@ -93,9 +92,9 @@ class ProjectGenerator:
 
         if createconfigfile:
             projectconfig = ProjectConfig(
-                template.metadata.location,
+                self.template.metadata.location,
                 bindings,
-                directory=template.metadata.directory,
+                directory=self.template.metadata.directory,
             )
             projectconfigfile = createprojectconfigfile(
                 PurePath(project.name), projectconfig
@@ -124,7 +123,7 @@ def generate(
         bindings=extrabindings,
     )
 
-    project = generator.generate(bindings, template, createconfigfile)
+    project = generator.generate(bindings, createconfigfile)
     return storeproject(
         project,
         outputdir,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -88,12 +88,7 @@ class ProjectGenerator:
             bindings,
         )
         hookfiles = renderfiles(self.hooks, self.render, bindings)
-        project = Project.create(projectfiles, hookfiles)
-
-        if createconfigfile:
-            project = self.createconfig(project, bindings)
-
-        return project
+        return Project.create(projectfiles, hookfiles)
 
     def createconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
@@ -128,6 +123,10 @@ def generate(
     )
 
     project = generator.generate(bindings, createconfigfile)
+
+    if createconfigfile:
+        project = generator.createconfig(project, bindings)
+
     return storeproject(
         project,
         outputdir,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -86,7 +86,7 @@ class ProjectGenerator:
         """Return the template variables."""
         return self.config.variables
 
-    def generate(self, bindings: Sequence[Binding], createconfigfile: bool) -> Project:
+    def generate(self, bindings: Sequence[Binding]) -> Project:
         """Generate a project using the given bindings."""
         projectfiles = renderfiles(
             self.paths,
@@ -128,7 +128,7 @@ def generate(
         bindings=extrabindings,
     )
 
-    project = generator.generate(bindings, createconfigfile)
+    project = generator.generate(bindings)
 
     if createconfigfile:
         project = generator.createconfig(project, bindings)

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -91,17 +91,21 @@ class ProjectGenerator:
         project = Project.create(projectfiles, hookfiles)
 
         if createconfigfile:
-            projectconfig = ProjectConfig(
-                self.template.metadata.location,
-                bindings,
-                directory=self.template.metadata.directory,
-            )
-            projectconfigfile = createprojectconfigfile(
-                PurePath(project.name), projectconfig
-            )
-            project = project.add(projectconfigfile)
+            project = self.createconfig(project, bindings)
 
         return project
+
+    def createconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
+        """Add a configuration file to the project."""
+        projectconfig = ProjectConfig(
+            self.template.metadata.location,
+            bindings,
+            directory=self.template.metadata.directory,
+        )
+        projectconfigfile = createprojectconfigfile(
+            PurePath(project.name), projectconfig
+        )
+        return project.add(projectconfigfile)
 
 
 def generate(

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -96,7 +96,7 @@ class ProjectGenerator:
         hookfiles = renderfiles(self.hooks, self.render, bindings)
         return Project.create(projectfiles, hookfiles)
 
-    def createconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
+    def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
         projectconfig = ProjectConfig(
             self.template.metadata.location,
@@ -131,7 +131,7 @@ def generate(
     project = generator.generate(bindings)
 
     if createconfigfile:
-        project = generator.createconfig(project, bindings)
+        project = generator.addconfig(project, bindings)
 
     return storeproject(
         project,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -28,6 +28,7 @@ from cutty.templates.domain.bindings import Binding
 from cutty.templates.domain.config import Config
 from cutty.templates.domain.render import Renderer
 from cutty.templates.domain.renderfiles import renderfiles
+from cutty.templates.domain.variables import Variable
 
 
 class EmptyTemplateError(CuttyError):
@@ -80,6 +81,11 @@ class ProjectGenerator:
         hooks = findcookiecutterhooks(template.root)
         return cls(template, config, render, paths, hooks)
 
+    @property
+    def variables(self) -> Sequence[Variable]:
+        """Return the template variables."""
+        return self.config.variables
+
     def generate(self, bindings: Sequence[Binding], createconfigfile: bool) -> Project:
         """Generate a project using the given bindings."""
         projectfiles = renderfiles(
@@ -116,7 +122,7 @@ def generate(
     """Generate a project from a project template."""
     generator = ProjectGenerator.create(template)
     bindings = bindcookiecuttervariables(
-        generator.config.variables,
+        generator.variables,
         generator.render,
         interactive=not no_input,
         bindings=extrabindings,


### PR DESCRIPTION
- 🔨 [projects] Move parameter `template` into `ProjectGenerator`
- 🔨 [projects] Extract function `ProjectGenerator.createconfig`
- 🔨 [projects] Move `ProjectGenerator.createconfig` call to caller
- 🔨 [projects] Extract function `ProjectGenerator.variables`
- 🔨 [projects] Remove parameter `createconfigfile` from `ProjectGenerator.generate`
- 🔨 [projects] Rename function `ProjectGenerator.{create => add}config
