### PR TITLE
🔨[services] Use positional parameter for bindings in `generate`

### DIFF
--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -11,8 +11,8 @@ from cutty.templates.domain.bindings import Binding
 def generate(
     template: Template,
     *,
-    extrabindings: Sequence[Binding],
     interactive: bool,
+    extrabindings: Sequence[Binding] = (),
     createconfigfile: bool = True,
 ) -> Project:
     """Generate a project from a project template."""

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -14,13 +14,9 @@ def generate(
     /,
     *,
     interactive: bool,
-    extrabindings: Sequence[Binding] = (),
     createconfigfile: bool = True,
 ) -> Project:
     """Generate a project from a project template."""
-    if extrabindings:
-        bindings = extrabindings
-
     generator = ProjectGenerator.create(template)
 
     bindings = bindcookiecuttervariables(

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -10,19 +10,24 @@ from cutty.templates.domain.bindings import Binding
 
 def generate(
     template: Template,
+    bindings: Sequence[Binding] = (),
+    /,
     *,
     interactive: bool,
     extrabindings: Sequence[Binding] = (),
     createconfigfile: bool = True,
 ) -> Project:
     """Generate a project from a project template."""
+    if extrabindings:
+        bindings = extrabindings
+
     generator = ProjectGenerator.create(template)
 
     bindings = bindcookiecuttervariables(
         generator.variables,
         generator.renderer,
         interactive=interactive,
-        bindings=extrabindings,
+        bindings=bindings,
     )
 
     project = generator.generate(bindings)

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -24,10 +24,7 @@ def createproject(
     template = Template.load(location, checkout, directory)
 
     project = generate(
-        template,
-        extrabindings=extrabindings,
-        interactive=interactive,
-        createconfigfile=False,
+        template, extrabindings, interactive=interactive, createconfigfile=False
     )
 
     storeproject(

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -25,7 +25,7 @@ def createproject(
     """Generate projects from Cookiecutter templates."""
     template = Template.load(location, revision, directory)
 
-    project = generate(template, extrabindings=extrabindings, interactive=interactive)
+    project = generate(template, extrabindings, interactive=interactive)
 
     projectdir = storeproject(
         project,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -39,7 +39,7 @@ def link(
         raise TemplateNotSpecifiedError()
 
     template = Template.load(location, revision, directory)
-    project = generate(template, extrabindings=extrabindings, interactive=interactive)
+    project = generate(template, extrabindings, interactive=interactive)
 
     repository = ProjectRepository(projectdir)
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -30,15 +30,13 @@ def update(
     template = Template.load(
         projectconfig.template, projectconfig.revision, projectconfig.directory
     )
-    project = generate(
-        template, extrabindings=projectconfig.bindings, interactive=interactive
-    )
+    project = generate(template, projectconfig.bindings, interactive=interactive)
 
     with repository.reset(template.metadata) as (outputdir, getlatest):
         storeproject(project, outputdir, outputdirisproject=True)
 
     template = Template.load(projectconfig.template, revision, directory)
-    project = generate(template, extrabindings=extrabindings, interactive=interactive)
+    project = generate(template, extrabindings, interactive=interactive)
 
     with repository.update(template.metadata, parent=getlatest()) as outputdir:
         storeproject(project, outputdir, outputdirisproject=True)


### PR DESCRIPTION
- 🔨 [projects] Add default argument for `extrabindings` in `generate`
- 🔨 [projects] Add optional positional parameter `bindings` to `generate`
- 🔨 [services] Adapt `generate` calls in `update` to use positional parameter
- 🔨 [services] Adapt `generate` call in `link` to use positional parameter
- 🔨 [services] Adapt `generate` call in `create` to use positional parameter
- 🔨 [services] Adapt `generate` call in `cookiecutter` to use positional parameter
- 🔨 [projects] Remove parameter `extrabindings` from `generate`
