### PR TITLE
🔨 [projects] Replace parameter `no_input` by `interactive` and add default arguments

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -110,7 +110,7 @@ def cookiecutter(
         location,
         output_dir,
         extrabindings=extrabindings,
-        no_input=no_input,
+        interactive=not no_input,
         checkout=checkout,
         directory=directory2,
         fileexists=fileexists,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -85,7 +85,7 @@ def create(
         template,
         output_dir,
         extrabindings=extrabindings,
-        no_input=no_input,
+        interactive=not no_input,
         checkout=checkout,
         directory=directory2,
         fileexists=fileexists,

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -59,7 +59,7 @@ def link(
         template,
         cwd,
         extrabindings=extrabindings,
-        no_input=no_input,
+        interactive=not no_input,
         checkout=checkout,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -93,7 +93,7 @@ def update(
     service_update(
         cwd,
         extrabindings=extrabindings,
-        no_input=no_input,
+        interactive=not no_input,
         checkout=checkout,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -8,7 +8,7 @@ from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariab
 from cutty.templates.domain.bindings import Binding
 
 
-def generate2(
+def generate(
     template: Template,
     *,
     extrabindings: Sequence[Binding],

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -8,22 +8,6 @@ from cutty.templates.adapters.cookiecutter.binders import bindcookiecuttervariab
 from cutty.templates.domain.bindings import Binding
 
 
-def generate(
-    template: Template,
-    *,
-    extrabindings: Sequence[Binding],
-    no_input: bool,
-    createconfigfile: bool = True,
-) -> Project:
-    """Generate a project from a project template."""
-    return generate2(
-        template,
-        extrabindings=extrabindings,
-        interactive=not no_input,
-        createconfigfile=createconfigfile,
-    )
-
-
 def generate2(
     template: Template,
     *,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -13,7 +13,7 @@ def generate(
     *,
     extrabindings: Sequence[Binding],
     no_input: bool,
-    createconfigfile: bool,
+    createconfigfile: bool = True,
 ) -> Project:
     """Generate a project from a project template."""
     generator = ProjectGenerator.create(template)

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -16,12 +16,28 @@ def generate(
     createconfigfile: bool = True,
 ) -> Project:
     """Generate a project from a project template."""
+    return generate2(
+        template,
+        extrabindings=extrabindings,
+        interactive=not no_input,
+        createconfigfile=createconfigfile,
+    )
+
+
+def generate2(
+    template: Template,
+    *,
+    extrabindings: Sequence[Binding],
+    interactive: bool,
+    createconfigfile: bool = True,
+) -> Project:
+    """Generate a project from a project template."""
     generator = ProjectGenerator.create(template)
 
     bindings = bindcookiecuttervariables(
         generator.variables,
         generator.renderer,
-        interactive=not no_input,
+        interactive=interactive,
         bindings=extrabindings,
     )
 

--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -11,7 +11,7 @@ def storeproject(
     project: Project,
     outputdir: pathlib.Path,
     outputdirisproject: bool,
-    fileexists: FileExistsPolicy,
+    fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
 ) -> pathlib.Path:
     """Store a project in the output directory."""
     projectdir = outputdir if outputdirisproject else outputdir / project.name

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate
+from cutty.projects.generate import generate2
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
@@ -23,10 +23,10 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    project = generate(
+    project = generate2(
         template,
         extrabindings=extrabindings,
-        no_input=no_input,
+        interactive=not no_input,
         createconfigfile=False,
     )
 

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
@@ -23,7 +23,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    project = generate2(
+    project = generate(
         template,
         extrabindings=extrabindings,
         interactive=not no_input,

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -15,7 +15,7 @@ def createproject(
     outputdir: pathlib.Path,
     *,
     extrabindings: Sequence[Binding],
-    no_input: bool,
+    interactive: bool,
     checkout: Optional[str],
     directory: Optional[pathlib.PurePosixPath],
     fileexists: FileExistsPolicy,
@@ -26,7 +26,7 @@ def createproject(
     project = generate(
         template,
         extrabindings=extrabindings,
-        interactive=not no_input,
+        interactive=interactive,
         createconfigfile=False,
     )
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -16,7 +16,7 @@ def createproject(
     outputdir: pathlib.Path,
     *,
     extrabindings: Sequence[Binding],
-    no_input: bool,
+    interactive: bool,
     checkout: Optional[str],
     directory: Optional[pathlib.PurePosixPath],
     fileexists: FileExistsPolicy,
@@ -25,7 +25,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    project = generate(template, extrabindings=extrabindings, interactive=not no_input)
+    project = generate(template, extrabindings=extrabindings, interactive=interactive)
 
     projectdir = storeproject(
         project,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -25,7 +25,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    project = generate2(template, extrabindings=extrabindings, interactive=not no_input)
+    project = generate(template, extrabindings=extrabindings, interactive=not no_input)
 
     projectdir = storeproject(
         project,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -25,12 +25,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    project = generate(
-        template,
-        extrabindings=extrabindings,
-        no_input=no_input,
-        createconfigfile=True,
-    )
+    project = generate(template, extrabindings=extrabindings, no_input=no_input)
 
     projectdir = storeproject(
         project,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate
+from cutty.projects.generate import generate2
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -25,7 +25,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, checkout, directory)
 
-    project = generate(template, extrabindings=extrabindings, no_input=no_input)
+    project = generate2(template, extrabindings=extrabindings, interactive=not no_input)
 
     projectdir = storeproject(
         project,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -23,7 +23,7 @@ def link(
     /,
     *,
     extrabindings: Sequence[Binding],
-    no_input: bool,
+    interactive: bool,
     checkout: Optional[str],
     directory: Optional[pathlib.PurePosixPath],
 ) -> None:
@@ -42,7 +42,7 @@ def link(
 
     def generateproject(outputdir: pathlib.Path) -> None:
         project = generate(
-            template, extrabindings=extrabindings, interactive=not no_input
+            template, extrabindings=extrabindings, interactive=interactive
         )
         storeproject(project, outputdir, outputdirisproject=True)
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.projects.generate import generate
+from cutty.projects.generate import generate2
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -41,7 +41,9 @@ def link(
     template = Template.load(location, checkout, directory)
 
     def generateproject(outputdir: pathlib.Path) -> None:
-        project = generate(template, extrabindings=extrabindings, no_input=no_input)
+        project = generate2(
+            template, extrabindings=extrabindings, interactive=not no_input
+        )
         storeproject(project, outputdir, outputdirisproject=True)
 
     project = ProjectRepository(projectdir)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
@@ -43,12 +42,7 @@ def link(
 
     def generateproject(outputdir: pathlib.Path) -> None:
         project = generate(template, extrabindings=extrabindings, no_input=no_input)
-        storeproject(
-            project,
-            outputdir,
-            outputdirisproject=True,
-            fileexists=FileExistsPolicy.RAISE,
-        )
+        storeproject(project, outputdir, outputdirisproject=True)
 
     project = ProjectRepository(projectdir)
     project.link(generateproject, template.metadata)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -42,12 +42,7 @@ def link(
     template = Template.load(location, checkout, directory)
 
     def generateproject(outputdir: pathlib.Path) -> None:
-        project = generate(
-            template,
-            extrabindings=extrabindings,
-            no_input=no_input,
-            createconfigfile=True,
-        )
+        project = generate(template, extrabindings=extrabindings, no_input=no_input)
         storeproject(
             project,
             outputdir,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -41,7 +41,7 @@ def link(
     template = Template.load(location, checkout, directory)
 
     def generateproject(outputdir: pathlib.Path) -> None:
-        project = generate2(
+        project = generate(
             template, extrabindings=extrabindings, interactive=not no_input
         )
         storeproject(project, outputdir, outputdirisproject=True)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
 
-from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
@@ -32,12 +31,7 @@ def update(
 
     def generateproject(outputdir: Path) -> None:
         project = generate(template, extrabindings=extrabindings, no_input=no_input)
-        storeproject(
-            project,
-            outputdir,
-            outputdirisproject=True,
-            fileexists=FileExistsPolicy.RAISE,
-        )
+        storeproject(project, outputdir, outputdirisproject=True)
 
     project = ProjectRepository(projectdir)
     project.update(generateproject, template.metadata)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -31,12 +31,7 @@ def update(
     template = Template.load(projectconfig.template, checkout, directory)
 
     def generateproject(outputdir: Path) -> None:
-        project = generate(
-            template,
-            extrabindings=extrabindings,
-            no_input=no_input,
-            createconfigfile=True,
-        )
+        project = generate(template, extrabindings=extrabindings, no_input=no_input)
         storeproject(
             project,
             outputdir,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
 
-from cutty.projects.generate import generate
+from cutty.projects.generate import generate2
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -30,7 +30,9 @@ def update(
     template = Template.load(projectconfig.template, checkout, directory)
 
     def generateproject(outputdir: Path) -> None:
-        project = generate(template, extrabindings=extrabindings, no_input=no_input)
+        project = generate2(
+            template, extrabindings=extrabindings, interactive=not no_input
+        )
         storeproject(project, outputdir, outputdirisproject=True)
 
     project = ProjectRepository(projectdir)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -16,7 +16,7 @@ def update(
     projectdir: Path,
     *,
     extrabindings: Sequence[Binding],
-    no_input: bool,
+    interactive: bool,
     checkout: Optional[str],
     directory: Optional[PurePosixPath],
 ) -> None:
@@ -31,7 +31,7 @@ def update(
 
     def generateproject(outputdir: Path) -> None:
         project = generate(
-            template, extrabindings=extrabindings, interactive=not no_input
+            template, extrabindings=extrabindings, interactive=interactive
         )
         storeproject(project, outputdir, outputdirisproject=True)
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Optional
 
-from cutty.projects.generate import generate2
+from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -30,7 +30,7 @@ def update(
     template = Template.load(projectconfig.template, checkout, directory)
 
     def generateproject(outputdir: Path) -> None:
-        project = generate2(
+        project = generate(
             template, extrabindings=extrabindings, interactive=not no_input
         )
         storeproject(project, outputdir, outputdirisproject=True)


### PR DESCRIPTION
- 🔨 [projects] Add default argument for `createconfigfile` in `generate`
- 🔨 [projects] Add default argument for `filexists` in `storeproject`
- 🔨 [projects] Extract function `generate2` with `interactive` parameter
- 🔨 [projects] Inline function `generate`
- 🔨 [projects] Rename function `generate2`
- 🔨 [services] Replace parameter `no_input` by `interactive` in `cookiecutter`
- 🔨 [services] Replace parameter `no_input` by `interactive` in `create`
- 🔨 [services] Replace parameter `no_input` by `interactive` in `link`
- 🔨 [services] Replace parameter `no_input` by `interactive` in `update`
