### PR TITLE
🔨 [projects] Store `Template.Metadata` only in `ProjectGenerator`

### DIFF
--- a/src/cutty/projects/generator.py
+++ b/src/cutty/projects/generator.py
@@ -26,7 +26,7 @@ from cutty.templates.domain.variables import Variable
 class ProjectGenerator:
     """A project generator."""
 
-    _template: Template
+    _template: Template.Metadata
     _config: Config
     renderer: Renderer
     _paths: Iterable[Path]
@@ -39,7 +39,7 @@ class ProjectGenerator:
         renderer = createcookiecutterrenderer(template.root, config)
         paths = findcookiecutterpaths(template.root, config)
         hooks = findcookiecutterhooks(template.root)
-        return cls(template, config, renderer, paths, hooks)
+        return cls(template.metadata, config, renderer, paths, hooks)
 
     @property
     def variables(self) -> Sequence[Variable]:
@@ -55,9 +55,7 @@ class ProjectGenerator:
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
         projectconfig = ProjectConfig(
-            self._template.metadata.location,
-            bindings,
-            directory=self._template.metadata.directory,
+            self._template.location, bindings, directory=self._template.directory
         )
         projectconfigfile = createprojectconfigfile(
             PurePath(project.name), projectconfig

--- a/tests/unit/projects/conftest.py
+++ b/tests/unit/projects/conftest.py
@@ -6,6 +6,6 @@ from cutty.projects.template import Template
 
 @pytest.fixture
 def template() -> Template.Metadata:
-    """Fixture for a `Template` instance."""
+    """Fixture for a `Template.Metadata` instance."""
     location = "https://example.com/template"
     return Template.Metadata(location, None, None, "template", None)


### PR DESCRIPTION
- 💡 [projects] Update stale docstring for `template` fixture
- 🔨 [projects] Store `Template.Metadata` only in `ProjectGenerator`
