### PR TITLE
💥 [entrypoints] Rename option `--checkout` to `--revision`

### DIFF
--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -19,8 +19,7 @@ from cutty.templates.domain.bindings import Binding
     help="Do not prompt for template variables.",
 )
 @click.option(
-    "-c",
-    "--checkout",
+    "--revision",
     metavar="REV",
     help="Branch, tag, or commit hash of the template repository.",
 )
@@ -65,7 +64,7 @@ def create(
     template: str,
     extra_context: dict[str, str],
     no_input: bool,
-    checkout: Optional[str],
+    revision: Optional[str],
     output_dir: Optional[pathlib.Path],
     directory: Optional[pathlib.Path],
     overwrite_if_exists: bool,
@@ -86,7 +85,7 @@ def create(
         output_dir,
         extrabindings=extrabindings,
         interactive=not no_input,
-        checkout=checkout,
+        checkout=revision,
         directory=directory2,
         fileexists=fileexists,
         in_place=in_place,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -85,7 +85,7 @@ def create(
         output_dir,
         extrabindings=extrabindings,
         interactive=not no_input,
-        checkout=revision,
+        revision=revision,
         directory=directory2,
         fileexists=fileexists,
         in_place=in_place,

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -59,6 +59,6 @@ def link(
         cwd,
         extrabindings=extrabindings,
         interactive=not no_input,
-        checkout=revision,
+        revision=revision,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -27,8 +27,7 @@ from cutty.templates.domain.bindings import Binding
     help="Directory of the generated project.",
 )
 @click.option(
-    "-c",
-    "--checkout",
+    "--revision",
     metavar="REV",
     help="Branch, tag, or commit hash of the template repository.",
 )
@@ -46,7 +45,7 @@ def link(
     extra_context: dict[str, str],
     no_input: bool,
     cwd: Optional[pathlib.Path],
-    checkout: Optional[str],
+    revision: Optional[str],
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
@@ -60,6 +59,6 @@ def link(
         cwd,
         extrabindings=extrabindings,
         interactive=not no_input,
-        checkout=checkout,
+        checkout=revision,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -27,8 +27,7 @@ from cutty.templates.domain.bindings import Binding
     help="Directory of the generated project.",
 )
 @click.option(
-    "-c",
-    "--checkout",
+    "--revision",
     metavar="REV",
     help="Branch, tag, or commit hash of the template repository.",
 )
@@ -64,7 +63,7 @@ def update(
     extra_context: dict[str, str],
     no_input: bool,
     cwd: Optional[pathlib.Path],
-    checkout: Optional[str],
+    revision: Optional[str],
     directory: Optional[pathlib.Path],
     continue_: bool,
     skip: bool,
@@ -94,6 +93,6 @@ def update(
         cwd,
         extrabindings=extrabindings,
         interactive=not no_input,
-        checkout=checkout,
+        checkout=revision,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -93,6 +93,6 @@ def update(
         cwd,
         extrabindings=extrabindings,
         interactive=not no_input,
-        checkout=revision,
+        revision=revision,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -22,7 +22,6 @@ class Template:
         """Metadata for a project template."""
 
         location: str
-        checkout: Optional[str]
         directory: Optional[pathlib.PurePosixPath]
         name: str
         revision: Optional[Revision]
@@ -47,6 +46,6 @@ class Template:
         )
 
         metadata = cls.Metadata(
-            template, revision, directory, repository.name, repository.revision
+            template, directory, repository.name, repository.revision
         )
         return cls(metadata, repository.path)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -34,7 +34,7 @@ class Template:
     def load(
         cls,
         template: str,
-        checkout: Optional[str],
+        revision: Optional[str],
         directory: Optional[pathlib.PurePosixPath],
     ) -> Template:
         """Load a project template."""
@@ -42,11 +42,11 @@ class Template:
         repositoryprovider = getdefaultrepositoryprovider(cachedir)
         repository = repositoryprovider(
             template,
-            revision=checkout,
+            revision=revision,
             directory=(PurePath(*directory.parts) if directory is not None else None),
         )
 
         metadata = cls.Metadata(
-            template, checkout, directory, repository.name, repository.revision
+            template, revision, directory, repository.name, repository.revision
         )
         return cls(metadata, repository.path)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -17,13 +17,13 @@ def createproject(
     *,
     extrabindings: Sequence[Binding],
     interactive: bool,
-    checkout: Optional[str],
+    revision: Optional[str],
     directory: Optional[pathlib.PurePosixPath],
     fileexists: FileExistsPolicy,
     in_place: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
-    template = Template.load(location, checkout, directory)
+    template = Template.load(location, revision, directory)
 
     project = generate(template, extrabindings=extrabindings, interactive=interactive)
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -24,7 +24,7 @@ def link(
     *,
     extrabindings: Sequence[Binding],
     interactive: bool,
-    checkout: Optional[str],
+    revision: Optional[str],
     directory: Optional[pathlib.PurePosixPath],
 ) -> None:
     """Link project to a Cookiecutter template."""
@@ -38,7 +38,7 @@ def link(
     if location is None:
         raise TemplateNotSpecifiedError()
 
-    template = Template.load(location, checkout, directory)
+    template = Template.load(location, revision, directory)
     repository = ProjectRepository(projectdir)
 
     with repository.link(template.metadata) as outputdir:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -17,7 +17,7 @@ def update(
     *,
     extrabindings: Sequence[Binding],
     interactive: bool,
-    checkout: Optional[str],
+    revision: Optional[str],
     directory: Optional[PurePosixPath],
 ) -> None:
     """Update a project with changes from its Cookiecutter template."""
@@ -27,7 +27,7 @@ def update(
     if directory is None:
         directory = projectconfig.directory
 
-    template = Template.load(projectconfig.template, checkout, directory)
+    template = Template.load(projectconfig.template, revision, directory)
     repository = ProjectRepository(projectdir)
 
     with repository.update(template.metadata) as outputdir:

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -97,7 +97,7 @@ def test_commit_message_revision(runcutty: RunCutty, template: Path) -> None:
 
     updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
 
-    runcutty("create", f"--checkout={revision}", str(template))
+    runcutty("create", f"--revision={revision}", str(template))
 
     repository = Repository.open(Path("example"))
 

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -71,13 +71,13 @@ def test_directory(runcutty: RunCutty, project: Path, template: Path) -> None:
     assert directory == str(config.directory)
 
 
-def test_checkout(runcutty: RunCutty, project: Path, template: Path) -> None:
+def test_revision(runcutty: RunCutty, project: Path, template: Path) -> None:
     """It uses the specified revision of the template."""
     initial = Repository.open(template).head.commit.id
 
     updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
 
-    runcutty("link", f"--cwd={project}", f"--checkout={initial}", str(template))
+    runcutty("link", f"--cwd={project}", f"--revision={initial}", str(template))
 
     latest = Repository.open(project).branch(LATEST_BRANCH)
     assert "LICENSE" not in latest.commit.tree

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -284,7 +284,7 @@ def test_directory_update(runcutty: RunCutty, template: Path, project: Path) -> 
     assert directory == str(config.directory)
 
 
-def test_checkout(
+def test_revision(
     runcutty: RunCutty, template: Path, templateproject: Path, project: Path
 ) -> None:
     """It uses the specified revision of the template."""
@@ -294,7 +294,7 @@ def test_checkout(
 
     updatefile(templateproject / "LICENSE", "b")
 
-    runcutty("update", f"--cwd={project}", f"--checkout={revision}")
+    runcutty("update", f"--cwd={project}", f"--revision={revision}")
 
     assert (project / "LICENSE").read_text() == "a"
 

--- a/tests/unit/projects/conftest.py
+++ b/tests/unit/projects/conftest.py
@@ -8,4 +8,4 @@ from cutty.projects.template import Template
 def template() -> Template.Metadata:
     """Fixture for a `Template.Metadata` instance."""
     location = "https://example.com/template"
-    return Template.Metadata(location, None, None, "template", None)
+    return Template.Metadata(location, None, "template", None)


### PR DESCRIPTION
- ✅ [functional] Replace `--checkout` with `--revision` in `cutty create` test
- 💥 [entrypoints] Rename option `--checkout` to `--revision` in `cutty create`
- 🔨 [services] Rename parameter `checkout` to `revision` in `create`
- ✅ [functional] Replace `--checkout` with `--revision` in `cutty update` test
- 💥 [entrypoints] Rename option `--checkout` to `--revision` in `cutty update`
- 🔨 [services] Rename parameter `checkout` to `revision` in `update`
- ✅ [functional] Replace `--checkout` with `--revision` in `cutty link` test
- 💥 [entrypoints] Rename option `--checkout` to `--revision` in `cutty link`
- 🔨 [services] Rename parameter `checkout` to `revision` in `link`
- 🔨 [projects] Rename parameter `checkout` to `revision` in `Template.load`
- 🔥 [projects] Remove attribute `Template.Metadata.checkout`
