### PR TITLE
💥 [services] Use cutty.json to determine the base revision for updates

### DIFF
--- a/src/cutty/projects/generator.py
+++ b/src/cutty/projects/generator.py
@@ -55,7 +55,10 @@ class ProjectGenerator:
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
         projectconfig = ProjectConfig(
-            self._template.location, bindings, directory=self._template.directory
+            self._template.location,
+            bindings,
+            directory=self._template.directory,
+            revision=self._template.revision,
         )
         projectconfigfile = createprojectconfigfile(
             PurePath(project.name), projectconfig

--- a/src/cutty/projects/projectconfig.py
+++ b/src/cutty/projects/projectconfig.py
@@ -20,7 +20,7 @@ class ProjectConfig:
 
     template: str
     bindings: Sequence[Binding]
-    revision: Optional[str] = None
+    revision: Optional[str]
     directory: Optional[pathlib.Path] = None
 
 
@@ -88,4 +88,4 @@ def readcookiecutterjson(project: pathlib.Path) -> ProjectConfig:
     template = data.pop("_template")
     bindings = [Binding(name, value) for name, value in data.items()]
 
-    return ProjectConfig(template, bindings)
+    return ProjectConfig(template, bindings, revision=None)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -59,6 +59,7 @@ class ProjectRepository:
         with self.reset(template) as path:
             yield path
 
+        message = _linkcommitmessage(template)
         update = self.project.branch(UPDATE_BRANCH)
 
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(
@@ -66,7 +67,7 @@ class ProjectRepository:
         )
 
         self.project.commit(
-            message=_linkcommitmessage(template),
+            message=message,
             author=update.commit.author,
             committer=self.project.default_signature,
         )

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -51,6 +51,8 @@ class ProjectRepository:
         # Squash the empty initial commit.
         _squash_branch(self.project, update)
 
+        self.project.heads[LATEST_BRANCH] = update.commit
+
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(
             (update.commit.tree / PROJECT_CONFIG_FILE).data
         )
@@ -60,8 +62,6 @@ class ProjectRepository:
             author=update.commit.author,
             committer=self.project.default_signature,
         )
