### PR TITLE
✨ [projects] Store template revision in cutty.json

### DIFF
--- a/src/cutty/projects/projectconfig.py
+++ b/src/cutty/projects/projectconfig.py
@@ -55,7 +55,7 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
 
     if not (directory is None or isinstance(directory, str)):
         raise TypeError(
-            f"{path}: template directory must be 'str' or 'None', got {template!r}"
+            f"{path}: template directory must be 'str' or 'None', got {directory!r}"
         )
 
     revision = data["template"]["revision"]

--- a/src/cutty/projects/projectconfig.py
+++ b/src/cutty/projects/projectconfig.py
@@ -29,7 +29,11 @@ def createprojectconfigfile(project: PurePath, config: ProjectConfig) -> Regular
     directory = str(config.directory) if config.directory is not None else None
     path = project / PROJECT_CONFIG_FILE
     data = {
-        "template": {"location": config.template, "directory": directory},
+        "template": {
+            "location": config.template,
+            "revision": config.revision,
+            "directory": directory,
+        },
         "bindings": {binding.name: binding.value for binding in config.bindings},
     }
     text = json.dumps(data, indent=2) + "\n"

--- a/src/cutty/projects/projectconfig.py
+++ b/src/cutty/projects/projectconfig.py
@@ -21,6 +21,7 @@ class ProjectConfig:
     template: str
     bindings: Sequence[Binding]
     directory: Optional[pathlib.PurePosixPath] = None
+    revision: Optional[str] = None
 
 
 def createprojectconfigfile(project: PurePath, config: ProjectConfig) -> RegularFile:

--- a/src/cutty/projects/projectconfig.py
+++ b/src/cutty/projects/projectconfig.py
@@ -58,12 +58,20 @@ def readprojectconfigfile(project: pathlib.Path) -> ProjectConfig:
             f"{path}: template directory must be 'str' or 'None', got {template!r}"
         )
 
+    revision = data["template"]["revision"]
+
+    if not (revision is None or isinstance(revision, str)):
+        raise TypeError(
+            f"{path}: template revision must be 'str' or 'None', got {revision!r}"
+        )
+
     bindings = [Binding(key, value) for key, value in data["bindings"].items()]
 
     return ProjectConfig(
         template,
         bindings,
         directory=pathlib.PurePosixPath(directory) if directory is not None else None,
+        revision=revision,
     )
 
 

--- a/tests/unit/projects/test_projectconfig.py
+++ b/tests/unit/projects/test_projectconfig.py
@@ -93,6 +93,24 @@ def test_readprojectconfigfile_directory_typeerror(
         readprojectconfigfile(storage.root)
 
 
+def test_readprojectconfigfile_revision_typeerror(
+    storage: DiskFileStorage, projectconfig: ProjectConfig
+) -> None:
+    """It checks that the template revision is a string or None."""
+    file = createprojectconfigfile(PurePath(), projectconfig)
+
+    # Replace the template location with 42 in the JSON record.
+    data = json.loads(file.blob.decode())
+    data["template"]["revision"] = 42
+    file = dataclasses.replace(file, blob=json.dumps(data).encode())
+
+    with storage:
+        storage.add(file)
+
+    with pytest.raises(TypeError):
+        readprojectconfigfile(storage.root)
+
+
 def test_createprojectconfigfile_format(
     storage: DiskFileStorage, projectconfig: ProjectConfig
 ) -> None:

--- a/tests/unit/projects/test_projectconfig.py
+++ b/tests/unit/projects/test_projectconfig.py
@@ -130,7 +130,7 @@ def test_readcookiecutterjson(
 ) -> None:
     """It loads a project configuration from a .cookiecutter.json file."""
     # The .cookiecutter.json format does not include the template directory.
-    projectconfig = dataclasses.replace(projectconfig, directory=None)
+    projectconfig = dataclasses.replace(projectconfig, directory=None, revision=None)
 
     file = createlegacyprojectconfigfile(PurePath(), projectconfig)
 

--- a/tests/unit/projects/test_projectconfig.py
+++ b/tests/unit/projects/test_projectconfig.py
@@ -2,6 +2,7 @@
 import dataclasses
 import json
 import pathlib
+from typing import Any
 
 import pytest
 
@@ -57,51 +58,23 @@ def test_readprojectconfigfile_typeerror(
         readprojectconfigfile(storage.root)
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("location", None),
+        ("directory", 42),
+        ("revision", 42),
+    ],
+)
 def test_readprojectconfigfile_template_typeerror(
-    storage: DiskFileStorage, projectconfig: ProjectConfig
+    storage: DiskFileStorage, projectconfig: ProjectConfig, field: str, value: Any
 ) -> None:
     """It checks that the template location is a string."""
     file = createprojectconfigfile(PurePath(), projectconfig)
 
     # Replace the template location with `None` in the JSON record.
     data = json.loads(file.blob.decode())
