### PR TITLE
🔨 [projects] Extract function `ProjectBuilder.commit(message)`, derive attribute `ProjectBuilder.path`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -66,6 +66,12 @@ class ProjectRepository:
     @contextmanager
     def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
         """Create an orphan commit with a generated project."""
+        with self.reset2(template) as builder:
+            yield builder
+
+    @contextmanager
+    def reset2(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
+        """Create an orphan commit with a generated project."""
         with self.build(self.root) as builder:
             builder.message = _createcommitmessage(template)
             yield builder

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -87,7 +87,8 @@ class ProjectRepository:
 
             worktree.commit(message=builder.message)
 
-        commit = self.project.heads.pop(branch.name)
+        commit = branch.commit
+        self.project.heads.pop(branch.name)
         builder.commit = str(commit.id)
 
     @contextmanager

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -61,13 +61,13 @@ class ProjectRepository:
         except pygit2.GitError:
             project = Repository.init(projectdir)
 
-        project.commit(message=_createcommitmessage(template))
+        project.commit(message=createcommitmessage(template))
 
     @contextmanager
     def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
         """Create an orphan commit with a generated project."""
         with self.build(self.root) as builder:
-            builder.message = _createcommitmessage(template)
+            builder.message = createcommitmessage(template)
             yield builder
 
     @property
@@ -153,7 +153,7 @@ class ProjectRepository:
         self.project.resetcherrypick()
 
 
-def _createcommitmessage(template: Template.Metadata) -> str:
+def createcommitmessage(template: Template.Metadata) -> str:
     """Return the commit message for importing the template."""
     if template.revision:
         return f"Initial import from {template.name} {template.revision}"

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -24,7 +24,12 @@ class ProjectBuilder:
     """Adding a project to the repository."""
 
     _worktree: Repository
-    path: Path
+    _path: Path
+
+    @property
+    def path(self) -> Path:
+        """Return the project directory."""
+        return self._path
 
     def commit2(self, message: str) -> str:
         """Commit the project."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -25,12 +25,10 @@ class ProjectBuilder:
 
     _worktree: Repository
     path: Path
-    message: str = ""
 
     def commit2(self, message: str) -> str:
         """Commit the project."""
-        self.message = message
-        self._worktree.commit(message=self.message)
+        self._worktree.commit(message=message)
         return str(self._worktree.head.commit.id)
 
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -40,10 +40,6 @@ class ProjectBuilder:
         """Set the ID of the newly created commit."""
         self._commit = commit
 
-    def commit2(self) -> None:
-        """Commit the project."""
-        self.commit = self.commit3()
-
     def commit3(self) -> str:
         """Commit the project."""
         self._worktree.commit(message=self.message)
@@ -95,7 +91,7 @@ class ProjectRepository:
         with self.build(self.root) as builder:
             yield builder.path
             builder.message = createcommitmessage(template)
-            builder.commit2()
+            builder.commit = builder.commit3()
 
         commit = self.project._repository[builder.commit]
         self.updateconfig(message=linkcommitmessage(template), commit=commit)
@@ -118,7 +114,7 @@ class ProjectRepository:
         with self.build(parent) as builder:
             yield builder.path
             builder.message = updatecommitmessage(template)
-            builder.commit2()
+            builder.commit = builder.commit3()
 
         if builder.commit != parent:
             commit = self.project._repository[builder.commit]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -66,9 +66,10 @@ class ProjectRepository:
     @contextmanager
     def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
         """Create an orphan commit with a generated project."""
-        with self.build(self.root) as builder:
+        with self.build2(self.root) as builder:
             builder.message = _createcommitmessage(template)
             yield builder
+            builder.commit2()
 
     @property
     def root(self) -> str:
@@ -78,14 +79,6 @@ class ProjectRepository:
         tree = repository.TreeBuilder().write()
         oid = repository.create_commit(None, author, committer, "", tree, [])
         return str(oid)
-
-    @contextmanager
-    def build(self, parent: str) -> Iterator[ProjectBuilder]:
-        """Create a commit with a generated project."""
-        with self.build2(parent) as builder:
-            yield builder
-
-            builder.commit2()
 
     @contextmanager
     def build2(self, parent: str) -> Iterator[ProjectBuilder]:
@@ -124,9 +117,10 @@ class ProjectRepository:
     @contextmanager
     def update(self, template: Template.Metadata, *, parent: str) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
-        with self.build(parent) as builder:
+        with self.build2(parent) as builder:
             builder.message = _updatecommitmessage(template)
             yield builder.path
+            builder.commit2()
 
         if builder.commit != parent:
             commit = self.project._repository[builder.commit]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -64,13 +64,6 @@ class ProjectRepository:
         project.commit(message=_createcommitmessage(template))
 
     @contextmanager
-    def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
-        """Create an orphan commit with a generated project."""
-        with self.reset2(template) as builder:
-            yield builder
-            builder.commit2()
-
-    @contextmanager
     def reset2(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
         """Create an orphan commit with a generated project."""
         with self.build(self.root) as builder:
@@ -102,8 +95,9 @@ class ProjectRepository:
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
-        with self.reset(template) as builder:
+        with self.reset2(template) as builder:
             yield builder.path
+            builder.commit2()
 
         commit = self.project._repository[builder.commit]
         self.updateconfig(message=_linkcommitmessage(template), commit=commit)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -27,7 +27,7 @@ class ProjectBuilder:
     path: Path
     message: str = ""
 
-    def commit3(self) -> str:
+    def commit(self) -> str:
         """Commit the project."""
         self._worktree.commit(message=self.message)
         return str(self._worktree.head.commit.id)
@@ -78,7 +78,7 @@ class ProjectRepository:
         with self.build(self.root) as builder:
             yield builder.path
             builder.message = createcommitmessage(template)
-            commit2 = builder.commit3()
+            commit2 = builder.commit()
 
         commit = self.project._repository[commit2]
         self.updateconfig(message=linkcommitmessage(template), commit=commit)
@@ -101,7 +101,7 @@ class ProjectRepository:
         with self.build(parent) as builder:
             yield builder.path
             builder.message = updatecommitmessage(template)
-            commit2 = builder.commit3()
+            commit2 = builder.commit()
 
         if commit2 != parent:
             commit = self.project._repository[commit2]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -24,6 +24,7 @@ class NoUpdateInProgressError(CuttyError):
 class ProjectBuilder:
     """Adding a project to the repository."""
 
+    _worktree: Repository
     path: Path
     message: str = ""
     _commit: Optional[str] = None
@@ -81,7 +82,7 @@ class ProjectRepository:
         )
 
         with self.project.worktree(branch, checkout=False) as worktree:
-            builder = ProjectBuilder(worktree.path)
+            builder = ProjectBuilder(worktree, worktree.path)
             yield builder
 
             worktree.commit(message=builder.message)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -30,10 +30,6 @@ class ProjectBuilder:
     def commit2(self, message: str) -> str:
         """Commit the project."""
         self.message = message
-        return self.commit()
-
-    def commit(self) -> str:
-        """Commit the project."""
         self._worktree.commit(message=self.message)
         return str(self._worktree.head.commit.id)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -100,7 +100,7 @@ class ProjectRepository:
             builder.commit2()
 
         commit = self.project._repository[builder.commit]
-        self.updateconfig(message=_linkcommitmessage(template), commit=commit)
+        self.updateconfig(message=linkcommitmessage(template), commit=commit)
 
     def updateconfig(self, message: str, *, commit: pygit2.Commit) -> None:
         """Update the project configuration."""
@@ -169,7 +169,7 @@ def updatecommitmessage(template: Template.Metadata) -> str:
         return f"Update {template.name}"
 
 
-def _linkcommitmessage(template: Template.Metadata) -> str:
+def linkcommitmessage(template: Template.Metadata) -> str:
     """Return the commit message for linking the template."""
     if template.revision:
         return f"Link to {template.name} {template.revision}"

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -2,7 +2,6 @@
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import pygit2
 
@@ -27,18 +26,6 @@ class ProjectBuilder:
     _worktree: Repository
     path: Path
     message: str = ""
-    _commit: Optional[str] = None
-
-    @property
-    def commit(self) -> str:
-        """Return the ID of the newly created commit."""
-        assert self._commit is not None  # noqa: S101
-        return self._commit
-
-    @commit.setter
-    def commit(self, commit: str) -> None:
-        """Set the ID of the newly created commit."""
-        self._commit = commit
 
     def commit3(self) -> str:
         """Commit the project."""
@@ -91,9 +78,9 @@ class ProjectRepository:
         with self.build(self.root) as builder:
             yield builder.path
             builder.message = createcommitmessage(template)
-            builder.commit = builder.commit3()
+            commit2 = builder.commit3()
 
-        commit = self.project._repository[builder.commit]
+        commit = self.project._repository[commit2]
         self.updateconfig(message=linkcommitmessage(template), commit=commit)
 
     def updateconfig(self, message: str, *, commit: pygit2.Commit) -> None:
@@ -114,10 +101,10 @@ class ProjectRepository:
         with self.build(parent) as builder:
             yield builder.path
             builder.message = updatecommitmessage(template)
-            builder.commit = builder.commit3()
+            commit2 = builder.commit3()
 
-        if builder.commit != parent:
-            commit = self.project._repository[builder.commit]
+        if commit2 != parent:
+            commit = self.project._repository[commit2]
             self.project.cherrypick(commit)
 
     def continueupdate(self) -> None:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -64,7 +64,7 @@ class ProjectRepository:
         project.commit(message=_createcommitmessage(template))
 
     @contextmanager
-    def reset2(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
+    def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
         """Create an orphan commit with a generated project."""
         with self.build(self.root) as builder:
             builder.message = _createcommitmessage(template)
@@ -95,7 +95,7 @@ class ProjectRepository:
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
-        with self.reset2(template) as builder:
+        with self.reset(template) as builder:
             yield builder.path
             builder.commit2()
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -89,8 +89,8 @@ class ProjectRepository:
     def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
         with self.build(self.root) as builder:
-            builder.message = createcommitmessage(template)
             yield builder.path
+            builder.message = createcommitmessage(template)
             builder.commit2()
 
         commit = self.project._repository[builder.commit]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -66,7 +66,7 @@ class ProjectRepository:
     @contextmanager
     def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
         """Create an orphan commit with a generated project."""
-        with self.build2(self.root) as builder:
+        with self.build(self.root) as builder:
             builder.message = _createcommitmessage(template)
             yield builder
             builder.commit2()
@@ -81,7 +81,7 @@ class ProjectRepository:
         return str(oid)
 
     @contextmanager
-    def build2(self, parent: str) -> Iterator[ProjectBuilder]:
+    def build(self, parent: str) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
         branch = self.project.heads.create(
             UPDATE_BRANCH, self.project._repository[parent], force=True
@@ -117,7 +117,7 @@ class ProjectRepository:
     @contextmanager
     def update(self, template: Template.Metadata, *, parent: str) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
-        with self.build2(parent) as builder:
+        with self.build(parent) as builder:
             builder.message = _updatecommitmessage(template)
             yield builder.path
             builder.commit2()

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -82,6 +82,12 @@ class ProjectRepository:
     @contextmanager
     def build(self, parent: str) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
+        with self.build2(parent) as builder:
+            yield builder
+
+    @contextmanager
+    def build2(self, parent: str) -> Iterator[ProjectBuilder]:
+        """Create a commit with a generated project."""
         branch = self.project.heads.create(
             UPDATE_BRANCH, self.project._repository[parent], force=True
         )

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -29,7 +29,7 @@ class ProjectBuilder:
     @property
     def path(self) -> Path:
         """Return the project directory."""
-        return self._path
+        return self._worktree.path
 
     def commit2(self, message: str) -> str:
         """Commit the project."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -30,7 +30,7 @@ class ProjectBuilder:
         """Return the project directory."""
         return self._worktree.path
 
-    def commit2(self, message: str) -> str:
+    def commit(self, message: str) -> str:
         """Commit the project."""
         self._worktree.commit(message=message)
         return str(self._worktree.head.commit.id)
@@ -80,7 +80,7 @@ class ProjectRepository:
         """Link a project to a project template."""
         with self.build(self.root) as builder:
             yield builder.path
-            commit2 = builder.commit2(createcommitmessage(template))
+            commit2 = builder.commit(createcommitmessage(template))
 
         commit = self.project._repository[commit2]
         self.updateconfig(message=linkcommitmessage(template), commit=commit)
@@ -102,7 +102,7 @@ class ProjectRepository:
         """Update a project by applying changes between the generated trees."""
         with self.build(parent) as builder:
             yield builder.path
-            commit2 = builder.commit2(updatecommitmessage(template))
+            commit2 = builder.commit(updatecommitmessage(template))
 
         if commit2 != parent:
             commit = self.project._repository[commit2]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -86,8 +86,8 @@ class ProjectRepository:
             yield builder
 
             worktree.commit(message=builder.message)
+            builder.commit = str(branch.commit.id)
 
-        builder.commit = str(branch.commit.id)
         self.project.heads.pop(branch.name)
 
     @contextmanager

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -87,9 +87,8 @@ class ProjectRepository:
 
             worktree.commit(message=builder.message)
 
-        commit = branch.commit
+        builder.commit = str(branch.commit.id)
         self.project.heads.pop(branch.name)
-        builder.commit = str(commit.id)
 
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -24,7 +24,6 @@ class ProjectBuilder:
     """Adding a project to the repository."""
 
     _worktree: Repository
-    _path: Path
 
     @property
     def path(self) -> Path:
@@ -71,7 +70,7 @@ class ProjectRepository:
         )
 
         with self.project.worktree(branch, checkout=False) as worktree:
-            builder = ProjectBuilder(worktree, worktree.path)
+            builder = ProjectBuilder(worktree)
             yield builder
 
         self.project.heads.pop(branch.name)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -85,6 +85,8 @@ class ProjectRepository:
         with self.build2(parent) as builder:
             yield builder
 
+            builder.commit2()
+
     @contextmanager
     def build2(self, parent: str) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
@@ -95,8 +97,6 @@ class ProjectRepository:
         with self.project.worktree(branch, checkout=False) as worktree:
             builder = ProjectBuilder(worktree, worktree.path)
             yield builder
-
-            builder.commit2()
 
         self.project.heads.pop(branch.name)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -42,6 +42,10 @@ class ProjectBuilder:
 
     def commit2(self) -> None:
         """Commit the project."""
+        self.commit3()
+
+    def commit3(self) -> None:
+        """Commit the project."""
         self._worktree.commit(message=self.message)
         self.commit = str(self._worktree.head.commit.id)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -42,12 +42,12 @@ class ProjectBuilder:
 
     def commit2(self) -> None:
         """Commit the project."""
-        self.commit3()
+        self.commit = self.commit3()
 
-    def commit3(self) -> None:
+    def commit3(self) -> str:
         """Commit the project."""
         self._worktree.commit(message=self.message)