-
-        self.project.heads[LATEST_BRANCH] = update.commit
 
     @contextmanager
     def update(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -53,6 +53,8 @@ class ProjectRepository:
 
         self.project.heads[LATEST_BRANCH] = update.commit
 
+        update = self.project.branch(UPDATE_BRANCH)
+
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(
             (update.commit.tree / PROJECT_CONFIG_FILE).data
         )

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -59,7 +59,10 @@ class ProjectRepository:
         with self.reset(template) as path:
             yield path
 
-        message = _linkcommitmessage(template)
+        self.updateconfig(message=_linkcommitmessage(template))
+
+    def updateconfig(self, message: str) -> None:
+        """Update the project configuration."""
         update = self.project.branch(UPDATE_BRANCH)
 
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -34,10 +34,7 @@ class ProjectRepository:
         project.heads[LATEST_BRANCH] = project.head.commit
 
     @contextmanager
-    def link(
-        self,
-        template: Template.Metadata,
-    ) -> Iterator[Path]:
+    def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
         for name in (LATEST_BRANCH, UPDATE_BRANCH):
             self.project.heads.pop(name, None)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -34,8 +34,8 @@ class ProjectRepository:
         project.heads[LATEST_BRANCH] = project.head.commit
 
     @contextmanager
-    def link(self, template: Template.Metadata) -> Iterator[Path]:
-        """Link a project to a project template."""
+    def reset(self, template: Template.Metadata) -> Iterator[Path]:
+        """Create an orphan branch for project generation."""
         for name in (LATEST_BRANCH, UPDATE_BRANCH):
             self.project.heads.pop(name, None)
 
@@ -52,6 +52,12 @@ class ProjectRepository:
         _squash_branch(self.project, update)
 
         self.project.heads[LATEST_BRANCH] = update.commit
+
+    @contextmanager
+    def link(self, template: Template.Metadata) -> Iterator[Path]:
+        """Link a project to a project template."""
+        with self.reset(template) as path:
+            yield path
 
         update = self.project.branch(UPDATE_BRANCH)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -106,6 +106,7 @@ class ProjectRepository:
         """Skip an update with conflicts."""
         self.project.resetcherrypick()
         self.project.heads[LATEST_BRANCH] = self.project.heads[UPDATE_BRANCH]
+        self.updateconfig("Skip update")
 
     def abortupdate(self) -> None:
         """Abort an update with conflicts."""

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -27,6 +27,16 @@ def update(
         directory = projectconfig.directory
 
     repository = ProjectRepository(projectdir)
+    template = Template.load(
+        projectconfig.template, projectconfig.revision, projectconfig.directory
+    )
+
+    with repository.reset(template.metadata) as outputdir:
+        project = generate(
+            template, extrabindings=projectconfig.bindings, interactive=interactive
+        )
+        storeproject(project, outputdir, outputdirisproject=True)
+
     template = Template.load(projectconfig.template, revision, directory)
 
     with repository.update(template.metadata) as outputdir:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -26,8 +26,8 @@ def update(
     if directory is None:
         directory = projectconfig.directory
 
-    template = Template.load(projectconfig.template, revision, directory)
     repository = ProjectRepository(projectdir)
+    template = Template.load(projectconfig.template, revision, directory)
 
     with repository.update(template.metadata) as outputdir:
         project = generate(

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -371,7 +371,6 @@ def undo(repository: Repository) -> None:
     repository._repository.reset(parent.id, pygit2.GIT_RESET_HARD)
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_reverted_update(
     runcutty: RunCutty, templateproject: Path, project: Path
 ) -> None:

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -334,6 +334,7 @@ def test_continue(runcutty: RunCutty, templateproject: Path, project: Path) -> N
     assert (project / "LICENSE").read_text() == "b"
 
 
+@pytest.mark.xfail(reason="merge conflict in cutty.json due to template revision")
 def test_skip(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
     """It skips the update."""
     updatefile(project / "LICENSE", "a")

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -334,7 +334,6 @@ def test_continue(runcutty: RunCutty, templateproject: Path, project: Path) -> N
     assert (project / "LICENSE").read_text() == "b"
 
 
-@pytest.mark.xfail(reason="merge conflict in cutty.json due to template revision")
 def test_skip(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
     """It skips the update."""
     updatefile(project / "LICENSE", "a")

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -116,6 +116,7 @@ def test_continueupdate_state_cleanup(repository: Repository, path: Path) -> Non
 
 def test_skipupdate_fastforwards_latest(repository: Repository, path: Path) -> None:
     """It fast-forwards the latest branch to the tip of the update branch."""
+    updatefile(repository.path / "cutty.json")
     createconflict(repository, path, ours="a", theirs="b")
 
     updatehead = repository.heads[UPDATE_BRANCH]


### PR DESCRIPTION
- ✨ [projects] Store template revision in cutty.json
- 🚨 [functional] Mark test for `cutty update --skip` as XFAIL
- 🔨 [projects] Remove default argument for `ProjectConfig.revision`
- 🎨 [projects] Reformat function `ProjectRepository.link`
- 🔨 [projects] Slide `latest` branch creation in `ProjectRepository.link`
- 🔨 [projects] Split variable `update` in `ProjectRepository.link`
- 🔨 [projects] Extract function `ProjectRepository.reset`
- 🔨 [services] Slide statement in `update`
- ✨ [services] Use template revision from cutty.json in `cutty update`
- ✅ [functional] Remove XFAIL marker for reverted update test
- ✅ [functional] Remove XFAIL marker for `cutty update --skip` test
- 🔨 [projects] Extract variable `message` in `ProjectRepository.link`
- 🔨 [projects] Extract function `ProjectRepository.updateconfig`
- ✨ [projects] Update project config on `cutty update --skip`
- ✅ [projects] Adapt unit test for `ProjectRepository.skipupdate` to provide cutty.json
