### PR TITLE
🔨 [projects] Extract class `ProjectBuilder` from `ProjectRepository`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -69,9 +69,7 @@ class ProjectRepository:
         return commit
 
     @contextmanager
-    def store(
-        self, parent: pygit2.Commit, message: str = ""
-    ) -> Iterator[ProjectBuilder]:
+    def store(self, parent: pygit2.Commit) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
         branch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
 
@@ -79,7 +77,7 @@ class ProjectRepository:
             builder = ProjectBuilder(worktree.path, lambda: commit)
             yield builder
 
-            worktree.commit(message=builder.message or message)
+            worktree.commit(message=builder.message)
 
         commit = self.project.heads.pop(branch.name)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -54,7 +54,7 @@ class ProjectRepository:
     @contextmanager
     def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
         """Create an orphan commit with a generated project."""
-        with self.store(self.root) as builder:
+        with self.build(self.root) as builder:
             builder.message = _createcommitmessage(template)
             yield builder
 
@@ -69,7 +69,7 @@ class ProjectRepository:
         return commit
 
     @contextmanager
-    def store(self, parent: pygit2.Commit) -> Iterator[ProjectBuilder]:
+    def build(self, parent: pygit2.Commit) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
         branch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
 
@@ -106,7 +106,7 @@ class ProjectRepository:
         self, template: Template.Metadata, *, parent: pygit2.Commit
     ) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
-        with self.store(parent) as builder:
+        with self.build(parent) as builder:
             builder.message = _updatecommitmessage(template)
             yield builder.path
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -81,7 +81,7 @@ class ProjectRepository:
 
             worktree.commit(message=builder.message)
 
-        commit = self.project.heads.pop(branch.name)
+        builder._commit = commit = self.project.heads.pop(branch.name)
 
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -108,8 +108,8 @@ class ProjectRepository:
         self, template: Template.Metadata, *, parent: pygit2.Commit
     ) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
-        message = _updatecommitmessage(template)
-        with self.store(parent, message) as builder:
+        with self.store(parent) as builder:
+            builder.message = _updatecommitmessage(template)
             yield builder.path
 
         if builder.commit != parent:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -69,7 +69,9 @@ class ProjectRepository:
         return commit
 
     @contextmanager
-    def store(self, parent: pygit2.Commit, message: str) -> Iterator[ProjectBuilder]:
+    def store(
+        self, parent: pygit2.Commit, message: str = ""
+    ) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
         branch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -1,5 +1,4 @@
 """Project repositories."""
-from collections.abc import Callable
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,7 +25,6 @@ class ProjectBuilder:
     """Adding a project to the repository."""
 
     path: Path
-    _getcommit: Callable[[], pygit2.Commit]
     message: str = ""
     _commit: Optional[pygit2.Commit] = None
 
@@ -77,12 +75,12 @@ class ProjectRepository:
         branch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
 
         with self.project.worktree(branch, checkout=False) as worktree:
-            builder = ProjectBuilder(worktree.path, lambda: commit)
+            builder = ProjectBuilder(worktree.path)
             yield builder
 
             worktree.commit(message=builder.message)
 
-        builder._commit = commit = self.project.heads.pop(branch.name)
+        builder._commit = self.project.heads.pop(branch.name)
 
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -1,6 +1,7 @@
 """Project repositories."""
 from collections.abc import Callable
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 import pygit2
@@ -17,6 +18,19 @@ UPDATE_BRANCH = "cutty/update"
 
 class NoUpdateInProgressError(CuttyError):
     """A sequencer action was invoked without an update in progress."""
+
+
+@dataclass
+class ProjectBuilder:
+    """Adding a project to the repository."""
+
+    path: Path
+    _getcommit: Callable[[], pygit2.Commit]
+
+    @property
+    def commit(self) -> pygit2.Commit:
+        """Return the newly created commit."""
+        return self._getcommit()
 
 
 class ProjectRepository:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -33,7 +33,8 @@ class ProjectBuilder:
     @property
     def commit(self) -> pygit2.Commit:
         """Return the newly created commit."""
-        return self._getcommit()
+        assert self._commit is not None  # noqa: S101
+        return self._commit
 
 
 class ProjectRepository:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -74,8 +74,10 @@ class ProjectRepository:
         branch = self.project.heads.create(UPDATE_BRANCH, parent, force=True)
 
         with self.project.worktree(branch, checkout=False) as worktree:
-            yield ProjectBuilder(worktree.path, lambda: commit)
-            worktree.commit(message=message)
+            builder = ProjectBuilder(worktree.path, lambda: commit)
+            yield builder
+
+            worktree.commit(message=builder.message or message)
 
         commit = self.project.heads.pop(branch.name)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -51,7 +51,7 @@ class ProjectRepository:
         project.commit(message=_createcommitmessage(template))
 
     @contextmanager
