### PR TITLE
✨ [projects] Create empty root commit in projects

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -60,7 +60,7 @@ class ProjectRepository:
 
     @property
     def root(self) -> str:
-        """Create an orphan empty commit."""
+        """Create an empty root commit."""
         return self.createroot(updateref=None)
 
     def createroot(self, *, updateref: Optional[str] = "HEAD") -> str:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -48,10 +48,12 @@ class ProjectRepository:
     def create(cls, projectdir: Path, template: Template.Metadata) -> None:
         """Initialize the git repository for a project."""
         try:
-            project = cls(projectdir).project
+            repository = cls(projectdir)
+            project = repository.project
         except pygit2.GitError:
             Repository.init(projectdir)
-            project = cls(projectdir).project
+            repository = cls(projectdir)
+            project = repository.project
 
         if project._repository.head_is_unborn:
             author = committer = project.default_signature

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -64,7 +64,7 @@ class ProjectRepository:
         return self.createroot(updateref=None)
 
     def createroot(self, *, updateref: Optional[str] = "HEAD") -> str:
-        """Create an orphan empty commit."""
+        """Create an empty root commit."""
         author = committer = self.project.default_signature
         repository = self.project._repository
         tree = repository.TreeBuilder().write()

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -51,6 +51,11 @@ class ProjectRepository:
         except pygit2.GitError:
             project = Repository.init(projectdir)
 
+            author = committer = project.default_signature
+            repository = project._repository
+            tree = repository.TreeBuilder().write()
+            repository.create_commit("HEAD", author, committer, "", tree, [])
+
         project.commit(message=createcommitmessage(template))
 
     @property

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -62,6 +62,10 @@ class ProjectRepository:
     @property
     def root(self) -> str:
         """Create an orphan empty commit."""
+        return self.createroot()
+
+    def createroot(self) -> str:
+        """Create an orphan empty commit."""
         author = committer = self.project.default_signature
         repository = self.project._repository
         tree = repository.TreeBuilder().write()

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -55,9 +55,8 @@ class ProjectRepository:
 
         if project._repository.head_is_unborn:
             author = committer = project.default_signature
-            repository = project._repository
-            tree = repository.TreeBuilder().write()
-            repository.create_commit("HEAD", author, committer, "", tree, [])
+            tree = project._repository.TreeBuilder().write()
+            project._repository.create_commit("HEAD", author, committer, "", tree, [])
 
         project.commit(message=createcommitmessage(template))
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -2,6 +2,7 @@
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import pygit2
 
@@ -62,14 +63,14 @@ class ProjectRepository:
     @property
     def root(self) -> str:
         """Create an orphan empty commit."""
-        return self.createroot()
+        return self.createroot(updateref=None)
 
-    def createroot(self) -> str:
+    def createroot(self, *, updateref: Optional[str]) -> str:
         """Create an orphan empty commit."""
         author = committer = self.project.default_signature
         repository = self.project._repository
         tree = repository.TreeBuilder().write()
-        oid = repository.create_commit(None, author, committer, "", tree, [])
+        oid = repository.create_commit(updateref, author, committer, "", tree, [])
         return str(oid)
 
     @contextmanager

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -51,6 +51,7 @@ class ProjectRepository:
         except pygit2.GitError:
             project = Repository.init(projectdir)
 
+        if project._repository.head_is_unborn:
             author = committer = project.default_signature
             repository = project._repository
             tree = repository.TreeBuilder().write()

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -48,7 +48,7 @@ class ProjectRepository:
     def create(cls, projectdir: Path, template: Template.Metadata) -> None:
         """Initialize the git repository for a project."""
         try:
-            project = Repository.open(projectdir)
+            project = cls(projectdir).project
         except pygit2.GitError:
             project = Repository.init(projectdir)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -54,7 +54,7 @@ class ProjectRepository:
             repository = cls(projectdir)
 
         if repository.project._repository.head_is_unborn:
-            repository.createroot(updateref="HEAD")
+            repository.createroot()
 
         repository.project.commit(message=createcommitmessage(template))
 
@@ -63,7 +63,7 @@ class ProjectRepository:
         """Create an orphan empty commit."""
         return self.createroot(updateref=None)
 
-    def createroot(self, *, updateref: Optional[str]) -> str:
+    def createroot(self, *, updateref: Optional[str] = "HEAD") -> str:
         """Create an orphan empty commit."""
         author = committer = self.project.default_signature
         repository = self.project._repository

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -49,11 +49,11 @@ class ProjectRepository:
         """Initialize the git repository for a project."""
         try:
             repository = cls(projectdir)
