### PR TITLE
💥 [projects] Reset existing `cutty/latest` branch in `cutty link`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -40,8 +40,11 @@ class ProjectRepository:
     ) -> Iterator[Path]:
         """Link a project to a project template."""
         if latest := self.project.heads.get(LATEST_BRANCH):
-            update = self.project.heads.create(UPDATE_BRANCH, latest, force=True)
-        else:
+            for name in (LATEST_BRANCH, UPDATE_BRANCH):
+                self.project.heads.pop(name, None)
+            latest = None
+
+        if not latest:
             # Unborn branches cannot have worktrees. Create an orphan branch with an
             # empty placeholder commit instead. We'll squash it after project creation.
             update = _create_orphan_branch(self.project, UPDATE_BRANCH)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -39,10 +39,10 @@ class ProjectRepository:
         template: Template.Metadata,
     ) -> Iterator[Path]:
         """Link a project to a project template."""
-        if latest := self.project.heads.get(LATEST_BRANCH):
-            for name in (LATEST_BRANCH, UPDATE_BRANCH):
-                self.project.heads.pop(name, None)
-            latest = None
+        for name in (LATEST_BRANCH, UPDATE_BRANCH):
+            self.project.heads.pop(name, None)
+
+        latest = None
 
         if not latest:
             # Unborn branches cannot have worktrees. Create an orphan branch with an

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -42,25 +42,17 @@ class ProjectRepository:
         for name in (LATEST_BRANCH, UPDATE_BRANCH):
             self.project.heads.pop(name, None)
 
-        latest = None
-
-        if not latest:
-            # Unborn branches cannot have worktrees. Create an orphan branch with an
-            # empty placeholder commit instead. We'll squash it after project creation.
-            update = _create_orphan_branch(self.project, UPDATE_BRANCH)
+        # Unborn branches cannot have worktrees. Create an orphan branch with an
+        # empty placeholder commit instead. We'll squash it after project creation.
+        update = _create_orphan_branch(self.project, UPDATE_BRANCH)
 
         with self.project.worktree(update, checkout=False) as worktree:
             yield worktree.path
-            message = (
-                _createcommitmessage(template)
-                if latest is None
-                else _updatecommitmessage(template)
-            )
+            message = _createcommitmessage(template)
             worktree.commit(message=message)
 
-        if latest is None:
-            # Squash the empty initial commit.
-            _squash_branch(self.project, update)
+        # Squash the empty initial commit.
+        _squash_branch(self.project, update)
 
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(
             (update.commit.tree / PROJECT_CONFIG_FILE).data

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -100,7 +100,7 @@ def test_orphan_branch(runcutty: RunCutty, project: Path, template: Path) -> Non
 def test_update_branch_exists(
     runcutty: RunCutty, project: Path, template: Path
 ) -> None:
-    """It updates an existing update branch."""
+    """It does not crash if latest and update branches already exist."""
     repository = Repository.open(project)
     for branch in UPDATE_BRANCH, LATEST_BRANCH:
         repository.heads.create(branch)

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -116,19 +116,17 @@ def test_update_branch_exists(
 def test_latest_branch_exists(
     runcutty: RunCutty, project: Path, template: Path
 ) -> None:
-    """It fast-forwards an existing latest branch."""
+    """It resets an existing latest branch."""
     repository = Repository.open(project)
     _, latest = [
         repository.heads.create(branch) for branch in (UPDATE_BRANCH, LATEST_BRANCH)
     ]
-    expected = latest.commit
 
     updatefile(project / "marker")
 
     runcutty("link", f"--cwd={project}", str(template))
 
-    [actual] = latest.commit.parents
-    assert expected == actual
+    assert not latest.commit.parents
 
 
 def test_commit_message_template(

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -1,4 +1,4 @@
-"""Unit tests for cutty.projects.create."""
+"""Unit tests for cutty.projects.repository."""
 import dataclasses
 import pathlib
 

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -1,4 +1,4 @@
-"""Unit tests for cutty.services.link."""
+"""Unit tests for cutty.projects.repository."""
 import dataclasses
 
 import pytest

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -90,14 +90,14 @@ def test_linkproject_latest_branch_commit_message(
 def test_linkproject_latest_branch_commit_message_update(
     project: Repository, template: Template.Metadata
 ) -> None:
-    """It uses a commit message indicating an update if the branch exists."""
+    """It uses a commit message indicating an initial import."""
     project.heads.create(LATEST_BRANCH)
 
     updatefile(project.path / "initial")
 
     linkproject(project, template)
 
-    assert "update" in project.heads[LATEST_BRANCH].message.lower()
+    assert "initial" in project.heads[LATEST_BRANCH].message.lower()
 
 
 def test_linkproject_update_branch(

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -1,4 +1,4 @@
-"""Unit tests for cutty.projects.update."""
+"""Unit tests for cutty.projects.repository."""
 import dataclasses
 from pathlib import Path
 


### PR DESCRIPTION
- 💡 [functional] Fix obsolete test docstring
- ✅ [functional] Change `cutty link` test to expect branches to be reset
- 💥 [projects] Reset existing `cutty/latest` branch in `cutty link`
- 💡 [projects] Fix module docstrings for unit tests
- ✅ [projects] Adapt unit test for `cutty link` with existing branch
- 🔨 [projects] Remove redundant check in `ProjectRepository.link`
- 🔨 [projects] Remove dead code in `ProjectRepository.link`
