### PR TITLE
🔨 [projects] Rename attributes in `ProjectGenerator` with leading underscore

### DIFF
--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -88,13 +88,9 @@ class ProjectGenerator:
 
     def generate(self, bindings: Sequence[Binding]) -> Project:
         """Generate a project using the given bindings."""
-        projectfiles = renderfiles(
-            self._paths,
-            self.renderer,
-            bindings,
-        )
+        files = renderfiles(self._paths, self.renderer, bindings)
         hookfiles = renderfiles(self._hooks, self.renderer, bindings)
-        return Project.create(projectfiles, hookfiles)
+        return Project.create(files, hookfiles)
 
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -66,7 +66,7 @@ class Project:
 class ProjectGenerator:
     """A project generator."""
 
-    template: Template
+    _template: Template
     config: Config
     render: Renderer
     paths: Iterable[Path]
@@ -99,9 +99,9 @@ class ProjectGenerator:
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
         projectconfig = ProjectConfig(
-            self.template.metadata.location,
+            self._template.metadata.location,
             bindings,
-            directory=self.template.metadata.directory,
+            directory=self._template.metadata.directory,
         )
         projectconfigfile = createprojectconfigfile(
             PurePath(project.name), projectconfig

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -89,8 +89,8 @@ class ProjectGenerator:
     def generate(self, bindings: Sequence[Binding]) -> Project:
         """Generate a project using the given bindings."""
         files = renderfiles(self._paths, self.renderer, bindings)
-        hookfiles = renderfiles(self._hooks, self.renderer, bindings)
-        return Project.create(files, hookfiles)
+        hooks = renderfiles(self._hooks, self.renderer, bindings)
+        return Project.create(files, hooks)
 
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -67,7 +67,7 @@ class ProjectGenerator:
     """A project generator."""
 
     _template: Template
-    config: Config
+    _config: Config
     render: Renderer
     paths: Iterable[Path]
     hooks: Iterable[Path]
@@ -84,7 +84,7 @@ class ProjectGenerator:
     @property
     def variables(self) -> Sequence[Variable]:
         """Return the template variables."""
-        return self.config.variables
+        return self._config.variables
 
     def generate(self, bindings: Sequence[Binding]) -> Project:
         """Generate a project using the given bindings."""

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -76,10 +76,10 @@ class ProjectGenerator:
     def create(cls, template: Template) -> ProjectGenerator:
         """Create a project generator."""
         config = loadcookiecutterconfig(template.metadata.location, template.root)
-        render = createcookiecutterrenderer(template.root, config)
+        renderer = createcookiecutterrenderer(template.root, config)
         paths = findcookiecutterpaths(template.root, config)
         hooks = findcookiecutterhooks(template.root)
-        return cls(template, config, render, paths, hooks)
+        return cls(template, config, renderer, paths, hooks)
 
     @property
     def variables(self) -> Sequence[Variable]:

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -68,7 +68,7 @@ class ProjectGenerator:
 
     _template: Template
     _config: Config
-    render: Renderer
+    renderer: Renderer
     paths: Iterable[Path]
     hooks: Iterable[Path]
 
@@ -90,10 +90,10 @@ class ProjectGenerator:
         """Generate a project using the given bindings."""
         projectfiles = renderfiles(
             self.paths,
-            self.render,
+            self.renderer,
             bindings,
         )
-        hookfiles = renderfiles(self.hooks, self.render, bindings)
+        hookfiles = renderfiles(self.hooks, self.renderer, bindings)
         return Project.create(projectfiles, hookfiles)
 
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
@@ -123,7 +123,7 @@ def generate(
     generator = ProjectGenerator.create(template)
     bindings = bindcookiecuttervariables(
         generator.variables,
-        generator.render,
+        generator.renderer,
         interactive=not no_input,
         bindings=extrabindings,
     )

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -70,7 +70,7 @@ class ProjectGenerator:
     _config: Config
     renderer: Renderer
     _paths: Iterable[Path]
-    hooks: Iterable[Path]
+    _hooks: Iterable[Path]
 
     @classmethod
     def create(cls, template: Template) -> ProjectGenerator:
@@ -93,7 +93,7 @@ class ProjectGenerator:
             self.renderer,
             bindings,
         )
-        hookfiles = renderfiles(self.hooks, self.renderer, bindings)
+        hookfiles = renderfiles(self._hooks, self.renderer, bindings)
         return Project.create(projectfiles, hookfiles)
 
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -69,7 +69,7 @@ class ProjectGenerator:
     _template: Template
     _config: Config
     renderer: Renderer
-    paths: Iterable[Path]
+    _paths: Iterable[Path]
     hooks: Iterable[Path]
 
     @classmethod
@@ -89,7 +89,7 @@ class ProjectGenerator:
     def generate(self, bindings: Sequence[Binding]) -> Project:
         """Generate a project using the given bindings."""
         projectfiles = renderfiles(
-            self.paths,
+            self._paths,
             self.renderer,
             bindings,
         )


### PR DESCRIPTION
- 🔨 [projects] Rename attribute `ProjectGenerator.{ => _}template
- 🔨 [projects] Rename attribute `ProjectGenerator.{ => _}config
- 🔨 [projects] Rename attribute `ProjectGenerator.render{ => er}
- 🔨 [projects] Rename attribute `ProjectGenerator.{ => _}paths
- 🔨 [projects] Rename attribute `ProjectGenerator.{ => _}hooks`
- 🔨 [projects] Rename variable `render{ => er}`
- 🔨 [projects] Rename variable `{project => }files` in `ProjectGenerator.generate`
- 🔨 [projects] Rename variable `hook{file => }s` in `ProjectGenerator.generate`
