### PR TITLE
💥 [projects] Do not create long-living branches to track project updates

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -54,7 +54,7 @@ class ProjectRepository:
         # Squash the empty initial commit.
         _squash_branch(self.project, update)
 
-        latest = self.project.heads[LATEST_BRANCH] = update.commit
+        latest = update.commit
 
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -83,7 +83,6 @@ class ProjectRepository:
         self, template: Template.Metadata, *, parent: pygit2.Commit
     ) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
-        latestbranch = self.project.branch(LATEST_BRANCH)
         updatebranch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
 
         with self.project.worktree(updatebranch, checkout=False) as worktree:
@@ -91,8 +90,6 @@ class ProjectRepository:
             worktree.commit(message=_updatecommitmessage(template))
 
         self.project.cherrypick(updatebranch.commit)
-
-        latestbranch.commit = updatebranch.commit
 
     def continueupdate(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -34,7 +34,7 @@ class ProjectRepository:
         project.heads[LATEST_BRANCH] = project.head.commit
 
     @contextmanager
-    def reset(self, template: Template.Metadata) -> Iterator[Path]:
+    def reset2(self, template: Template.Metadata) -> Iterator[Path]:
         """Create an orphan branch for project generation."""
         for name in (LATEST_BRANCH, UPDATE_BRANCH):
             self.project.heads.pop(name, None)
@@ -52,6 +52,12 @@ class ProjectRepository:
         _squash_branch(self.project, update)
 
         self.project.heads[LATEST_BRANCH] = update.commit
+
+    @contextmanager
+    def reset(self, template: Template.Metadata) -> Iterator[Path]:
+        """Create an orphan branch for project generation."""
+        with self.reset2(template) as path:
+            yield path
 
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -37,8 +37,6 @@ class ProjectRepository:
         self, template: Template.Metadata
     ) -> Iterator[tuple[Path, Callable[[], pygit2.Commit]]]:
         """Create an orphan branch for project generation."""
-        self.project.heads.pop(UPDATE_BRANCH, None)
-
         # Unborn branches cannot have worktrees. Create an orphan branch with an
         # empty placeholder commit instead. We'll squash it after project creation.
         update = _create_orphan_branch(self.project, UPDATE_BRANCH)
@@ -113,6 +111,7 @@ class ProjectRepository:
 def _create_orphan_branch(repository: Repository, name: str) -> Branch:
     """Create an orphan branch with an empty commit."""
     author = committer = repository.default_signature