-            project = repository.project
         except pygit2.GitError:
             Repository.init(projectdir)
             repository = cls(projectdir)
-            project = repository.project
+
+        project = repository.project
 
         if project._repository.head_is_unborn:
             author = committer = project.default_signature

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -56,9 +56,7 @@ class ProjectRepository:
         project = repository.project
 
         if project._repository.head_is_unborn:
-            author = committer = project.default_signature
-            tree = project._repository.TreeBuilder().write()
-            project._repository.create_commit("HEAD", author, committer, "", tree, [])
+            repository.createroot(updateref="HEAD")
 
         project.commit(message=createcommitmessage(template))
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -53,12 +53,10 @@ class ProjectRepository:
             Repository.init(projectdir)
             repository = cls(projectdir)
 
-        project = repository.project
-
-        if project._repository.head_is_unborn:
+        if repository.project._repository.head_is_unborn:
             repository.createroot(updateref="HEAD")
 
-        project.commit(message=createcommitmessage(template))
+        repository.project.commit(message=createcommitmessage(template))
 
     @property
     def root(self) -> str:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -50,7 +50,8 @@ class ProjectRepository:
         try:
             project = cls(projectdir).project
         except pygit2.GitError:
-            project = Repository.init(projectdir)
+            Repository.init(projectdir)
+            project = cls(projectdir).project
 
         if project._repository.head_is_unborn:
             author = committer = project.default_signature

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -126,3 +126,16 @@ def test_no_branches(runcutty: RunCutty, template: Path) -> None:
     runcutty("create", f"--cwd={project.path}", "--in-place", str(template))
 
     assert branches == list(project.heads)
+
+
+@pytest.mark.xfail(reason="TODO")
+def test_existing_files(runcutty: RunCutty, template: Path) -> None:
+    """It does not commit existing files."""
+    existing = Path("example", "do-not-commit-this-file")
+    existing.parent.mkdir()
+    existing.touch()
+
+    runcutty("create", str(template))
+
+    project = Repository.open(existing.parent)
+    assert Path(existing.name) not in project.head.commit.tree

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -63,6 +63,16 @@ def test_commit(project: pathlib.Path, template: Template.Metadata) -> None:
     repository.head.commit  # does not raise
 
 
+def test_initial_commit(project: pathlib.Path, template: Template.Metadata) -> None:
+    """It creates an empty initial commit."""
+    creategitrepository(project, template)
+
+    repository = Repository.open(project)
+    [root] = repository.head.commit.parents
+    assert not root.parents
+    assert not root.tree
+
+
 def test_commit_message_template(
     project: pathlib.Path, template: Template.Metadata
 ) -> None:

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -110,3 +110,22 @@ def test_existing_repository(
     creategitrepository(projectpath, template)
 
     assert file.path.name in repository.head.commit.tree
+
+
+def test_existing_repository_initial_commit(
+    storage: FileStorage,
+    file: RegularFile,
+    projectpath: pathlib.Path,
+    template: Template.Metadata,
+) -> None:
+    """It creates an empty root commit in an existing repository."""
+    repository = Repository.init(projectpath)
+
+    with storage:
+        storage.add(file)
+
+    creategitrepository(projectpath, template)
+
+    [root] = repository.head.commit.parents
+    assert not root.parents
+    assert not root.tree


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty create` with existing files
- ✅ [projects] Add test for `ProjectRepository.create` creating empty initial commit
- ✨ [projects] Create empty initial commit on `cutty create`
- ✅ [projects] Add test for empty root commit in existing repository
- ✨ [projects] Create empty root commit in existing repository with unborn HEAD
- 🔨 [projects] Extract function `ProjectRepository.createroot`
- 🔨 [projects] Add parameter `updateref` to `ProjectRepository.createroot`
- 🔨 [projects] Replace inline code with `ProjectRepository` constructor
- 🔨 [projects] Invoke `ProjectRepository` constructor also after `init`
- 🔨 [projects] Inline variable `repository`
- 🔨 [projects] Extract variable `repository`
- 🔨 [projects] Slide statement
- 🔨 [projects] Replace inline code with call to `ProjectRepository.createroot`
- 🔨 [projects] Inline variable `project`
- 🔨 [projects] Use "HEAD" as default `updateref` in `ProjectRepository.createroot`
- 💡 [projects] Update docstring for `ProjectRepository.createroot`
- 💡 [projects] Update docstring for `ProjectRepository.root`
