### PR TITLE
🔨 [projects] Extract function `ProjectRepository.import_`, inline function `ProjectRepository.update`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -107,10 +107,9 @@ class ProjectRepository:
         if commit2 != parent:
             self.import_(commit2)
 
-    def import_(self, commit2: str) -> None:
+    def import_(self, commit: str) -> None:
         """Import changes to the project made by the given commit."""
-        commit = self.project._repository[commit2]
-        self.project.cherrypick(commit)
+        self.project.cherrypick(self.project._repository[commit])
 
     def continueupdate(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -63,7 +63,7 @@ class ProjectRepository:
         return str(oid)
 
     @contextmanager
-    def build(self, parent: str) -> Iterator[ProjectBuilder]:
+    def build(self, *, parent: str) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
         branch = self.project.heads.create(
             UPDATE_BRANCH, self.project._repository[parent], force=True
@@ -78,7 +78,7 @@ class ProjectRepository:
     @contextmanager
     def link(self, template: Template.Metadata) -> Iterator[Path]:
         """Link a project to a project template."""
-        with self.build(self.root) as builder:
+        with self.build(parent=self.root) as builder:
             yield builder.path
             commit2 = builder.commit(createcommitmessage(template))
 
@@ -100,7 +100,7 @@ class ProjectRepository:
     @contextmanager
     def update(self, template: Template.Metadata, *, parent: str) -> Iterator[Path]:
         """Update a project by applying changes between the generated trees."""
-        with self.build(parent) as builder:
+        with self.build(parent=parent) as builder:
             yield builder.path
             commit2 = builder.commit(updatecommitmessage(template))
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -105,8 +105,12 @@ class ProjectRepository:
             commit2 = builder.commit(updatecommitmessage(template))
 
         if commit2 != parent:
-            commit = self.project._repository[commit2]
-            self.project.cherrypick(commit)
+            self.import_(commit2)
+
+    def import_(self, commit2: str) -> None:
+        """Import changes to the project made by the given commit."""
+        commit = self.project._repository[commit2]
+        self.project.cherrypick(commit)
 
     def continueupdate(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -97,16 +97,6 @@ class ProjectRepository:
             committer=self.project.default_signature,
         )
 
-    @contextmanager
-    def update(self, template: Template.Metadata, *, parent: str) -> Iterator[Path]:
-        """Update a project by applying changes between the generated trees."""
-        with self.build(parent=parent) as builder:
-            yield builder.path
-            commit2 = builder.commit(updatecommitmessage(template))
-
-        if commit2 != parent:
-            self.import_(commit2)
-
     def import_(self, commit: str) -> None:
         """Import changes to the project made by the given commit."""
         self.project.cherrypick(self.project._repository[commit])

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -7,6 +7,7 @@ from cutty.projects.generate import generate
 from cutty.projects.projectconfig import readprojectconfigfile
 from cutty.projects.repository import createcommitmessage
 from cutty.projects.repository import ProjectRepository
+from cutty.projects.repository import updatecommitmessage
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
@@ -40,5 +41,9 @@ def update(
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)
 
-    with repository.update(template.metadata, parent=commit) as outputdir:
-        storeproject(project, outputdir, outputdirisproject=True)
+    with repository.build(parent=commit) as builder:
+        storeproject(project, builder.path, outputdirisproject=True)
+        commit2 = builder.commit(updatecommitmessage(template.metadata))
+
+    if commit2 != commit:
+        repository.import_(commit2)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -33,7 +33,7 @@ def update(
     )
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
-    with repository.build(repository.root) as builder:
+    with repository.build(parent=repository.root) as builder:
         storeproject(project, builder.path, outputdirisproject=True)
         commit = builder.commit(createcommitmessage(template.metadata))
 

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -20,7 +20,7 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
 
-    with project.build(project.root) as builder:
+    with project.build(parent=project.root) as builder:
         commit = builder.commit(createcommitmessage(template))
 
     with project.update(template, parent=commit) as outputdir:
@@ -158,7 +158,7 @@ def test_updateproject_no_changes(
 
     repository = ProjectRepository(project.path)
 
-    with repository.build(repository.root) as builder:
+    with repository.build(parent=repository.root) as builder:
         commit = builder.commit(createcommitmessage(template))
 
     with repository.update(template, parent=commit):


### PR DESCRIPTION
- 🔨 [projects] Extract function `ProjectRepository.import_`
- 🔨 [projects] Rename parameter `commit2` in `ProjectRepository.import_`
- 🔨 [projects] Use keyword-only argument for `parent` in `ProjectRepository.build`
- 🔨 [projects] Inline function `ProjectRepository.update`
