### PR TITLE
🐛 [util] Do not commit untracked files in `cutty update`

### DIFF
--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -190,6 +190,7 @@ class Repository:
         message: str = "",
         author: Optional[pygit2.Signature] = None,
         committer: Optional[pygit2.Signature] = None,
+        stageallfiles: bool = True,
     ) -> None:
         """Commit all changes in the repository.
 
@@ -198,7 +199,8 @@ class Repository:
         repository = self._repository
         index = repository.index
 
-        index.add_all()
+        if stageallfiles:
+            index.add_all()
 
         tree = index.write_tree()
         if not repository.head_is_unborn and tree == repository.head.peel().tree.id:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -271,6 +271,7 @@ class Repository:
             message=commit.message,
             author=commit.author,
             committer=self.default_signature,
+            stageallfiles=False,
         )
 
         self._repository.state_cleanup()

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -418,3 +418,14 @@ def test_no_branches(runcutty: RunCutty, templateproject: Path, project: Path) -
     runcutty("update", f"--cwd={project}")
 
     assert branches == list(repository.heads)
+
+
+def test_dirty(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
+    """It does not commit untracked files."""
+    untracked = project / "untracked-file"
+    untracked.touch()
+
+    updatefile(templateproject / "LICENSE")
+    runcutty("update", f"--cwd={project}")
+
+    assert untracked.name not in Repository.open(project).head.commit.tree

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -469,6 +469,23 @@ def test_cherrypick_conflict_deletion(repository: Repository, path: Path) -> Non
         repository.cherrypick(branch.commit)
 
 
+def test_cherrypick_with_untracked_files(repository: Repository, path: Path) -> None:
+    """It does not commit untracked files."""
+    main = repository.head
+    branch = repository.heads.create("branch")
+
+    repository.checkout(branch)
+    updatefile(path)
+
+    untracked = repository.path / "untracked-file"
+    untracked.touch()
+
+    repository.checkout(main)
+    repository.cherrypick(branch.commit)
+
+    assert untracked.name not in repository.head.commit.tree
+
+
 def test_cherrypickhead_none(repository: Repository) -> None:
     """It returns None if no cherry pick is in progress."""
     assert repository.cherrypickhead is None


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty update` with untracked files
- ✅ [util] Add test for `git.Repository.cherrypick` with untracked files
- 🔨 [util] Add optional parameter `stageallfiles` to `git.Repository.commit`
- 🐛 [util] Do not stage files in working tree when cherry-picking