+    repository.heads.pop(name, None)
     repository._repository.create_commit(
         f"refs/heads/{name}",
         author,

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -36,7 +36,7 @@ class ProjectRepository:
     def reset(
         self, template: Template.Metadata
     ) -> Iterator[tuple[Path, Callable[[], pygit2.Commit]]]:
-        """Create an orphan branch for project generation."""
+        """Create an orphan commit with a generated project."""
         # Unborn branches cannot have worktrees. Create an orphan branch with an
         # empty placeholder commit instead. We'll squash it after project creation.
         branch = _create_orphan_branch(self.project, UPDATE_BRANCH)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -2,7 +2,6 @@
 from collections.abc import Callable
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Optional
 
 import pygit2
 
@@ -64,13 +63,8 @@ class ProjectRepository:
 
         self.updateconfig(message=_linkcommitmessage(template), commit=commit)
 
-    def updateconfig(
-        self, message: str, *, commit: Optional[pygit2.Commit] = None
-    ) -> None:
+    def updateconfig(self, message: str, *, commit: pygit2.Commit) -> None:
         """Update the project configuration."""
-        if commit is None:
-            commit = self.project.heads[UPDATE_BRANCH]
-
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(
             (commit.tree / PROJECT_CONFIG_FILE).data
         )

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -57,9 +57,7 @@ class ProjectRepository:
         with self.reset(template) as (path, getlatest):
             yield path
 
-        commit = getlatest()
-
-        self.updateconfig(message=_linkcommitmessage(template), commit=commit)
+        self.updateconfig(message=_linkcommitmessage(template), commit=getlatest())
 
     def updateconfig(self, message: str, *, commit: pygit2.Commit) -> None:
         """Update the project configuration."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -12,7 +12,6 @@ from cutty.util.git import Branch
 from cutty.util.git import Repository
 
 
-LATEST_BRANCH = "cutty/latest"
 UPDATE_BRANCH = "cutty/update"
 
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -67,8 +67,7 @@ class ProjectRepository:
     ) -> None:
         """Update the project configuration."""
         if commit is None:
-            update = self.project.branch(UPDATE_BRANCH)
-            commit = update.commit
+            commit = self.project.heads[UPDATE_BRANCH]
 
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(
             (commit.tree / PROJECT_CONFIG_FILE).data

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -47,14 +47,14 @@ class ProjectRepository:
         update = _create_orphan_branch(self.project, UPDATE_BRANCH)
 
         with self.project.worktree(update, checkout=False) as worktree:
-            yield worktree.path, lambda: self.project.heads[LATEST_BRANCH]
+            yield worktree.path, lambda: latest
             message = _createcommitmessage(template)
             worktree.commit(message=message)
 
         # Squash the empty initial commit.
         _squash_branch(self.project, update)
 
-        self.project.heads[LATEST_BRANCH] = update.commit
+        latest = self.project.heads[LATEST_BRANCH] = update.commit
 
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -64,14 +64,15 @@ class ProjectRepository:
     def updateconfig(self, message: str) -> None:
         """Update the project configuration."""
         update = self.project.branch(UPDATE_BRANCH)
+        commit = update.commit
 
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(
-            (update.commit.tree / PROJECT_CONFIG_FILE).data
+            (commit.tree / PROJECT_CONFIG_FILE).data
         )
 
         self.project.commit(
             message=message,
-            author=update.commit.author,
+            author=commit.author,
             committer=self.project.default_signature,
         )
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -111,7 +111,6 @@ class ProjectRepository:
     def abortupdate(self) -> None:
         """Abort an update with conflicts."""
         self.project.resetcherrypick()
-        self.project.heads[UPDATE_BRANCH] = self.project.heads[LATEST_BRANCH]
 
 
 def _create_orphan_branch(repository: Repository, name: str) -> Branch:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -32,7 +32,6 @@ class ProjectRepository:
             project = Repository.init(projectdir)
 
         project.commit(message=_createcommitmessage(template))
-        project.heads[LATEST_BRANCH] = project.head.commit
 
     @contextmanager
     def reset(

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -57,15 +57,9 @@ class ProjectRepository:
         self.project.heads[LATEST_BRANCH] = update.commit
 
     @contextmanager
-    def reset(self, template: Template.Metadata) -> Iterator[Path]:
-        """Create an orphan branch for project generation."""
-        with self.reset2(template) as (path, _):
-            yield path
-
-    @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
-        with self.reset(template) as path:
+        with self.reset2(template) as (path, _):
             yield path
 
         self.updateconfig(message=_linkcommitmessage(template))

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -1,6 +1,7 @@
 """Project repositories."""
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Optional
 
 import pygit2
 
@@ -76,12 +77,16 @@ class ProjectRepository:
         )
 
     @contextmanager
-    def update(self, template: Template.Metadata) -> Iterator[Path]:
+    def update(
+        self, template: Template.Metadata, *, parent: Optional[pygit2.Commit] = None
+    ) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
         latestbranch = self.project.branch(LATEST_BRANCH)
-        updatebranch = self.project.heads.create(
-            UPDATE_BRANCH, latestbranch.commit, force=True
-        )
+
+        if parent is None:
+            parent = latestbranch.commit
+
+        updatebranch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
 
         with self.project.worktree(updatebranch, checkout=False) as worktree:
             yield worktree.path

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -39,17 +39,17 @@ class ProjectRepository:
         """Create an orphan branch for project generation."""
         # Unborn branches cannot have worktrees. Create an orphan branch with an
         # empty placeholder commit instead. We'll squash it after project creation.
-        update = _create_orphan_branch(self.project, UPDATE_BRANCH)
+        branch = _create_orphan_branch(self.project, UPDATE_BRANCH)
 
-        with self.project.worktree(update, checkout=False) as worktree:
+        with self.project.worktree(branch, checkout=False) as worktree:
             yield worktree.path, lambda: latest
             message = _createcommitmessage(template)
             worktree.commit(message=message)
 
         # Squash the empty initial commit.
-        _squash_branch(self.project, update)
+        _squash_branch(self.project, branch)
 
-        latest = update.commit
+        latest = branch.commit
 
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -95,10 +95,9 @@ class ProjectRepository:
 
     def skipupdate(self) -> None:
         """Skip an update with conflicts."""
-        self.project.resetcherrypick()
-
         commit = self.project.heads[UPDATE_BRANCH]
 
+        self.project.resetcherrypick()
         self.updateconfig("Skip update", commit=commit)
 
     def abortupdate(self) -> None:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -76,13 +76,13 @@ class ProjectRepository:
         self, template: Template.Metadata, *, parent: pygit2.Commit
     ) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
-        updatebranch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
+        branch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
 
-        with self.project.worktree(updatebranch, checkout=False) as worktree:
+        with self.project.worktree(branch, checkout=False) as worktree:
             yield worktree.path
             worktree.commit(message=_updatecommitmessage(template))
 
-        self.project.cherrypick(updatebranch.commit)
+        self.project.cherrypick(branch.commit)
 
     def continueupdate(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -82,7 +82,9 @@ class ProjectRepository:
             yield worktree.path
             worktree.commit(message=_updatecommitmessage(template))
 
-        self.project.cherrypick(branch.commit)
+        commit = self.project.heads.pop(branch.name)
+
+        self.project.cherrypick(commit)
 
     def continueupdate(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -106,7 +106,6 @@ class ProjectRepository:
     def skipupdate(self) -> None:
         """Skip an update with conflicts."""
         self.project.resetcherrypick()
-        self.project.heads[LATEST_BRANCH] = self.project.heads[UPDATE_BRANCH]
         self.updateconfig("Skip update")
 
     def abortupdate(self) -> None:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -95,10 +95,9 @@ class ProjectRepository:
 
     def skipupdate(self) -> None:
         """Skip an update with conflicts."""
-        commit = self.project.heads[UPDATE_BRANCH]
-
-        self.project.resetcherrypick()
-        self.updateconfig("Skip update", commit=commit)
+        if commit := self.project.cherrypickhead:  # pragma: no branch
+            self.project.resetcherrypick()
+            self.updateconfig("Skip update", commit=commit)
 
     def abortupdate(self) -> None:
         """Abort an update with conflicts."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -60,7 +60,9 @@ class ProjectRepository:
         with self.reset(template) as (path, _):
             yield path
 
-        self.updateconfig(message=_linkcommitmessage(template))
+        commit = self.project.heads[UPDATE_BRANCH]
+
+        self.updateconfig(message=_linkcommitmessage(template), commit=commit)
 
     def updateconfig(
         self, message: str, *, commit: Optional[pygit2.Commit] = None

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -1,7 +1,6 @@
 """Project repositories."""
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Optional
 
 import pygit2
 
@@ -78,14 +77,10 @@ class ProjectRepository:
 
     @contextmanager
     def update(
-        self, template: Template.Metadata, *, parent: Optional[pygit2.Commit] = None
+        self, template: Template.Metadata, *, parent: pygit2.Commit
     ) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
         latestbranch = self.project.branch(LATEST_BRANCH)
-
-        if parent is None:
-            parent = latestbranch.commit
-
         updatebranch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
 
         with self.project.worktree(updatebranch, checkout=False) as worktree:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -49,7 +49,7 @@ class ProjectRepository:
         # Squash the empty initial commit.
         _squash_branch(self.project, branch)
 
-        latest = branch.commit
+        latest = self.project.heads.pop(branch.name)
 
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -38,7 +38,7 @@ class ProjectRepository:
         self, template: Template.Metadata
     ) -> Iterator[tuple[Path, Callable[[], pygit2.Commit]]]:
         """Create an orphan branch for project generation."""
-        for name in (LATEST_BRANCH, UPDATE_BRANCH):
+        for name in (UPDATE_BRANCH,):
             self.project.heads.pop(name, None)
 
         # Unborn branches cannot have worktrees. Create an orphan branch with an

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -38,8 +38,7 @@ class ProjectRepository:
         self, template: Template.Metadata
     ) -> Iterator[tuple[Path, Callable[[], pygit2.Commit]]]:
         """Create an orphan branch for project generation."""