-    def reset2(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
+    def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
         """Create an orphan commit with a generated project."""
         message = _createcommitmessage(template)
         with self.store(self.root, message) as (path, getcommit):
@@ -83,7 +83,7 @@ class ProjectRepository:
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
-        with self.reset2(template) as builder:
+        with self.reset(template) as builder:
             yield builder.path
 
         self.updateconfig(message=_linkcommitmessage(template), commit=builder.commit)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -107,9 +107,8 @@ class ProjectRepository:
         with self.store(parent, message) as builder:
             yield builder.path
 
-        commit = builder.commit
-        if commit != parent:
-            self.project.cherrypick(commit)
+        if builder.commit != parent:
+            self.project.cherrypick(builder.commit)
 
     def continueupdate(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -54,8 +54,8 @@ class ProjectRepository:
     @contextmanager
     def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
         """Create an orphan commit with a generated project."""
-        message = _createcommitmessage(template)
-        with self.store(self.root, message) as builder:
+        with self.store(self.root) as builder:
+            builder.message = _createcommitmessage(template)
             yield builder
 
     @property

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import pygit2
 
@@ -27,6 +28,7 @@ class ProjectBuilder:
     path: Path
     _getcommit: Callable[[], pygit2.Commit]
     message: str = ""
+    _commit: Optional[pygit2.Commit] = None
 
     @property
     def commit(self) -> pygit2.Commit:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -34,6 +34,11 @@ class ProjectBuilder:
         assert self._commit is not None  # noqa: S101
         return self._commit
 
+    @commit.setter
+    def commit(self, commit: pygit2.Commit) -> None:
+        """Set the newly created commit."""
+        self._commit = commit
+
 
 class ProjectRepository:
     """Project repository."""
@@ -80,7 +85,7 @@ class ProjectRepository:
 
             worktree.commit(message=builder.message)
 
-        builder._commit = self.project.heads.pop(branch.name)
+        builder.commit = self.project.heads.pop(branch.name)
 
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -26,6 +26,7 @@ class ProjectBuilder:
 
     path: Path
     _getcommit: Callable[[], pygit2.Commit]
+    message: str = ""
 
     @property
     def commit(self) -> pygit2.Commit:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -32,11 +32,11 @@ def update(
     )
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
-    with repository.reset(template.metadata) as (outputdir, getcommit):
-        storeproject(project, outputdir, outputdirisproject=True)
+    with repository.reset2(template.metadata) as builder:
+        storeproject(project, builder.path, outputdirisproject=True)
 
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)
 
-    with repository.update(template.metadata, parent=getcommit()) as outputdir:
+    with repository.update(template.metadata, parent=builder.commit) as outputdir:
         storeproject(project, outputdir, outputdirisproject=True)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -32,7 +32,7 @@ def update(
     )
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
-    with repository.reset2(template.metadata) as builder:
+    with repository.reset(template.metadata) as builder:
         storeproject(project, builder.path, outputdirisproject=True)
 
     template = Template.load(projectconfig.template, revision, directory)

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -19,10 +19,10 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
 
-    with project.reset(template) as (outputdir, getcommit):
+    with project.reset2(template) as builder:
         pass
 
-    with project.update(template, parent=getcommit()) as outputdir:
+    with project.update(template, parent=builder.commit) as outputdir:
         (outputdir / "cutty.json").touch()
 
 
@@ -157,10 +157,10 @@ def test_updateproject_no_changes(
 
     repository = ProjectRepository(project.path)
 
-    with repository.reset(template) as (outputdir, getcommit):
+    with repository.reset2(template) as builder:
         pass
 
-    with repository.update(template, parent=getcommit()):
+    with repository.update(template, parent=builder.commit):
         pass
 
     assert tip == project.head.commit

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -19,7 +19,7 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
 
-    with project.reset2(template) as builder:
+    with project.reset(template) as builder:
         pass
 
     with project.update(template, parent=builder.commit) as outputdir:
@@ -157,7 +157,7 @@ def test_updateproject_no_changes(
 
     repository = ProjectRepository(project.path)
 
-    with repository.reset2(template) as builder:
+    with repository.reset(template) as builder:
         pass
 
     with repository.update(template, parent=builder.commit):


### PR DESCRIPTION
- 🔨 [projects] Add class `ProjectBuilder`
- 🔨 [projects] Extract function `ProjectRepository.reset2` using `ProjectBuilder`
- 🔨 [projects] Inline function `ProjectRepository.reset`
- 🔨 [projects] Rename function `ProjectRepository.reset2`
- 🔨 [projects] Change `ProjectRepository.store` to yield `ProjectBuilder`
- 🔨 [projects] Inline variable `commit`
- 🔨 [projects] Add attribute `ProjectBuilder.message`
- 🔨 [projects] Use `ProjectBuilder.message` in `ProjectRepository.store`
- 🔨 [projects] Do not require parameter `message` in `ProjectRepository.store`
- 🔨 [projects] Use `ProjectBuilder.message` in `ProjectRepository.reset`
- 🔨 [projects] Use `ProjectBuilder.message` in `ProjectRepository.update`
- 🔨 [projects] Remove parameter `message` from `ProjectRepository.store`
- 🔨 [projects] Rename function `ProjectRepository.{store => build}`
- 🔨 [projects] Add attribute `ProjectBuilder._commit`
- 🔨 [projects] Set `ProjectBuilder._commit` in `ProjectRepository.build`
- 🔨 [projects] Use `ProjectBuilder._commit` in `ProjectBuilder.commit`
- 🔨 [projects] Remove attribute `ProjectBuilder._getcommit`
- 🔨 [projects] Extract property setter for `ProjectBuilder.commit`
