### PR TITLE
🔨 [projects] Separate project storage from project generation

### DIFF
--- a/src/cutty/projects/common.py
+++ b/src/cutty/projects/common.py
@@ -1,6 +1,0 @@
-"""Common functionality for projects."""
-from collections.abc import Callable
-from pathlib import Path
-
-
-GenerateProject = Callable[[Path], None]

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -8,7 +8,7 @@ from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariab
 from cutty.templates.domain.bindings import Binding
 
 
-def generate2(
+def generate(
     template: Template,
     *,
     extrabindings: Sequence[Binding],

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -24,6 +24,7 @@ def generate(
 ) -> pathlib.Path:
     """Generate a project from a project template."""
     generator = ProjectGenerator.create(template)
+
     bindings = bindcookiecuttervariables(
         generator.variables,
         generator.renderer,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -2,11 +2,9 @@
 import pathlib
 from collections.abc import Sequence
 
-from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.generator import ProjectGenerator
-from cutty.projects.project import Project
+from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
 from cutty.templates.domain.bindings import Binding
@@ -43,26 +41,3 @@ def generate(
         outputdirisproject,
         fileexists,
     )
-
-
-def storeproject(
-    project: Project,
-    outputdir: pathlib.Path,
-    outputdirisproject: bool,
-    fileexists: FileExistsPolicy,
-) -> pathlib.Path:
-    """Store a project in the output directory."""
-    projectdir = outputdir if outputdirisproject else outputdir / project.name
-    storage = createcookiecutterstorage(
-        outputdir, projectdir, fileexists, project.hooks
-    )
-
-    with storage:
-        for projectfile in project.files:
-            if outputdirisproject:
-                path = PurePath(*projectfile.path.parts[1:])
-                projectfile = projectfile.withpath(path)
-
-            storage.add(projectfile)
-
-    return projectdir

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -1,40 +1,11 @@
 """Generating projects from templates."""
-import pathlib
 from collections.abc import Sequence
 
-from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generator import ProjectGenerator
 from cutty.projects.project import Project
-from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
 from cutty.templates.domain.bindings import Binding
-
-
-def generate(
-    template: Template,
-    outputdir: pathlib.Path,
-    *,
-    extrabindings: Sequence[Binding],
-    no_input: bool,
-    fileexists: FileExistsPolicy,
-    outputdirisproject: bool,
-    createconfigfile: bool,
-) -> pathlib.Path:
-    """Generate a project from a project template."""
-    project = generate2(
-        template,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        createconfigfile=createconfigfile,
-    )
-
-    return storeproject(
-        project,
-        outputdir,
-        outputdirisproject,
-        fileexists,
-    )
 
 
 def generate2(

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generator import ProjectGenerator
+from cutty.projects.project import Project
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariables
@@ -21,6 +22,29 @@ def generate(
     createconfigfile: bool,
 ) -> pathlib.Path:
     """Generate a project from a project template."""
+    project = generate2(
+        template,
+        extrabindings=extrabindings,
+        no_input=no_input,
+        createconfigfile=createconfigfile,
+    )
+
+    return storeproject(
+        project,
+        outputdir,
+        outputdirisproject,
+        fileexists,
+    )
+
+
+def generate2(
+    template: Template,
+    *,
+    extrabindings: Sequence[Binding],
+    no_input: bool,
+    createconfigfile: bool,
+) -> Project:
+    """Generate a project from a project template."""
     generator = ProjectGenerator.create(template)
 
     bindings = bindcookiecuttervariables(
@@ -35,9 +59,4 @@ def generate(
     if createconfigfile:
         project = generator.addconfig(project, bindings)
 
-    return storeproject(
-        project,
-        outputdir,
-        outputdirisproject,
-        fileexists,
-    )
+    return project

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -1,9 +1,9 @@
 """Project repositories."""
+from collections.abc import Callable
 from pathlib import Path
 
 import pygit2
 
-from cutty.projects.common import GenerateProject
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Branch
@@ -12,6 +12,9 @@ from cutty.util.git import Repository
 
 LATEST_BRANCH = "cutty/latest"
 UPDATE_BRANCH = "cutty/update"
+
+
+GenerateProject = Callable[[Path], None]
 
 
 class ProjectRepository:

--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -1,0 +1,30 @@
+"""Storing projects."""
+import pathlib
+
+from cutty.filestorage.adapters.cookiecutter import createcookiecutterstorage
+from cutty.filestorage.adapters.disk import FileExistsPolicy
+from cutty.filesystems.domain.purepath import PurePath
+from cutty.projects.project import Project
+
+
+def storeproject(
+    project: Project,
+    outputdir: pathlib.Path,
+    outputdirisproject: bool,
+    fileexists: FileExistsPolicy,
+) -> pathlib.Path:
+    """Store a project in the output directory."""
+    projectdir = outputdir if outputdirisproject else outputdir / project.name
+    storage = createcookiecutterstorage(
+        outputdir, projectdir, fileexists, project.hooks
+    )
+
+    with storage:
+        for projectfile in project.files:
+            if outputdirisproject:
+                path = PurePath(*projectfile.path.parts[1:])
+                projectfile = projectfile.withpath(path)
+
+            storage.add(projectfile)
+
+    return projectdir

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -4,7 +4,8 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate
+from cutty.projects.generate import generate2
+from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -22,12 +23,16 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    generate(
+    project = generate2(
         template,
-        outputdir,
         extrabindings=extrabindings,
         no_input=no_input,
-        fileexists=fileexists,
-        outputdirisproject=False,
         createconfigfile=False,
+    )
+
+    storeproject(
+        project,
+        outputdir,
+        outputdirisproject=False,
+        fileexists=fileexists,
     )

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
@@ -23,7 +23,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    project = generate2(
+    project = generate(
         template,
         extrabindings=extrabindings,
         no_input=no_input,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -25,7 +25,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    project = generate2(
+    project = generate(
         template,
         extrabindings=extrabindings,
         no_input=no_input,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,8 +4,9 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate
+from cutty.projects.generate import generate2
 from cutty.projects.repository import ProjectRepository
+from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -24,14 +25,18 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    projectdir = generate(
+    project = generate2(
         template,
-        outputdir,
         extrabindings=extrabindings,
         no_input=no_input,
-        fileexists=fileexists,
-        outputdirisproject=in_place,
         createconfigfile=True,
+    )
+
+    projectdir = storeproject(
+        project,
+        outputdir,
+        outputdirisproject=in_place,
+        fileexists=fileexists,
     )
 
     ProjectRepository.create(projectdir, template.metadata)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -6,8 +6,9 @@ from typing import Optional
 
 from cutty.errors import CuttyError
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate
+from cutty.projects.generate import generate2
 from cutty.projects.repository import ProjectRepository
+from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import readcookiecutterjson
 from cutty.templates.domain.bindings import Binding
@@ -41,14 +42,17 @@ def link(
     template = Template.load(location, checkout, directory)
 
     def generateproject(outputdir: pathlib.Path) -> None:
-        generate(
+        project = generate2(
             template,
-            outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
-            fileexists=FileExistsPolicy.RAISE,
-            outputdirisproject=True,
             createconfigfile=True,
+        )
+        storeproject(
+            project,
+            outputdir,
+            outputdirisproject=True,
+            fileexists=FileExistsPolicy.RAISE,
         )
 
     project = ProjectRepository(projectdir)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from cutty.errors import CuttyError
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -42,7 +42,7 @@ def link(
     template = Template.load(location, checkout, directory)
 
     def generateproject(outputdir: pathlib.Path) -> None:
-        project = generate2(
+        project = generate(
             template,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -5,8 +5,9 @@ from pathlib import PurePosixPath
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate
+from cutty.projects.generate import generate2
 from cutty.projects.repository import ProjectRepository
+from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.adapters.cookiecutter.projectconfig import readprojectconfigfile
 from cutty.templates.domain.bindings import Binding
@@ -30,14 +31,17 @@ def update(
     template = Template.load(projectconfig.template, checkout, directory)
 
     def generateproject(outputdir: Path) -> None:
-        generate(
+        project = generate2(
             template,
-            outputdir,
             extrabindings=extrabindings,
             no_input=no_input,
-            fileexists=FileExistsPolicy.RAISE,
-            outputdirisproject=True,
             createconfigfile=True,
+        )
+        storeproject(
+            project,
+            outputdir,
+            outputdirisproject=True,
+            fileexists=FileExistsPolicy.RAISE,
         )
 
     project = ProjectRepository(projectdir)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -5,7 +5,7 @@ from pathlib import PurePosixPath
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -31,7 +31,7 @@ def update(
     template = Template.load(projectconfig.template, checkout, directory)
 
     def generateproject(outputdir: Path) -> None:
-        project = generate2(
+        project = generate(
             template,
             extrabindings=extrabindings,
             no_input=no_input,

--- a/tests/unit/projects/conftest.py
+++ b/tests/unit/projects/conftest.py
@@ -3,7 +3,7 @@ import pathlib
 
 import pytest
 
-from cutty.projects.common import GenerateProject
+from cutty.projects.repository import GenerateProject
 from cutty.projects.template import Template
 
 

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -3,7 +3,7 @@ import dataclasses
 
 import pytest
 
-from cutty.projects.common import GenerateProject
+from cutty.projects.repository import GenerateProject
 from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.repository import UPDATE_BRANCH

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from cutty.projects.common import GenerateProject
+from cutty.projects.repository import GenerateProject
 from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.repository import UPDATE_BRANCH


### PR DESCRIPTION
- 🔨 [projects] Move type alias `GenerateProject` to `repository` module
- 🔨 [projects] Add blank line
- 🔨 [projects] Move function `storeproject` to `store` module
- 🔨 [projects] Extract function `generate2` without `storeproject` call
- 🔨 [services] Inline function `generate` in `cookiecutter`
- 🔨 [services] Inline function `generate` in `create`
- 🔨 [services] Inline function `generate` in `link`
- 🔨 [services] Inline function `generate` in `update`
- 🔥 [projects] Remove function `generate`
- 🔨 [projects] Rename function `generate2`