-        self.commit = str(self._worktree.head.commit.id)
+        return str(self._worktree.head.commit.id)
 
 
 class ProjectRepository:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -63,13 +63,6 @@ class ProjectRepository:
 
         project.commit(message=createcommitmessage(template))
 
-    @contextmanager
-    def reset(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
-        """Create an orphan commit with a generated project."""
-        with self.build(self.root) as builder:
-            builder.message = createcommitmessage(template)
-            yield builder
-
     @property
     def root(self) -> str:
         """Create an orphan empty commit."""
@@ -95,7 +88,8 @@ class ProjectRepository:
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
-        with self.reset(template) as builder:
+        with self.build(self.root) as builder:
+            builder.message = createcommitmessage(template)
             yield builder.path
             builder.commit2()
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -86,7 +86,7 @@ class ProjectRepository:
             yield builder
 
             worktree.commit(message=builder.message)
-            builder.commit = str(branch.commit.id)
+            builder.commit = str(worktree.head.commit.id)
 
         self.project.heads.pop(branch.name)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -40,6 +40,11 @@ class ProjectBuilder:
         """Set the ID of the newly created commit."""
         self._commit = commit
 
+    def commit2(self) -> None:
+        """Commit the project."""
+        self._worktree.commit(message=self.message)
+        self.commit = str(self._worktree.head.commit.id)
+
 
 class ProjectRepository:
     """Project repository."""
@@ -85,8 +90,7 @@ class ProjectRepository:
             builder = ProjectBuilder(worktree, worktree.path)
             yield builder
 
-            worktree.commit(message=builder.message)
-            builder.commit = str(worktree.head.commit.id)
+            builder.commit2()
 
         self.project.heads.pop(branch.name)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -68,6 +68,7 @@ class ProjectRepository:
         """Create an orphan commit with a generated project."""
         with self.reset2(template) as builder:
             yield builder
+            builder.commit2()
 
     @contextmanager
     def reset2(self, template: Template.Metadata) -> Iterator[ProjectBuilder]:
@@ -75,7 +76,6 @@ class ProjectRepository:
         with self.build(self.root) as builder:
             builder.message = _createcommitmessage(template)
             yield builder
-            builder.commit2()
 
     @property
     def root(self) -> str:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -119,7 +119,7 @@ class ProjectRepository:
         """Update a project by applying changes between the generated trees."""
         with self.build(parent) as builder:
             yield builder.path
-            builder.message = _updatecommitmessage(template)
+            builder.message = updatecommitmessage(template)
             builder.commit2()
 
         if builder.commit != parent:
@@ -161,7 +161,7 @@ def createcommitmessage(template: Template.Metadata) -> str:
         return f"Initial import from {template.name}"
 
 
-def _updatecommitmessage(template: Template.Metadata) -> str:
+def updatecommitmessage(template: Template.Metadata) -> str:
     """Return the commit message for updating the template."""
     if template.revision:
         return f"Update {template.name} to {template.revision}"

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -27,6 +27,11 @@ class ProjectBuilder:
     path: Path
     message: str = ""
 
+    def commit2(self, message: str) -> str:
+        """Commit the project."""
+        self.message = message
+        return self.commit()
+
     def commit(self) -> str:
         """Commit the project."""
         self._worktree.commit(message=self.message)
@@ -77,8 +82,7 @@ class ProjectRepository:
         """Link a project to a project template."""
         with self.build(self.root) as builder:
             yield builder.path
-            builder.message = createcommitmessage(template)
-            commit2 = builder.commit()
+            commit2 = builder.commit2(createcommitmessage(template))
 
         commit = self.project._repository[commit2]
         self.updateconfig(message=linkcommitmessage(template), commit=commit)
@@ -100,8 +104,7 @@ class ProjectRepository:
         """Update a project by applying changes between the generated trees."""
         with self.build(parent) as builder:
             yield builder.path
-            builder.message = updatecommitmessage(template)
-            commit2 = builder.commit()
+            commit2 = builder.commit2(updatecommitmessage(template))
 
         if commit2 != parent:
             commit = self.project._repository[commit2]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -118,8 +118,8 @@ class ProjectRepository:
     def update(self, template: Template.Metadata, *, parent: str) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
         with self.build(parent) as builder:
-            builder.message = _updatecommitmessage(template)
             yield builder.path
+            builder.message = _updatecommitmessage(template)
             builder.commit2()
 
         if builder.commit != parent:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -36,7 +36,7 @@ def update(
     with repository.build(repository.root) as builder:
         storeproject(project, builder.path, outputdirisproject=True)
         builder.message = createcommitmessage(template.metadata)
-        builder.commit2()
+        builder.commit = builder.commit3()
 
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -36,10 +36,10 @@ def update(
     with repository.build(repository.root) as builder:
         storeproject(project, builder.path, outputdirisproject=True)
         builder.message = createcommitmessage(template.metadata)
-        builder.commit = builder.commit3()
+        commit = builder.commit3()
 
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)
 
-    with repository.update(template.metadata, parent=builder.commit) as outputdir:
+    with repository.update(template.metadata, parent=commit) as outputdir:
         storeproject(project, outputdir, outputdirisproject=True)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -32,8 +32,9 @@ def update(
     )
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
-    with repository.reset(template.metadata) as builder:
+    with repository.reset2(template.metadata) as builder:
         storeproject(project, builder.path, outputdirisproject=True)
+        builder.commit2()
 
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -34,8 +34,8 @@ def update(
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
     with repository.build(repository.root) as builder:
-        builder.message = createcommitmessage(template.metadata)
         storeproject(project, builder.path, outputdirisproject=True)
+        builder.message = createcommitmessage(template.metadata)
         builder.commit2()
 
     template = Template.load(projectconfig.template, revision, directory)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -35,8 +35,7 @@ def update(
 
     with repository.build(repository.root) as builder:
         storeproject(project, builder.path, outputdirisproject=True)
-        builder.message = createcommitmessage(template.metadata)
-        commit = builder.commit()
+        commit = builder.commit2(createcommitmessage(template.metadata))
 
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -36,7 +36,7 @@ def update(
     with repository.build(repository.root) as builder:
         storeproject(project, builder.path, outputdirisproject=True)
         builder.message = createcommitmessage(template.metadata)
-        commit = builder.commit3()
+        commit = builder.commit()
 
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -35,7 +35,7 @@ def update(
 
     with repository.build(repository.root) as builder:
         storeproject(project, builder.path, outputdirisproject=True)
-        commit = builder.commit2(createcommitmessage(template.metadata))
+        commit = builder.commit(createcommitmessage(template.metadata))
 
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from cutty.projects.generate import generate
 from cutty.projects.projectconfig import readprojectconfigfile
+from cutty.projects.repository import createcommitmessage
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -32,7 +33,8 @@ def update(
     )
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
-    with repository.reset(template.metadata) as builder:
+    with repository.build(repository.root) as builder:
+        builder.message = createcommitmessage(template.metadata)
         storeproject(project, builder.path, outputdirisproject=True)
         builder.commit2()
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -32,7 +32,7 @@ def update(
     )
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
-    with repository.reset2(template.metadata) as builder:
+    with repository.reset(template.metadata) as builder:
         storeproject(project, builder.path, outputdirisproject=True)
         builder.commit2()
 

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -22,7 +22,7 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
 
     with project.build(project.root) as builder:
         builder.message = createcommitmessage(template)
-        commit = builder.commit3()
+        commit = builder.commit()
 
     with project.update(template, parent=commit) as outputdir:
         (outputdir / "cutty.json").touch()
@@ -161,7 +161,7 @@ def test_updateproject_no_changes(
 
     with repository.build(repository.root) as builder:
         builder.message = createcommitmessage(template)
-        commit = builder.commit3()
+        commit = builder.commit()
 
     with repository.update(template, parent=commit):
         pass

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -19,8 +19,8 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
 
-    with project.reset(template) as builder:
-        pass
+    with project.reset2(template) as builder:
+        builder.commit2()
 
     with project.update(template, parent=builder.commit) as outputdir:
         (outputdir / "cutty.json").touch()
@@ -157,8 +157,8 @@ def test_updateproject_no_changes(
 
     repository = ProjectRepository(project.path)
 
-    with repository.reset(template) as builder:
-        pass
+    with repository.reset2(template) as builder:
+        builder.commit2()
 
     with repository.update(template, parent=builder.commit):
         pass

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -21,7 +21,7 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     project = ProjectRepository(projectdir)
 
     with project.build(project.root) as builder:
-        commit = builder.commit2(createcommitmessage(template))
+        commit = builder.commit(createcommitmessage(template))
 
     with project.update(template, parent=commit) as outputdir:
         (outputdir / "cutty.json").touch()
@@ -159,7 +159,7 @@ def test_updateproject_no_changes(
     repository = ProjectRepository(project.path)
 
     with repository.build(repository.root) as builder:
-        commit = builder.commit2(createcommitmessage(template))
+        commit = builder.commit(createcommitmessage(template))
 
     with repository.update(template, parent=commit):
         pass

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -21,8 +21,7 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     project = ProjectRepository(projectdir)
 
     with project.build(project.root) as builder:
-        builder.message = createcommitmessage(template)
-        commit = builder.commit()
+        commit = builder.commit2(createcommitmessage(template))
 
     with project.update(template, parent=commit) as outputdir:
         (outputdir / "cutty.json").touch()
@@ -160,8 +159,7 @@ def test_updateproject_no_changes(
     repository = ProjectRepository(project.path)
 
     with repository.build(repository.root) as builder:
-        builder.message = createcommitmessage(template)
-        commit = builder.commit()
+        commit = builder.commit2(createcommitmessage(template))
 
     with repository.update(template, parent=commit):
         pass

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -22,9 +22,9 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
 
     with project.build(project.root) as builder:
         builder.message = createcommitmessage(template)
-        builder.commit = builder.commit3()
+        commit = builder.commit3()
 
-    with project.update(template, parent=builder.commit) as outputdir:
+    with project.update(template, parent=commit) as outputdir:
         (outputdir / "cutty.json").touch()
 
 
@@ -161,9 +161,9 @@ def test_updateproject_no_changes(
 
     with repository.build(repository.root) as builder:
         builder.message = createcommitmessage(template)
-        builder.commit = builder.commit3()
+        commit = builder.commit3()
 
-    with repository.update(template, parent=builder.commit):
+    with repository.update(template, parent=commit):
         pass
 
     assert tip == project.head.commit

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from cutty.projects.repository import createcommitmessage
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.util.git import Repository
@@ -19,7 +20,8 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
 
-    with project.reset(template) as builder:
+    with project.build(project.root) as builder:
+        builder.message = createcommitmessage(template)
         builder.commit2()
 
     with project.update(template, parent=builder.commit) as outputdir:
@@ -157,7 +159,8 @@ def test_updateproject_no_changes(
 
     repository = ProjectRepository(project.path)
 
-    with repository.reset(template) as builder:
+    with repository.build(repository.root) as builder:
+        builder.message = createcommitmessage(template)
         builder.commit2()
 
     with repository.update(template, parent=builder.commit):

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -19,7 +19,7 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
 
-    with project.reset2(template) as builder:
+    with project.reset(template) as builder:
         builder.commit2()
 
     with project.update(template, parent=builder.commit) as outputdir:
@@ -157,7 +157,7 @@ def test_updateproject_no_changes(
 
     repository = ProjectRepository(project.path)
 
-    with repository.reset2(template) as builder:
+    with repository.reset(template) as builder:
         builder.commit2()
 
     with repository.update(template, parent=builder.commit):

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -22,7 +22,7 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
 
     with project.build(project.root) as builder:
         builder.message = createcommitmessage(template)
-        builder.commit2()
+        builder.commit = builder.commit3()
 
     with project.update(template, parent=builder.commit) as outputdir:
         (outputdir / "cutty.json").touch()
@@ -161,7 +161,7 @@ def test_updateproject_no_changes(
 
     with repository.build(repository.root) as builder:
         builder.message = createcommitmessage(template)
-        builder.commit2()
+        builder.commit = builder.commit3()
 
     with repository.update(template, parent=builder.commit):
         pass


### PR DESCRIPTION
- 🔨 [projects] Add attribute `ProjectBuilder._worktree`
- 🔨 [projects] Separate command and query in `ProjectRepository.build`
- 🔨 [projects] Slide statement and inline variable `commit`
- 🔨 [projects] Slide statement
- 🔨 [projects] Replace `branch` with `worktree.head` in `ProjectRepository.build`
- 🔨 [projects] Extract function `ProjectBuilder.commit2`
- 🔨 [projects] Extract function `ProjectRepository.build2`
- 🔨 [projects] Move `commit2` call from `ProjectRepository.build2` to `build`
- 🔨 [projects] Inline function `ProjectRepository.build`
- 🔨 [projects] Rename function `ProjectBuilder.build2`
- 🔨 [projects] Extract function `ProjectRepository.reset2`
- 🔨 [projects] Move `commit2` call from `ProjectBuilder.reset2` to `reset`
- 🔨 [projects] Inline function `ProjectRepository.reset`
- 🔨 [projects] Rename function `ProjectRepository.reset2`
- 🔨 [projects] Slide statement
- 🔨 [projects] Rename function `{_ => }createcommitmessage`
- 🔨 [projects] Rename function `{_ => }updatecommitmessage`
- 🔨 [projects] Rename function `{_ = > }linkcommitmessage`
- 🔨 [projects] Inline function `ProjectRepository.reset`
- 🔨 [projects] Slide statement
- 🔨 [services] Slide statement
- 🔨 [projects] Extract function `ProjectBuilder.commit3`
- 🔨 [projects] Move assignment from `ProjectBuilder.commit3` to `commit2`
- 🔨 [projects] Inline function `ProjectBuilder.commit2`
- 🔨 [projects] Inline attribute `ProjectBuilder.commit`
- 🔨 [projects] Rename function `ProjectBuilder.commit3`
- 🔨 [projects] Extract function `ProjectBuilder.commit2` with `message` parameter
- 🔨 [projects] Inline function `ProjectBuilder.commit`
- 🔨 [projects] Inline attribute `ProjectBuilder.message`
- 🔨 [projects] Encapsulate attribute `ProjectRepository.path`
- 🔨 [projects] Derive attribute `ProjectBuilder.path`
- 🔨 [projects] Remove attribute `ProjectBuilder._path`
- 🔨 [projects] Rename function `ProjectBuilder.commit2`
