### PR TITLE
💥 [entrypoints] Rename option `--directory` to `--template-directory`

### DIFF
--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -31,7 +31,7 @@ from cutty.templates.domain.bindings import Binding
     help="Parent directory of the generated project.",
 )
 @click.option(
-    "--directory",
+    "--template-directory",
     metavar="DIR",
     type=click.Path(path_type=pathlib.Path),
     help=(
@@ -66,7 +66,7 @@ def create(
     non_interactive: bool,
     revision: Optional[str],
     cwd: Optional[pathlib.Path],
-    directory: Optional[pathlib.Path],
+    template_directory: Optional[pathlib.Path],
     overwrite_if_exists: bool,
     skip_if_file_exists: bool,
     in_place: bool,
@@ -84,7 +84,7 @@ def create(
         extrabindings=extrabindings,
         interactive=not non_interactive,
         revision=revision,
-        directory=directory,
+        directory=template_directory,
         fileexists=fileexists,
         in_place=in_place,
     )

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -32,7 +32,7 @@ from cutty.templates.domain.bindings import Binding
     help="Branch, tag, or commit hash of the template repository.",
 )
 @click.option(
-    "--directory",
+    "--template-directory",
     metavar="DIR",
     type=click.Path(path_type=pathlib.Path),
     help=(
@@ -46,7 +46,7 @@ def link(
     non_interactive: bool,
     cwd: Optional[pathlib.Path],
     revision: Optional[str],
-    directory: Optional[pathlib.Path],
+    template_directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
     if cwd is None:
@@ -60,5 +60,5 @@ def link(
         extrabindings=extrabindings,
         interactive=not non_interactive,
         revision=revision,
-        directory=directory,
+        directory=template_directory,
     )

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -32,7 +32,7 @@ from cutty.templates.domain.bindings import Binding
     help="Branch, tag, or commit hash of the template repository.",
 )
 @click.option(
-    "--directory",
+    "--template-directory",
     metavar="DIR",
     type=click.Path(path_type=pathlib.Path),
     help=(
@@ -64,7 +64,7 @@ def update(
     non_interactive: bool,
     cwd: Optional[pathlib.Path],
     revision: Optional[str],
-    directory: Optional[pathlib.Path],
+    template_directory: Optional[pathlib.Path],
     continue_: bool,
     skip: bool,
     abort: bool,
@@ -94,5 +94,5 @@ def update(
         extrabindings=extrabindings,
         interactive=not non_interactive,
         revision=revision,
-        directory=directory,
+        directory=template_directory,
     )

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -79,7 +79,7 @@ def test_directory(runcutty: RunCutty, template: Path) -> None:
     directory = "a"
     move_repository_files_to_subdirectory(template, directory)
 
-    runcutty("create", f"--directory={directory}", str(template))
+    runcutty("create", f"--template-directory={directory}", str(template))
 
     assert template_files(template / "a") == project_files("example") - EXTRA
 

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -69,7 +69,9 @@ def test_directory(runcutty: RunCutty, project: Path, template: Path) -> None:
     directory = "a"
     move_repository_files_to_subdirectory(template, directory)
 
-    runcutty("link", f"--cwd={project}", f"--directory={directory}", str(template))
+    runcutty(
+        "link", f"--cwd={project}", f"--template-directory={directory}", str(template)
+    )
 
     config = readprojectconfigfile(project)
     assert directory == str(config.directory)

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -267,7 +267,7 @@ def test_directory_projectconfig(runcutty: RunCutty, template: Path) -> None:
     directory = "a"
     move_repository_files_to_subdirectory(template, directory)
 
-    runcutty("create", f"--directory={directory}", str(template))
+    runcutty("create", f"--template-directory={directory}", str(template))
     updatefile(template / "a" / "{{ cookiecutter.project }}" / "LICENSE")
     runcutty("update", f"--cwd={project}")
 
@@ -279,7 +279,7 @@ def test_directory_update(runcutty: RunCutty, template: Path, project: Path) -> 
     directory = "a"
     move_repository_files_to_subdirectory(template, directory)
 
-    runcutty("update", f"--cwd={project}", f"--directory={directory}")
+    runcutty("update", f"--cwd={project}", f"--template-directory={directory}")
 
     config = readprojectconfigfile(project)
     assert directory == str(config.directory)


### PR DESCRIPTION
- ✅ [functional] Rename option `--{ => template-}directory` in tests
- 💥 [entrypoints] Rename option `cutty update --{ => template-}directory`
- 💥 [entrypoints] Rename option `cutty link --{ => template-}directory`
- 💥 [entrypoints] Rename option `cutty create --{ => template-}directory`
