### PR TITLE
🔨 [projects] Re-extract function `ProjectRepository.link`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -82,8 +82,7 @@ class ProjectRepository:
             yield builder.path
             commit2 = builder.commit(createcommitmessage(template))
 
-        commit = self.project._repository[commit2]
-        self.updateconfig(message=linkcommitmessage(template), commit=str(commit.id))
+        self.updateconfig(message=linkcommitmessage(template), commit=commit2)
 
     def updateconfig(self, message: str, *, commit: str) -> None:
         """Update the project configuration."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -83,9 +83,9 @@ class ProjectRepository:
             commit2 = builder.commit(createcommitmessage(template))
 
         commit = self.project._repository[commit2]
-        self.updateconfig2(message=linkcommitmessage(template), commit=str(commit.id))
+        self.updateconfig(message=linkcommitmessage(template), commit=str(commit.id))
 
-    def updateconfig2(self, message: str, *, commit: str) -> None:
+    def updateconfig(self, message: str, *, commit: str) -> None:
         """Update the project configuration."""
         commit2 = self.project._repository[commit]
 
@@ -120,7 +120,7 @@ class ProjectRepository:
             raise NoUpdateInProgressError()
 
         self.project.resetcherrypick()
-        self.updateconfig2(f"Skip: {commit.message}", commit=str(commit.id))
+        self.updateconfig(f"Skip: {commit.message}", commit=str(commit.id))
 
     def abortupdate(self) -> None:
         """Abort an update with conflicts."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -75,7 +75,7 @@ class ProjectRepository:
 
         self.project.heads.pop(branch.name)
 
-    def updateconfig(self, message: str, *, commit: str) -> None:
+    def link(self, message: str, *, commit: str) -> None:
         """Update the project configuration."""
         commit2 = self.project._repository[commit]
 
@@ -110,7 +110,7 @@ class ProjectRepository:
             raise NoUpdateInProgressError()
 
         self.project.resetcherrypick()
