### PR TITLE
🔨 [projects] Use context managers instead of callbacks in `ProjectRepository`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -76,7 +76,7 @@ class ProjectRepository:
         self.project.heads[LATEST_BRANCH] = update.commit
 
     @contextmanager
-    def update2(self, template: Template.Metadata) -> Iterator[Path]:
+    def update(self, template: Template.Metadata) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
         latestbranch = self.project.branch(LATEST_BRANCH)
         updatebranch = self.project.heads.create(

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -38,7 +38,7 @@ class ProjectRepository:
         project.heads[LATEST_BRANCH] = project.head.commit
 
     @contextmanager
-    def link2(
+    def link(
         self,
         template: Template.Metadata,
     ) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -43,6 +43,15 @@ class ProjectRepository:
         template: Template.Metadata,
     ) -> None:
         """Link a project to a project template."""
+        with self.link2(template) as projectdir:
+            generateproject(projectdir)
+
+    @contextmanager
+    def link2(
+        self,
+        template: Template.Metadata,
+    ) -> Iterator[Path]:
+        """Link a project to a project template."""
         if latest := self.project.heads.get(LATEST_BRANCH):
             update = self.project.heads.create(UPDATE_BRANCH, latest, force=True)
         else:
@@ -51,7 +60,7 @@ class ProjectRepository:
             update = _create_orphan_branch(self.project, UPDATE_BRANCH)
 
         with self.project.worktree(update, checkout=False) as worktree:
-            generateproject(worktree.path)
+            yield worktree.path
             message = (
                 _createcommitmessage(template)
                 if latest is None

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -1,5 +1,4 @@
 """Project repositories."""
-from collections.abc import Callable
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -14,9 +13,6 @@ from cutty.util.git import Repository
 
 LATEST_BRANCH = "cutty/latest"
 UPDATE_BRANCH = "cutty/update"
-
-
-GenerateProject = Callable[[Path], None]
 
 
 class ProjectRepository:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -37,15 +37,6 @@ class ProjectRepository:
         project.commit(message=_createcommitmessage(template))
         project.heads[LATEST_BRANCH] = project.head.commit
 
-    def link(
-        self,
-        generateproject: GenerateProject,
-        template: Template.Metadata,
-    ) -> None:
-        """Link a project to a project template."""
-        with self.link2(template) as projectdir:
-            generateproject(projectdir)
-
     @contextmanager
     def link2(
         self,

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -75,13 +75,6 @@ class ProjectRepository:
 
         self.project.heads[LATEST_BRANCH] = update.commit
 
-    def update(
-        self, generateproject: GenerateProject, template: Template.Metadata
-    ) -> None:
-        """Update a project by applying changes between the generated trees."""
-        with self.update2(template) as projectdir:
-            generateproject(projectdir)
-
     @contextmanager
     def update2(self, template: Template.Metadata) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -39,12 +39,10 @@ def link(
         raise TemplateNotSpecifiedError()
 
     template = Template.load(location, checkout, directory)
+    repository = ProjectRepository(projectdir)
 
-    def generateproject(outputdir: pathlib.Path) -> None:
+    with repository.link2(template.metadata) as outputdir:
         project = generate(
             template, extrabindings=extrabindings, interactive=interactive
         )
         storeproject(project, outputdir, outputdirisproject=True)
-
-    project = ProjectRepository(projectdir)
-    project.link(generateproject, template.metadata)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -41,7 +41,7 @@ def link(
     template = Template.load(location, checkout, directory)
     repository = ProjectRepository(projectdir)
 
-    with repository.link2(template.metadata) as outputdir:
+    with repository.link(template.metadata) as outputdir:
         project = generate(
             template, extrabindings=extrabindings, interactive=interactive
         )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -30,7 +30,7 @@ def update(
     template = Template.load(projectconfig.template, checkout, directory)
     repository = ProjectRepository(projectdir)
 
-    with repository.update2(template.metadata) as outputdir:
+    with repository.update(template.metadata) as outputdir:
         project = generate(
             template, extrabindings=extrabindings, interactive=interactive
         )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -28,12 +28,10 @@ def update(
         directory = projectconfig.directory
 
     template = Template.load(projectconfig.template, checkout, directory)
+    repository = ProjectRepository(projectdir)
 
-    def generateproject(outputdir: Path) -> None:
+    with repository.update2(template.metadata) as outputdir:
         project = generate(
             template, extrabindings=extrabindings, interactive=interactive
         )
         storeproject(project, outputdir, outputdirisproject=True)
-
-    project = ProjectRepository(projectdir)
-    project.update(generateproject, template.metadata)

--- a/tests/unit/projects/conftest.py
+++ b/tests/unit/projects/conftest.py
@@ -1,9 +1,6 @@
 """Fixtures for cutty.projects."""
-import pathlib
-
 import pytest
 
-from cutty.projects.repository import GenerateProject
 from cutty.projects.template import Template
 
 
@@ -12,13 +9,3 @@ def template() -> Template.Metadata:
     """Fixture for a `Template` instance."""
     location = "https://example.com/template"
     return Template.Metadata(location, None, None, "template", None)
-
-
-@pytest.fixture
-def generateproject() -> GenerateProject:
-    """Fixture for a `generateproject` function."""
-
-    def _(project: pathlib.Path) -> None:
-        (project / "cutty.json").touch()
-
-    return _

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -3,7 +3,6 @@ import dataclasses
 
 import pytest
 
-from cutty.projects.repository import GenerateProject
 from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.repository import UPDATE_BRANCH
@@ -15,15 +14,11 @@ from tests.util.git import updatefile
 pytest_plugins = ["tests.fixtures.git"]
 
 
-def linkproject(
-    project: Repository,
-    generateproject: GenerateProject,
-    template: Template.Metadata,
-) -> None:
+def linkproject(project: Repository, template: Template.Metadata) -> None:
     """Link a project to a project template."""
     repository = ProjectRepository(project.path)
     with repository.link(template) as projectdir:
-        generateproject(projectdir)
+        (projectdir / "cutty.json").touch()
 
 
 @pytest.fixture
@@ -32,89 +27,85 @@ def project(repository: Repository) -> Repository:
     return repository
 
 
-def test_linkproject_commit(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
-) -> None:
+def test_linkproject_commit(project: Repository, template: Template.Metadata) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
 
-    linkproject(project, generateproject, template)
+    linkproject(project, template)
 
     assert [tip] == project.head.commit.parents
 
 
 def test_linkproject_commit_message(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It uses a commit message indicating the linkage."""
-    linkproject(project, generateproject, template)
+    linkproject(project, template)
 
     assert "link" in project.head.commit.message.lower()
 
 
 def test_linkproject_commit_message_template(
-    project: Repository,
-    generateproject: GenerateProject,
-    template: Template.Metadata,
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
-    linkproject(project, generateproject, template)
+    linkproject(project, template)
 
     assert template.name in project.head.commit.message
 
 
 def test_linkproject_commit_message_revision(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
     template = dataclasses.replace(template, revision="1.0.0")
 
-    linkproject(project, generateproject, template)
+    linkproject(project, template)
 
     assert template.revision in project.head.commit.message
 
 
 def test_linkproject_latest_branch(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It creates the latest branch."""
     updatefile(project.path / "initial")
 
-    linkproject(project, generateproject, template)
+    linkproject(project, template)
 
     assert LATEST_BRANCH in project.heads
 
 
 def test_linkproject_latest_branch_commit_message(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It uses a commit message indicating an initial import."""
     updatefile(project.path / "initial")
 
-    linkproject(project, generateproject, template)
+    linkproject(project, template)
 
     assert "initial" in project.heads[LATEST_BRANCH].message.lower()
 
 
 def test_linkproject_latest_branch_commit_message_update(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It uses a commit message indicating an update if the branch exists."""
     project.heads.create(LATEST_BRANCH)
 
     updatefile(project.path / "initial")
 
-    linkproject(project, generateproject, template)
+    linkproject(project, template)
 
     assert "update" in project.heads[LATEST_BRANCH].message.lower()
 
 
 def test_linkproject_update_branch(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It creates the update branch."""
     updatefile(project.path / "initial")
 
-    linkproject(project, generateproject, template)
+    linkproject(project, template)
 
     assert UPDATE_BRANCH in project.heads

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -22,7 +22,8 @@ def linkproject(
 ) -> None:
     """Link a project to a project template."""
     repository = ProjectRepository(project.path)
-    repository.link(generateproject, template)
+    with repository.link2(template) as projectdir:
+        generateproject(projectdir)
 
 
 @pytest.fixture

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -22,7 +22,7 @@ def linkproject(
 ) -> None:
     """Link a project to a project template."""
     repository = ProjectRepository(project.path)
-    with repository.link2(template) as projectdir:
+    with repository.link(template) as projectdir:
         generateproject(projectdir)
 
 

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -24,7 +24,8 @@ def updateproject(
 ) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
-    project.update(generateproject, template)
+    with project.update2(template) as outputdir:
+        generateproject(outputdir)
 
 
 def continueupdate(projectdir: Path) -> None:

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -24,7 +24,7 @@ def updateproject(
 ) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
-    with project.update2(template) as outputdir:
+    with project.update(template) as outputdir:
         generateproject(outputdir)
 
 

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-from cutty.projects.repository import GenerateProject
 from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.repository import UPDATE_BRANCH
@@ -19,13 +18,11 @@ from tests.util.git import updatefile
 pytest_plugins = ["tests.fixtures.git"]
 
 
-def updateproject(
-    projectdir: Path, generateproject: GenerateProject, template: Template.Metadata
-) -> None:
+def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
     with project.update(template) as outputdir:
-        generateproject(outputdir)
+        (outputdir / "cutty.json").touch()
 
 
 def continueupdate(projectdir: Path) -> None:
@@ -148,64 +145,62 @@ def project(repository: Repository) -> Repository:
     return repository
 
 
-def test_updateproject_commit(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
-) -> None:
+def test_updateproject_commit(project: Repository, template: Template.Metadata) -> None:
     """It creates a commit on the current branch."""
     tip = project.head.commit
 
-    updateproject(project.path, generateproject, template)
+    updateproject(project.path, template)
 
     assert [tip] == project.head.commit.parents
 
 
 def test_updateproject_commit_message(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It uses a commit message indicating an update."""
-    updateproject(project.path, generateproject, template)
+    updateproject(project.path, template)
 
     assert "update" in project.head.commit.message.lower()
 
 
 def test_updateproject_commit_message_template(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
-    updateproject(project.path, generateproject, template)
+    updateproject(project.path, template)
 
     assert template.name in project.head.commit.message
 
 
 def test_updateproject_commit_message_revision(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
     template = dataclasses.replace(template, revision="1.0.0")
 
-    updateproject(project.path, generateproject, template)
+    updateproject(project.path, template)
 
     assert template.revision in project.head.commit.message
 
 
 def test_updateproject_latest_branch(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It updates the latest branch."""
     updatefile(project.path / "initial")
 
     tip = project.heads[LATEST_BRANCH]
 
-    updateproject(project.path, generateproject, template)
+    updateproject(project.path, template)
 
     assert [tip] == project.heads[LATEST_BRANCH].parents
 
 
 def test_updateproject_update_branch(
-    project: Repository, generateproject: GenerateProject, template: Template.Metadata
+    project: Repository, template: Template.Metadata
 ) -> None:
     """It creates the update branch."""
-    updateproject(project.path, generateproject, template)
+    updateproject(project.path, template)
 
     assert project.heads[LATEST_BRANCH] == project.heads[UPDATE_BRANCH]
 
@@ -216,6 +211,8 @@ def test_updateproject_no_changes(
     """It does not create an empty commit."""
     tip = project.head.commit
 
-    updateproject(project.path, lambda _: None, template)
+    repository = ProjectRepository(project.path)
+    with repository.update(template):
+        pass
 
     assert tip == project.head.commit


### PR DESCRIPTION
- 🔨 [projects] Extract function `ProjectRepository.update2` returning context manager
- 🔨 [projects] Inline function `ProjectRepository.update`
- 🔨 [projects] Rename function `ProjectRepository.update2`
- 🔨 [projects] Extract function `ProjectRepository.link2` returning context manager
- 🔨 [projects] Inline function `ProjectRepository.link`
- 🔨 [projects] Rename function `ProjectRepository.link2`
- 🔨 [projects] Inline fixture `generateproject`
- 🔥 [projects] Remove type alias `GenerateProject`