-    data["template"]["location"] = None
-    file = dataclasses.replace(file, blob=json.dumps(data).encode())
-
-    with storage:
-        storage.add(file)
-
-    with pytest.raises(TypeError):
-        readprojectconfigfile(storage.root)
-
-
-def test_readprojectconfigfile_directory_typeerror(
-    storage: DiskFileStorage, projectconfig: ProjectConfig
-) -> None:
-    """It checks that the template directory is a string or None."""
-    file = createprojectconfigfile(PurePath(), projectconfig)
-
-    # Replace the template location with 42 in the JSON record.
-    data = json.loads(file.blob.decode())
-    data["template"]["directory"] = 42
-    file = dataclasses.replace(file, blob=json.dumps(data).encode())
-
-    with storage:
-        storage.add(file)
-
-    with pytest.raises(TypeError):
-        readprojectconfigfile(storage.root)
-
-
-def test_readprojectconfigfile_revision_typeerror(
-    storage: DiskFileStorage, projectconfig: ProjectConfig
-) -> None:
-    """It checks that the template revision is a string or None."""
-    file = createprojectconfigfile(PurePath(), projectconfig)
-
-    # Replace the template location with 42 in the JSON record.
-    data = json.loads(file.blob.decode())
-    data["template"]["revision"] = 42
+    data["template"][field] = value
     file = dataclasses.replace(file, blob=json.dumps(data).encode())
 
     with storage:

--- a/tests/unit/projects/test_projectconfig.py
+++ b/tests/unit/projects/test_projectconfig.py
@@ -44,7 +44,7 @@ def test_roundtrip(storage: DiskFileStorage, projectconfig: ProjectConfig) -> No
 def test_readprojectconfigfile_typeerror(
     storage: DiskFileStorage, projectconfig: ProjectConfig
 ) -> None:
-    """It checks that the template location is a string."""
+    """It checks that the payload is a JSON object."""
     file = createprojectconfigfile(PurePath(), projectconfig)
     file = dataclasses.replace(file, blob=json.dumps("teapot").encode())
 

--- a/tests/unit/projects/test_projectconfig.py
+++ b/tests/unit/projects/test_projectconfig.py
@@ -21,8 +21,9 @@ def projectconfig() -> ProjectConfig:
     """Fixture for a project configuration."""
     template = "https://example.com/repository.git"
     bindings = [Binding("project", "example"), Binding("license", "MIT")]
+    directory = pathlib.PurePosixPath("a")
 
-    return ProjectConfig(template, bindings, directory=pathlib.PurePosixPath("a"))
+    return ProjectConfig(template, bindings, directory=directory)
 
 
 @pytest.fixture

--- a/tests/unit/projects/test_projectconfig.py
+++ b/tests/unit/projects/test_projectconfig.py
@@ -20,10 +20,11 @@ from cutty.templates.domain.bindings import Binding
 def projectconfig() -> ProjectConfig:
     """Fixture for a project configuration."""
     template = "https://example.com/repository.git"
+    revision = "cac8df79d0680240f6d7d11c027548d5582ea308"
     bindings = [Binding("project", "example"), Binding("license", "MIT")]
     directory = pathlib.PurePosixPath("a")
 
-    return ProjectConfig(template, bindings, directory=directory)
+    return ProjectConfig(template, bindings, directory=directory, revision=revision)
 
 
 @pytest.fixture


### PR DESCRIPTION
- 💡 [projects] Fix bogus docstring for `readprojectconfigfile` test
- 🔨 [projects] Extract variable `directory` in `projectconfig` fixture
- ✅ [projects] Update test fixture to pass revision to `ProjectConfig`
- ✨ [projects] Add attribute `ProjectConfig.revision`
- ✅ [projects] Adapt test for `readcookiecutterjson`
- ✨ [projects] Load template revision from cutty.json
- 🐛 [projects] Fix bogus value in error message for invalid cutty.json
- ✨ [projects] Store template revision in cutty.json
- ✅ [projects] Add test for invalid template revision in cutty.json
- 🔨 [projects] Parameterize test for `readprojectconfigfile` type errors