-        self.updateconfig(f"Skip: {commit.message}", commit=str(commit.id))
+        self.link(f"Skip: {commit.message}", commit=str(commit.id))
 
     def abortupdate(self) -> None:
         """Abort an update with conflicts."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -87,13 +87,19 @@ class ProjectRepository:
 
     def updateconfig(self, message: str, *, commit: pygit2.Commit) -> None:
         """Update the project configuration."""
+        self.updateconfig2(str(commit.id))
+
+    def updateconfig2(self, message: str, *, commit: str) -> None:
+        """Update the project configuration."""
+        commit2 = self.project._repository[commit]
+
         (self.project.path / PROJECT_CONFIG_FILE).write_bytes(
-            (commit.tree / PROJECT_CONFIG_FILE).data
+            (commit2.tree / PROJECT_CONFIG_FILE).data
         )
 
         self.project.commit(
             message=message,
-            author=commit.author,
+            author=commit2.author,
             committer=self.project.default_signature,
         )
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -75,15 +75,6 @@ class ProjectRepository:
 
         self.project.heads.pop(branch.name)
 
-    @contextmanager
-    def link(self, template: Template.Metadata) -> Iterator[Path]:
-        """Link a project to a project template."""
-        with self.build(parent=self.root) as builder:
-            yield builder.path
-            commit2 = builder.commit(createcommitmessage(template))
-
-        self.updateconfig(message=linkcommitmessage(template), commit=commit2)
-
     def updateconfig(self, message: str, *, commit: str) -> None:
         """Update the project configuration."""
         commit2 = self.project._repository[commit]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -83,11 +83,7 @@ class ProjectRepository:
             commit2 = builder.commit(createcommitmessage(template))
 
         commit = self.project._repository[commit2]
-        self.updateconfig(message=linkcommitmessage(template), commit=commit)
-
-    def updateconfig(self, message: str, *, commit: pygit2.Commit) -> None:
-        """Update the project configuration."""
-        self.updateconfig2(str(commit.id))
+        self.updateconfig2(message=linkcommitmessage(template), commit=str(commit.id))
 
     def updateconfig2(self, message: str, *, commit: str) -> None:
         """Update the project configuration."""
@@ -124,7 +120,7 @@ class ProjectRepository:
             raise NoUpdateInProgressError()
 
         self.project.resetcherrypick()
-        self.updateconfig(f"Skip: {commit.message}", commit=commit)
+        self.updateconfig2(f"Skip: {commit.message}", commit=str(commit.id))
 
     def abortupdate(self) -> None:
         """Abort an update with conflicts."""

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -49,6 +49,4 @@ def link(
         storeproject(project, builder.path, outputdirisproject=True)
         commit2 = builder.commit(createcommitmessage(template.metadata))
 
-    repository.updateconfig(
-        message=linkcommitmessage(template.metadata), commit=commit2
-    )
+    repository.link(message=linkcommitmessage(template.metadata), commit=commit2)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -7,6 +7,8 @@ from typing import Optional
 from cutty.errors import CuttyError
 from cutty.projects.generate import generate
 from cutty.projects.projectconfig import readcookiecutterjson
+from cutty.projects.repository import createcommitmessage
+from cutty.projects.repository import linkcommitmessage
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -43,5 +45,10 @@ def link(
 
     repository = ProjectRepository(projectdir)
 
-    with repository.link(template.metadata) as outputdir:
-        storeproject(project, outputdir, outputdirisproject=True)
+    with repository.build(parent=repository.root) as builder:
+        storeproject(project, builder.path, outputdirisproject=True)
+        commit2 = builder.commit(createcommitmessage(template.metadata))
+
+    repository.updateconfig(
+        message=linkcommitmessage(template.metadata), commit=commit2
+    )

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -3,6 +3,8 @@ import dataclasses
 
 import pytest
 
+from cutty.projects.repository import createcommitmessage
+from cutty.projects.repository import linkcommitmessage
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.util.git import Repository
@@ -14,8 +16,12 @@ pytest_plugins = ["tests.fixtures.git"]
 def linkproject(project: Repository, template: Template.Metadata) -> None:
     """Link a project to a project template."""
     repository = ProjectRepository(project.path)
-    with repository.link(template) as projectdir:
-        (projectdir / "cutty.json").touch()
+
+    with repository.build(parent=repository.root) as builder:
+        (builder.path / "cutty.json").touch()
+        commit2 = builder.commit(createcommitmessage(template))
+
+    repository.updateconfig(message=linkcommitmessage(template), commit=commit2)
 
 
 @pytest.fixture

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -19,7 +19,7 @@ def linkproject(project: Repository, template: Template.Metadata) -> None:
         (builder.path / "cutty.json").touch()
         commit2 = builder.commit(createcommitmessage(template))
 
-    repository.updateconfig(message=linkcommitmessage(template), commit=commit2)
+    repository.link(message=linkcommitmessage(template), commit=commit2)
 
 
 def test_linkproject_commit(

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -1,8 +1,6 @@
 """Unit tests for cutty.projects.repository."""
 import dataclasses
 
-import pytest
-
 from cutty.projects.repository import createcommitmessage
 from cutty.projects.repository import linkcommitmessage
 from cutty.projects.repository import ProjectRepository
@@ -24,45 +22,41 @@ def linkproject(project: Repository, template: Template.Metadata) -> None:
     repository.updateconfig(message=linkcommitmessage(template), commit=commit2)
 
 
-@pytest.fixture
-def project(repository: Repository) -> Repository:
-    """Fixture for a project repository."""
-    return repository
-
-
-def test_linkproject_commit(project: Repository, template: Template.Metadata) -> None:
+def test_linkproject_commit(
+    repository: Repository, template: Template.Metadata
+) -> None:
     """It creates a commit on the current branch."""
-    tip = project.head.commit
+    tip = repository.head.commit
 
-    linkproject(project, template)
+    linkproject(repository, template)
 
-    assert [tip] == project.head.commit.parents
+    assert [tip] == repository.head.commit.parents
 
 
 def test_linkproject_commit_message(
-    project: Repository, template: Template.Metadata
+    repository: Repository, template: Template.Metadata
 ) -> None:
     """It uses a commit message indicating the linkage."""
-    linkproject(project, template)
+    linkproject(repository, template)
 
-    assert "link" in project.head.commit.message.lower()
+    assert "link" in repository.head.commit.message.lower()
 
 
 def test_linkproject_commit_message_template(
-    project: Repository, template: Template.Metadata
+    repository: Repository, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
-    linkproject(project, template)
+    linkproject(repository, template)
 
-    assert template.name in project.head.commit.message
+    assert template.name in repository.head.commit.message
 
 
 def test_linkproject_commit_message_revision(
-    project: Repository, template: Template.Metadata
+    repository: Repository, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
     template = dataclasses.replace(template, revision="1.0.0")
 
-    linkproject(project, template)
+    linkproject(repository, template)
 
-    assert template.revision in project.head.commit.message
+    assert template.revision in repository.head.commit.message


### PR DESCRIPTION
- 🔨 [projects] Extract function `ProjectRepository.updateconfig` with commit ID
- 🔨 [projects] Inline function `ProjectRepository.updateconfig`
- 🔨 [projects] Rename function `ProjectRepository.updateconfig2`
- 🔨 [projects] Eliminate redundant OID lookup in `ProjectRepository.link`
- 🔨 [projects] Inline function `ProjectRepository.link`
- 🔨 [projects] Inline fixture `project` in `test_link`
- 🔨 [projects] Rename function `ProjectRepository.{updateconfig => link}
