### PR TITLE
💥 [entrypoints] Rename option `cutty create --output-dir` to `--cwd`

### DIFF
--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -24,8 +24,8 @@ from cutty.templates.domain.bindings import Binding
     help="Branch, tag, or commit hash of the template repository.",
 )
 @click.option(
-    "-o",
-    "--output-dir",
+    "-C",
+    "--cwd",
     metavar="DIR",
     type=click.Path(file_okay=False, dir_okay=True, path_type=pathlib.Path),
     help="Parent directory of the generated project.",
@@ -65,7 +65,7 @@ def create(
     extra_context: dict[str, str],
     non_interactive: bool,
     revision: Optional[str],
-    output_dir: Optional[pathlib.Path],
+    cwd: Optional[pathlib.Path],
     directory: Optional[pathlib.Path],
     overwrite_if_exists: bool,
     skip_if_file_exists: bool,
@@ -74,13 +74,13 @@ def create(
     """Generate projects from Cookiecutter templates."""
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]
 
-    if output_dir is None:
-        output_dir = pathlib.Path.cwd()
+    if cwd is None:
+        cwd = pathlib.Path.cwd()
 
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
     createproject(
         template,
-        output_dir,
+        cwd,
         extrabindings=extrabindings,
         interactive=not non_interactive,
         revision=revision,

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -57,12 +57,12 @@ def test_cutty_json_already_exists(runcutty: RunCutty, template: Path) -> None:
         runcutty("create", str(template))
 
 
-def test_output_dir(runcutty: RunCutty, template: Path) -> None:
+def test_cwd(runcutty: RunCutty, template: Path) -> None:
     """It creates the project directory in the output directory."""
     outputdir = Path("output")
     outputdir.mkdir()
 
-    runcutty("create", f"--output-dir={outputdir}", str(template))
+    runcutty("create", f"--cwd={outputdir}", str(template))
 
     assert template_files(template) == project_files(outputdir / "example") - EXTRA
 
@@ -123,6 +123,6 @@ def test_no_branches(runcutty: RunCutty, template: Path) -> None:
 
     branches = list(project.heads)
 
-    runcutty("create", f"--output-dir={project.path}", "--in-place", str(template))
+    runcutty("create", f"--cwd={project.path}", "--in-place", str(template))
 
     assert branches == list(project.heads)


### PR DESCRIPTION
- ✅ [functional] Replace `cutty create --output-dir` with `--cwd` in tests
- 💥 [entrypoints] Replace `cutty create --output-dir` with `--cwd`
