### PR TITLE
🔨[services] Slide `generate` before `Repository.worktree`

### DIFF
--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -39,9 +39,9 @@ def link(
         raise TemplateNotSpecifiedError()
 
     template = Template.load(location, revision, directory)
+    project = generate(template, extrabindings=extrabindings, interactive=interactive)
 
     repository = ProjectRepository(projectdir)
-    project = generate(template, extrabindings=extrabindings, interactive=interactive)
 
     with repository.link(template.metadata) as outputdir:
         storeproject(project, outputdir, outputdirisproject=True)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -41,9 +41,7 @@ def link(
     template = Template.load(location, revision, directory)
 
     repository = ProjectRepository(projectdir)
+    project = generate(template, extrabindings=extrabindings, interactive=interactive)
 
     with repository.link(template.metadata) as outputdir:
-        project = generate(
-            template, extrabindings=extrabindings, interactive=interactive
-        )
         storeproject(project, outputdir, outputdirisproject=True)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -30,17 +30,15 @@ def update(
     template = Template.load(
         projectconfig.template, projectconfig.revision, projectconfig.directory
     )
+    project = generate(
+        template, extrabindings=projectconfig.bindings, interactive=interactive
+    )
 
     with repository.reset(template.metadata) as (outputdir, getlatest):
-        project = generate(
-            template, extrabindings=projectconfig.bindings, interactive=interactive
-        )
         storeproject(project, outputdir, outputdirisproject=True)
 
     template = Template.load(projectconfig.template, revision, directory)
+    project = generate(template, extrabindings=extrabindings, interactive=interactive)
 
     with repository.update(template.metadata, parent=getlatest()) as outputdir:
-        project = generate(
-            template, extrabindings=extrabindings, interactive=interactive
-        )
         storeproject(project, outputdir, outputdirisproject=True)


### PR DESCRIPTION
- 🔨 [services] Slide project generation before worktree creation in `update`
- 🔨 [services] Slide project generation before worktree creation in `link`
- 🔨 [services] Slide statement in `link`