-        for name in (UPDATE_BRANCH,):
-            self.project.heads.pop(name, None)
+        self.project.heads.pop(UPDATE_BRANCH, None)
 
         # Unborn branches cannot have worktrees. Create an orphan branch with an
         # empty placeholder commit instead. We'll squash it after project creation.

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -106,7 +106,10 @@ class ProjectRepository:
     def skipupdate(self) -> None:
         """Skip an update with conflicts."""
         self.project.resetcherrypick()
-        self.updateconfig("Skip update")
+
+        commit = self.project.heads[UPDATE_BRANCH]
+
+        self.updateconfig("Skip update", commit=commit)
 
     def abortupdate(self) -> None:
         """Abort an update with conflicts."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -103,8 +103,6 @@ class ProjectRepository:
                 committer=self.project.default_signature,
             )
 
-        self.project.heads[LATEST_BRANCH] = self.project.heads[UPDATE_BRANCH]
-
     def skipupdate(self) -> None:
         """Skip an update with conflicts."""
         self.project.resetcherrypick()

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -35,7 +35,7 @@ class ProjectRepository:
         project.heads[LATEST_BRANCH] = project.head.commit
 
     @contextmanager
-    def reset2(
+    def reset(
         self, template: Template.Metadata
     ) -> Iterator[tuple[Path, Callable[[], pygit2.Commit]]]:
         """Create an orphan branch for project generation."""
@@ -59,7 +59,7 @@ class ProjectRepository:
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
-        with self.reset2(template) as (path, _):
+        with self.reset(template) as (path, _):
             yield path
 
         self.updateconfig(message=_linkcommitmessage(template))

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -2,6 +2,7 @@
 from collections.abc import Callable
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Optional
 
 import pygit2
 
@@ -61,10 +62,13 @@ class ProjectRepository:
 
         self.updateconfig(message=_linkcommitmessage(template))
 
-    def updateconfig(self, message: str) -> None:
+    def updateconfig(
+        self, message: str, *, commit: Optional[pygit2.Commit] = None
+    ) -> None:
         """Update the project configuration."""
-        update = self.project.branch(UPDATE_BRANCH)
-        commit = update.commit
+        if commit is None:
+            update = self.project.branch(UPDATE_BRANCH)
+            commit = update.commit
 
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(
             (commit.tree / PROJECT_CONFIG_FILE).data

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -54,10 +54,10 @@ class ProjectRepository:
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
-        with self.reset(template) as (path, _):
+        with self.reset(template) as (path, getlatest):
             yield path
 
-        commit = self.project.heads[UPDATE_BRANCH]
+        commit = getlatest()
 
         self.updateconfig(message=_linkcommitmessage(template), commit=commit)
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from cutty.projects.generate import generate
 from cutty.projects.projectconfig import readprojectconfigfile
+from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -39,7 +40,8 @@ def update(
 
     template = Template.load(projectconfig.template, revision, directory)
 
-    with repository.update(template.metadata) as outputdir:
+    parent = repository.project.heads[LATEST_BRANCH]
+    with repository.update(template.metadata, parent=parent) as outputdir:
         project = generate(
             template, extrabindings=extrabindings, interactive=interactive
         )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -32,7 +32,7 @@ def update(
         projectconfig.template, projectconfig.revision, projectconfig.directory
     )
 
-    with repository.reset(template.metadata) as outputdir:
+    with repository.reset2(template.metadata) as (outputdir, _):
         project = generate(
             template, extrabindings=projectconfig.bindings, interactive=interactive
         )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -32,7 +32,7 @@ def update(
         projectconfig.template, projectconfig.revision, projectconfig.directory
     )
 
-    with repository.reset2(template.metadata) as (outputdir, _):
+    with repository.reset(template.metadata) as (outputdir, _):
         project = generate(
             template, extrabindings=projectconfig.bindings, interactive=interactive
         )

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 from cutty.projects.generate import generate
 from cutty.projects.projectconfig import readprojectconfigfile
-from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -32,7 +31,7 @@ def update(
         projectconfig.template, projectconfig.revision, projectconfig.directory
     )
 
-    with repository.reset(template.metadata) as (outputdir, _):
+    with repository.reset(template.metadata) as (outputdir, getlatest):
         project = generate(
             template, extrabindings=projectconfig.bindings, interactive=interactive
         )
@@ -40,7 +39,7 @@ def update(
 
     template = Template.load(projectconfig.template, revision, directory)
 
-    parent = repository.project.heads[LATEST_BRANCH]
+    parent = getlatest()
     with repository.update(template.metadata, parent=parent) as outputdir:
         project = generate(
             template, extrabindings=extrabindings, interactive=interactive

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -39,8 +39,7 @@ def update(
 
     template = Template.load(projectconfig.template, revision, directory)
 
-    parent = getlatest()
-    with repository.update(template.metadata, parent=parent) as outputdir:
+    with repository.update(template.metadata, parent=getlatest()) as outputdir:
         project = generate(
             template, extrabindings=extrabindings, interactive=interactive
         )

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -116,7 +116,6 @@ def test_empty_template(emptytemplate: Path, runcutty: RunCutty) -> None:
         runcutty("create", str(emptytemplate))
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_no_branches(runcutty: RunCutty, template: Path) -> None:
     """It does not create additional branches."""
     project = Repository.init(Path("example"))

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -114,3 +114,16 @@ def test_empty_template(emptytemplate: Path, runcutty: RunCutty) -> None:
     """It exits with a non-zero status code."""
     with pytest.raises(RunCuttyError):
         runcutty("create", str(emptytemplate))
+
+
+@pytest.mark.xfail(reason="TODO")
+def test_no_branches(runcutty: RunCutty, template: Path) -> None:
+    """It does not create additional branches."""
+    project = Repository.init(Path("example"))
+    project.commit()
+
+    branches = list(project.heads)
+
+    runcutty("create", f"--output-dir={project.path}", "--in-place", str(template))
+
+    assert branches == list(project.heads)

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -5,7 +5,6 @@ import pytest
 
 from cutty.projects.projectconfig import readprojectconfigfile
 from cutty.projects.repository import LATEST_BRANCH
-from cutty.projects.repository import UPDATE_BRANCH
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
 from tests.functional.conftest import RunCuttyError
@@ -89,46 +88,6 @@ def test_revision(runcutty: RunCutty, project: Path, template: Path) -> None:
     assert "LICENSE" not in latest.commit.tree
 
 
-def test_orphan_branch(runcutty: RunCutty, project: Path, template: Path) -> None:
-    """It creates an orphan branch."""
-    runcutty("link", f"--cwd={project}", str(template))
-
-    repository = Repository.open(project)
-    assert not repository.heads[LATEST_BRANCH].parents
-
-
-def test_update_branch_exists(
-    runcutty: RunCutty, project: Path, template: Path
-) -> None:
-    """It does not crash if latest and update branches already exist."""
-    repository = Repository.open(project)
-    for branch in UPDATE_BRANCH, LATEST_BRANCH:
-        repository.heads.create(branch)
-
-    updatefile(project / "marker")
-
-    runcutty("link", f"--cwd={project}", str(template))
-
-    assert (project / "marker").is_file()
-    assert (project / "cutty.json").is_file()
-
-
-def test_latest_branch_exists(
-    runcutty: RunCutty, project: Path, template: Path
-) -> None:
-    """It resets an existing latest branch."""
-    repository = Repository.open(project)
-    _, latest = [
-        repository.heads.create(branch) for branch in (UPDATE_BRANCH, LATEST_BRANCH)
-    ]
-
-    updatefile(project / "marker")
-
-    runcutty("link", f"--cwd={project}", str(template))
-
-    assert not latest.commit.parents
-
-
 def test_commit_message_template(
     runcutty: RunCutty, project: Path, template: Path
 ) -> None:
@@ -141,22 +100,6 @@ def test_commit_message_template(
 
 def test_commit_message_verb(runcutty: RunCutty, project: Path, template: Path) -> None:
     """It uses the verb 'Link' in the commit message."""
-    runcutty("link", f"--cwd={project}", str(template))
-
-    repository = Repository.open(project)
-    assert "Link" in repository.head.commit.message
-
-
-def test_commit_message_verb_branch_exists(
-    runcutty: RunCutty, project: Path, template: Path
-) -> None:
-    """It uses the verb 'Link' when the update branch already exists."""
-    repository = Repository.open(project)
-    for branch in UPDATE_BRANCH, LATEST_BRANCH:
-        repository.heads.create(branch)
-
-    updatefile(project / "marker")
-
     runcutty("link", f"--cwd={project}", str(template))
 
     repository = Repository.open(project)

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 
 from cutty.projects.projectconfig import readprojectconfigfile
-from cutty.projects.repository import LATEST_BRANCH
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
 from tests.functional.conftest import RunCuttyError
@@ -83,9 +82,9 @@ def test_revision(runcutty: RunCutty, project: Path, template: Path) -> None:
     updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
 
     runcutty("link", f"--cwd={project}", f"--revision={initial}", str(template))
+    runcutty("update", f"--cwd={project}")
 
-    latest = Repository.open(project).branch(LATEST_BRANCH)
-    assert "LICENSE" not in latest.commit.tree
+    assert "LICENSE" in Repository.open(project).head.commit.tree
 
 
 def test_commit_message_template(

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -392,3 +392,15 @@ def test_reverted_update(
 
     assert "a" in repository.head.commit.tree
     assert "b" in repository.head.commit.tree
+
+
+@pytest.mark.xfail(reason="TODO")
+def test_no_branches(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
+    """It does not create additional branches."""
+    repository = Repository.open(project)
+    branches = list(repository.heads)
+
+    updatefile(templateproject / "LICENSE")
+    runcutty("update", f"--cwd={project}")
+
+    assert branches == list(repository.heads)

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -394,7 +394,6 @@ def test_reverted_update(
     assert "b" in repository.head.commit.tree
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_no_branches(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
     """It does not create additional branches."""
     repository = Repository.open(project)

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -8,7 +8,6 @@ from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.util.git import Repository
@@ -101,21 +100,3 @@ def test_existing_repository(
     creategitrepository(projectpath, template)
 
     assert file.path.name in repository.head.commit.tree
-
-
-def test_branch(project: pathlib.Path, template: Template.Metadata) -> None:
-    """It creates a branch pointing to the initial commit."""
-    creategitrepository(project, template)
-
-    repository = Repository.open(project)
-    assert repository.head.commit == repository.heads[LATEST_BRANCH]
-
-
-def test_branch_not_checked_out(
-    project: pathlib.Path, template: Template.Metadata
-) -> None:
-    """It does not check out the `latest` branch."""
-    creategitrepository(project, template)
-
-    repository = Repository.open(project)
-    assert repository.head.name != LATEST_BRANCH

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -3,12 +3,9 @@ import dataclasses
 
 import pytest
 
-from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.repository import UPDATE_BRANCH
 from cutty.projects.template import Template
 from cutty.util.git import Repository
-from tests.util.git import updatefile
 
 
 pytest_plugins = ["tests.fixtures.git"]
@@ -63,49 +60,3 @@ def test_linkproject_commit_message_revision(
     linkproject(project, template)
 
     assert template.revision in project.head.commit.message
-
-
-def test_linkproject_latest_branch(
-    project: Repository, template: Template.Metadata
-) -> None:
-    """It creates the latest branch."""
-    updatefile(project.path / "initial")
-
-    linkproject(project, template)
-
-    assert LATEST_BRANCH in project.heads
-
-
-def test_linkproject_latest_branch_commit_message(
-    project: Repository, template: Template.Metadata
-) -> None:
-    """It uses a commit message indicating an initial import."""
-    updatefile(project.path / "initial")
-
-    linkproject(project, template)
-
-    assert "initial" in project.heads[LATEST_BRANCH].message.lower()
-
-
-def test_linkproject_latest_branch_commit_message_update(
-    project: Repository, template: Template.Metadata
-) -> None:
-    """It uses a commit message indicating an initial import."""
-    project.heads.create(LATEST_BRANCH)
-
-    updatefile(project.path / "initial")
-
-    linkproject(project, template)
-
-    assert "initial" in project.heads[LATEST_BRANCH].message.lower()
-
-
-def test_linkproject_update_branch(
-    project: Repository, template: Template.Metadata
-) -> None:
-    """It creates the update branch."""
-    updatefile(project.path / "initial")
-
-    linkproject(project, template)
-
-    assert UPDATE_BRANCH in project.heads

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -17,9 +17,6 @@ from tests.util.git import updatefile
 pytest_plugins = ["tests.fixtures.git"]
 
 
-LATEST_BRANCH = "cutty/latest"
-
-
 def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
@@ -54,7 +51,7 @@ def createconflict(
 ) -> None:
     """Create an update conflict."""
     main = repository.head
-    update, _ = createbranches(repository, UPDATE_BRANCH, LATEST_BRANCH)
+    [update] = createbranches(repository, UPDATE_BRANCH)
 
     repository.checkout(update)
     updatefile(path, theirs)
@@ -125,7 +122,6 @@ def test_abortupdate(repository: Repository, path: Path) -> None:
 @pytest.fixture
 def project(repository: Repository) -> Repository:
     """Fixture for a project repository."""
-    repository.heads.create(LATEST_BRANCH)
     return repository
 
 

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -115,16 +115,15 @@ def test_continueupdate_state_cleanup(repository: Repository, path: Path) -> Non
     assert repository.cherrypickhead is None
 
 
-def test_skipupdate_fastforwards_latest(repository: Repository, path: Path) -> None:
-    """It fast-forwards the latest branch to the tip of the update branch."""
+def test_skipupdate(repository: Repository, path: Path) -> None:
+    """It uses our version."""
     updatefile(repository.path / "cutty.json")
     createconflict(repository, path, ours="a", theirs="b")
 
-    updatehead = repository.heads[UPDATE_BRANCH]
-
     skipupdate(repository.path)
 
-    assert repository.heads[LATEST_BRANCH] == updatehead
+    blob = repository.head.commit.tree / path.name
+    assert blob.data.decode() == "a"
 
 
 def test_abortupdate_rewinds_update_branch(repository: Repository, path: Path) -> None:

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -21,7 +21,8 @@ pytest_plugins = ["tests.fixtures.git"]
 def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
-    with project.update(template) as outputdir:
+    parent = project.project.heads[LATEST_BRANCH]
+    with project.update(template, parent=parent) as outputdir:
         (outputdir / "cutty.json").touch()
 
 
@@ -168,7 +169,8 @@ def test_updateproject_no_changes(
     tip = project.head.commit
 
     repository = ProjectRepository(project.path)
-    with repository.update(template):
+    parent = repository.project.heads[LATEST_BRANCH]
+    with repository.update(template, parent=parent):
         pass
 
     assert tip == project.head.commit

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -71,26 +71,6 @@ def test_continueupdate_commits_changes(repository: Repository, path: Path) -> N
     assert blob.data == b"b"
 
 
-def test_continueupdate_preserves_metainfo(repository: Repository, path: Path) -> None:
-    """It preserves the original commit message."""
-    createconflict(repository, path, ours="a", theirs="b")
-    resolveconflicts(repository.path, path, Side.THEIRS)
-
-    continueupdate(repository.path)
-
-    assert repository.heads[UPDATE_BRANCH].message == repository.head.commit.message
-
-
-def test_continueupdate_fastforwards_latest(repository: Repository, path: Path) -> None:
-    """It updates the latest branch to the tip of the update branch."""
-    createconflict(repository, path, ours="a", theirs="b")
-    resolveconflicts(repository.path, path, Side.THEIRS)
-
-    continueupdate(repository.path)
-
-    assert repository.heads[LATEST_BRANCH] == repository.heads[UPDATE_BRANCH]
-
-
 def test_continueupdate_works_after_commit(repository: Repository, path: Path) -> None:
     """It continues the update even if the cherry-pick is no longer in progress."""
     createconflict(repository, path, ours="a", theirs="b")

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -57,8 +57,10 @@ def createconflict(
     repository.checkout(main)
     updatefile(path, ours)
 
+    cherry = repository.heads.pop(branch.name)
+
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick(branch.commit)
+        repository.cherrypick(cherry)
 
 
 def test_continueupdate_commits_changes(repository: Repository, path: Path) -> None:

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -92,7 +92,7 @@ def test_continueupdate_fastforwards_latest(repository: Repository, path: Path) 
 
 
 def test_continueupdate_works_after_commit(repository: Repository, path: Path) -> None:
-    """It updates the latest branch even if the cherry-pick is no longer in progress."""
+    """It continues the update even if the cherry-pick is no longer in progress."""
     createconflict(repository, path, ours="a", theirs="b")
     resolveconflicts(repository.path, path, Side.THEIRS)
 
@@ -101,7 +101,8 @@ def test_continueupdate_works_after_commit(repository: Repository, path: Path) -
 
     continueupdate(repository.path)
 
-    assert repository.heads[LATEST_BRANCH] == repository.heads[UPDATE_BRANCH]
+    blob = repository.head.commit.tree / path.name
+    assert blob.data.decode() == "b"
 
 
 def test_continueupdate_state_cleanup(repository: Repository, path: Path) -> None:

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -126,17 +126,14 @@ def test_skipupdate(repository: Repository, path: Path) -> None:
     assert blob.data.decode() == "a"
 
 
-def test_abortupdate_rewinds_update_branch(repository: Repository, path: Path) -> None:
-    """It resets the update branch to the tip of the latest branch."""
+def test_abortupdate(repository: Repository, path: Path) -> None:
+    """It uses our version."""
     createconflict(repository, path, ours="a", theirs="b")
-
-    latesthead = repository.heads[LATEST_BRANCH]
 
     abortupdate(repository.path)
 
-    assert (
-        repository.heads[LATEST_BRANCH] == latesthead == repository.heads[UPDATE_BRANCH]
-    )
+    blob = repository.head.commit.tree / path.name
+    assert blob.data.decode() == "a"
 
 
 @pytest.fixture

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -23,8 +23,11 @@ LATEST_BRANCH = "cutty/latest"
 def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
-    parent = project.project.heads[LATEST_BRANCH]
-    with project.update(template, parent=parent) as outputdir:
+
+    with project.reset(template) as (outputdir, getlatest):
+        pass
+
+    with project.update(template, parent=getlatest()) as outputdir:
         (outputdir / "cutty.json").touch()
 
 
@@ -171,8 +174,11 @@ def test_updateproject_no_changes(
     tip = project.head.commit
 
     repository = ProjectRepository(project.path)
-    parent = repository.project.heads[LATEST_BRANCH]
-    with repository.update(template, parent=parent):
+
+    with repository.reset(template) as (outputdir, getlatest):
+        pass
+
+    with repository.update(template, parent=getlatest()):
         pass
 
     assert tip == project.head.commit

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.repository import UPDATE_BRANCH
 from cutty.projects.template import Template
 from cutty.util.git import Repository
 from tests.util.git import createbranches
@@ -51,7 +50,7 @@ def createconflict(
 ) -> None:
     """Create an update conflict."""
     main = repository.head
-    [update] = createbranches(repository, UPDATE_BRANCH)
+    [update] = createbranches(repository, "branch")
 
     repository.checkout(update)
     updatefile(path, theirs)

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -181,28 +181,6 @@ def test_updateproject_commit_message_revision(
     assert template.revision in project.head.commit.message
 
 
-def test_updateproject_latest_branch(
-    project: Repository, template: Template.Metadata
-) -> None:
-    """It updates the latest branch."""
-    updatefile(project.path / "initial")
-
-    tip = project.heads[LATEST_BRANCH]
-
-    updateproject(project.path, template)
-
-    assert [tip] == project.heads[LATEST_BRANCH].parents
-
-
-def test_updateproject_update_branch(
-    project: Repository, template: Template.Metadata
-) -> None:
-    """It creates the update branch."""
-    updateproject(project.path, template)
-
-    assert project.heads[LATEST_BRANCH] == project.heads[UPDATE_BRANCH]
-
-
 def test_updateproject_no_changes(
     project: Repository, template: Template.Metadata
 ) -> None:

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -7,7 +7,6 @@ import pytest
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.util.git import Repository
-from tests.util.git import createbranches
 from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
@@ -50,7 +49,7 @@ def createconflict(
 ) -> None:
     """Create an update conflict."""
     main = repository.head
-    [branch] = createbranches(repository, "branch")
+    branch = repository.heads.create("branch")
 
     repository.checkout(branch)
     updatefile(path, theirs)

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-from cutty.projects.repository import LATEST_BRANCH
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.repository import UPDATE_BRANCH
 from cutty.projects.template import Template
@@ -16,6 +15,9 @@ from tests.util.git import updatefile
 
 
 pytest_plugins = ["tests.fixtures.git"]
+
+
+LATEST_BRANCH = "cutty/latest"
 
 
 def updateproject(projectdir: Path, template: Template.Metadata) -> None:

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -50,16 +50,16 @@ def createconflict(
 ) -> None:
     """Create an update conflict."""
     main = repository.head
-    [update] = createbranches(repository, "branch")
+    [branch] = createbranches(repository, "branch")
 
-    repository.checkout(update)
+    repository.checkout(branch)
     updatefile(path, theirs)
 
     repository.checkout(main)
     updatefile(path, ours)
 
     with pytest.raises(Exception, match=path.name):
-        repository.cherrypick(update.commit)
+        repository.cherrypick(branch.commit)
 
 
 def test_continueupdate_commits_changes(repository: Repository, path: Path) -> None:

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -156,7 +156,7 @@ def test_updateproject_commit_message_template(
 def test_updateproject_commit_message_revision(
     project: Repository, template: Template.Metadata
 ) -> None:
-    """It includes the template name in the commit message."""
+    """It includes the template revision in the commit message."""
     template = dataclasses.replace(template, revision="1.0.0")
 
     updateproject(project.path, template)


### PR DESCRIPTION
- 🔥 [projects] Remove branch-related tests from `test_create`
- 🔥 [projects] Remove branch-related tests from `test_link`
- ✅ [projects] Adapt test for `continueupdate` to avoid branches
- ✅ [projects] Adapt test for `skipupdate` to avoid branches
- ✅ [projects] Adapt test for `abortupdate` to avoid branches
- 🔥 [projects] Remove branch-related tests for `updateproject`
- 🔥 [projects] Remove branch-related tests for `continueupdate`
- 🔥 [functional] Remove branch-related tests for `cutty link`
- ✅ [functional] Adapt test for `cutty link --revision` to avoid branches
- ✅ [functional] Add test for `cutty update` not creating branches (XFAIL)
- ✅ [functional] Add test for `cutty create` not creating branches (XFAIL)
- 🔨 [projects] Add optional parameter `parent` to `ProjectRepository.update`
- 🔨 [services] Pass `parent` to `ProjectRepository.update` in `update`
- 🔨 [projects] Pass `parent` to `ProjectRepository.update` in `test_update`
- 🔨 [projects] Require `parent` parameter to `ProjectRepository.update`
- 🔨 [projects] Extract function `ProjectRepository.reset2`
- 🔨 [projects] Return closure over latest commit from `ProjectRepository.reset2`
- 🔨 [projects] Inline function `ProjectRepository.reset`
- 🔨 [projects] Rename function `ProjectRepository.reset2`
- 🔨 [services] Use commit closure instead of branch in `update`
- 🔨 [services] Inline variable `parent`
- 🔨 [projects] Extract variable `latest` in `ProjectRepository.reset`
- 💥 [projects] Do not update latest branch in `cutty update --continue`
- 💥 [projects] Do not update latest branch in `cutty update --skip`
- 💥 [projects] Do not update `update` branch in `cutty update --abort`
- 💥 [projects] Do not update latest branch in `cutty update`
- 💥 [projects] Do not create latest branch in `cutty update` and `cutty link`
- 💥 [projects] Do not create latest branch in `cutty create`
- ✅ [functional] Remove XFAIL marker from test for `cutty create` not creating branches
- 🔨 [projects] Do not remove latest branch in `ProjectRepository.reset`
- 🔨 [projects] Inline variable `name`
- 🔨 [projects] Move constant `LATEST_BRANCH` to `test_update`
- 💡 [projects] Update docstring for `update` test
- ✅ [projects] Adapt `update` tests to use `reset` instead of latest branch
- 🔥 [projects] Remove latest branch from test setup in `test_update`
- 🔨 [projects] Extract variable `commit` in `ProjectRepository.updateconfig`
- 🔨 [projects] Add optional parameter `commit` to `ProjectRepository.updateconfig`
- 🔨 [projects] Inline variable `update` in `ProjectRepository.updateconfig`
- 🔨 [projects] Pass `commit` to `updateconfig` in `link`
- 🔨 [projects] Pass `commit` to `updateconfig` in `skipupdate`
- 🔨 [projects] Require `commit` parameter in `ProjectRepository.updateconfig`
- 🔨 [projects] Remove update branch in `_create_orphan_branch` not its caller
- 🔨 [projects] Use commit closure instead of branch in `ProjectRepository.link`
- 🔨 [projects] Inline variable `commit` in `ProjectRepository.link`
- 🔨 [projects] Rename variable `update` to `branch` in `ProjectRepository.reset`
- 💥 [projects] Do not leak branch from `ProjectRepository.reset`
- 🔨 [projects] Slide statement in `skipupdate`
- 🔨 [projects] Use CHERRY_PICK_HEAD instead of update branch in `skipupdate`
- 🔨 [projects] Rename variable `updatebranch` to `branch` in `ProjectRepository.update`
- 💥 [projects] Do not leak update branch from `ProjectRepository.update`
- 💡 [projects] Improve docstring of `ProjectRepository.reset`
- ✅ [functional] Remove XFAIL marker from test for `cutty update` not creating branches
- ✅ [projects] Do not use `UPDATE_BRANCH` in `test_update` setup
- 🔨 [projects] Rename variable `update` to `branch` in `test_update` setup
- 🔨 [projects] Inline function `createbranches` in `test_update` setup
- ✅ [projects] Remove branch before cherrypick in `test_update` setup
