### PR TITLE
💥 [entrypoints] Rename option `--no-input` to `--non-interactive`

### DIFF
--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -13,7 +13,7 @@ from cutty.templates.domain.bindings import Binding
 @click.argument("template")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
-    "--no-input",
+    "--non-interactive",
     is_flag=True,
     default=False,
     help="Do not prompt for template variables.",
@@ -63,7 +63,7 @@ from cutty.templates.domain.bindings import Binding
 def create(
     template: str,
     extra_context: dict[str, str],
-    no_input: bool,
+    non_interactive: bool,
     revision: Optional[str],
     output_dir: Optional[pathlib.Path],
     directory: Optional[pathlib.Path],
@@ -84,7 +84,7 @@ def create(
         template,
         output_dir,
         extrabindings=extrabindings,
-        interactive=not no_input,
+        interactive=not non_interactive,
         revision=revision,
         directory=directory2,
         fileexists=fileexists,

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -12,7 +12,7 @@ from cutty.templates.domain.bindings import Binding
 @click.argument("template", required=False)
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
-    "--no-input",
+    "--non-interactive",
     is_flag=True,
     default=False,
     help="Do not prompt for template variables.",
@@ -43,7 +43,7 @@ from cutty.templates.domain.bindings import Binding
 def link(
     template: Optional[str],
     extra_context: dict[str, str],
-    no_input: bool,
+    non_interactive: bool,
     cwd: Optional[pathlib.Path],
     revision: Optional[str],
     directory: Optional[pathlib.Path],
@@ -58,7 +58,7 @@ def link(
         template,
         cwd,
         extrabindings=extrabindings,
-        interactive=not no_input,
+        interactive=not non_interactive,
         revision=revision,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -12,7 +12,7 @@ from cutty.templates.domain.bindings import Binding
 
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
-    "--no-input",
+    "--non-interactive",
     is_flag=True,
     default=False,
     help="Do not prompt for template variables.",
@@ -61,7 +61,7 @@ from cutty.templates.domain.bindings import Binding
 )
 def update(
     extra_context: dict[str, str],
-    no_input: bool,
+    non_interactive: bool,
     cwd: Optional[pathlib.Path],
     revision: Optional[str],
     directory: Optional[pathlib.Path],
@@ -92,7 +92,7 @@ def update(
     service_update(
         cwd,
         extrabindings=extrabindings,
-        interactive=not no_input,
+        interactive=not non_interactive,
         revision=revision,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
     )

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -69,7 +69,7 @@ def test_output_dir(runcutty: RunCutty, template: Path) -> None:
 
 def test_inplace(runcutty: RunCutty, template: Path) -> None:
     """It generates the project files in the current directory."""
-    runcutty("create", "--no-input", "--in-place", str(template))
+    runcutty("create", "--non-interactive", "--in-place", str(template))
 
     assert template_files(template) == project_files(".") - EXTRA
 

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -53,9 +53,15 @@ def test_extra_context(runcutty: RunCutty, project: Path, template: Path) -> Non
     assert "excellent" == projectvariable(project, "project")
 
 
-def test_no_input(runcutty: RunCutty, project: Path, template: Path) -> None:
+def test_non_interactive(runcutty: RunCutty, project: Path, template: Path) -> None:
     """It does not prompt for variables."""
-    runcutty("link", f"--cwd={project}", "--no-input", str(template), input="ignored\n")
+    runcutty(
+        "link",
+        f"--cwd={project}",
+        "--non-interactive",
+        str(template),
+        input="ignored\n",
+    )
 
     assert "example" == projectvariable(project, "project")
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -28,7 +28,7 @@ def project(runcutty: RunCutty, template: Path) -> Path:
     """Fixture for a generated project."""
     project = Path("awesome")
 
-    runcutty("create", "--no-input", str(template), f"project={project.name}")
+    runcutty("create", "--non-interactive", str(template), f"project={project.name}")
 
     return project
 

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -146,12 +146,12 @@ def test_extra_context_new_variable(
     assert "stable" == projectvariable(project, "status")
 
 
-def test_no_input(runcutty: RunCutty, template: Path, project: Path) -> None:
+def test_non_interactive(runcutty: RunCutty, template: Path, project: Path) -> None:
     """It does not prompt for variables added after the last project generation."""
     updatetemplatevariable(template, "status", ["alpha", "beta", "stable"])
 
     with chdir(project):
-        runcutty("update", "--no-input", input="3\n")
+        runcutty("update", "--non-interactive", input="3\n")
 
     assert "alpha" == projectvariable(project, "status")
 


### PR DESCRIPTION
- ✅ [functional] Replace `--no-input` with `--non-interactive` in `cutty create` test
- 💥 [entrypoints] Rename option `--no-input` to `--non-interactive` in `cutty create`
- ✅ [functional] Replace `--no-input` with `--non-interactive` in `cutty update` test
- 💥 [entrypoints] Rename option `--no-input` to `--non-interactive` in `cutty update`
- ✅ [functional] Replace `--no-input` with `--non-interactive` in `cutty link` test
- 💥 [entrypoints] Rename option `--no-input` with `--non-interactive` in `cutty link`
