### PR TITLE
🔨 [projects] Pass `projectdir` to `storeproject`

### DIFF
--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -15,7 +15,8 @@ def storeproject(
 ) -> pathlib.Path:
     """Store a project in the output directory."""
     projectdir = outputdir if outputdirisproject else outputdir / project.name
-    return storeproject2(project, projectdir, outputdir, outputdirisproject, fileexists)
+    storeproject2(project, projectdir, outputdir, outputdirisproject, fileexists)
+    return projectdir
 
 
 def storeproject2(
@@ -24,7 +25,7 @@ def storeproject2(
     outputdir: pathlib.Path,
     outputdirisproject: bool,
     fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
-) -> pathlib.Path:
+) -> None:
     """Store a project in the output directory."""
     storage = createcookiecutterstorage(
         outputdir, projectdir, fileexists, project.hooks
@@ -37,5 +38,3 @@ def storeproject2(
                 projectfile = projectfile.withpath(path)
 
             storage.add(projectfile)
-
-    return projectdir

--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -28,7 +28,7 @@ def storeproject2(
     project: Project,
     projectdir: pathlib.Path,
     *,
-    outputdirisproject: bool,
+    outputdirisproject: bool = True,
     fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
 ) -> None:
     """Store a project in the output directory."""

--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -15,7 +15,13 @@ def storeproject(
 ) -> pathlib.Path:
     """Store a project in the output directory."""
     projectdir = outputdir if outputdirisproject else outputdir / project.name
-    storeproject2(project, projectdir, outputdir, outputdirisproject, fileexists)
+    storeproject2(
+        project,
+        projectdir,
+        outputdir,
+        outputdirisproject=outputdirisproject,
+        fileexists=fileexists,
+    )
     return projectdir
 
 
@@ -23,6 +29,7 @@ def storeproject2(
     project: Project,
     projectdir: pathlib.Path,
     outputdir: pathlib.Path,
+    *,
     outputdirisproject: bool,
     fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
 ) -> None:

--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -14,6 +14,16 @@ def storeproject(
     fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
 ) -> pathlib.Path:
     """Store a project in the output directory."""
+    return storeproject2(project, outputdir, outputdirisproject, fileexists)
+
+
+def storeproject2(
+    project: Project,
+    outputdir: pathlib.Path,
+    outputdirisproject: bool,
+    fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
+) -> pathlib.Path:
+    """Store a project in the output directory."""
     projectdir = outputdir if outputdirisproject else outputdir / project.name
     storage = createcookiecutterstorage(
         outputdir, projectdir, fileexists, project.hooks

--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -18,7 +18,6 @@ def storeproject(
     storeproject2(
         project,
         projectdir,
-        outputdir,
         outputdirisproject=outputdirisproject,
         fileexists=fileexists,
     )
@@ -28,12 +27,12 @@ def storeproject(
 def storeproject2(
     project: Project,
     projectdir: pathlib.Path,
-    outputdir: pathlib.Path,
     *,
     outputdirisproject: bool,
     fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
 ) -> None:
     """Store a project in the output directory."""
+    outputdir = projectdir if outputdirisproject else projectdir.parent
     storage = createcookiecutterstorage(
         outputdir, projectdir, fileexists, project.hooks
     )

--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -7,7 +7,7 @@ from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.project import Project
 
 
-def storeproject2(
+def storeproject(
     project: Project,
     projectdir: pathlib.Path,
     *,

--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -7,23 +7,6 @@ from cutty.filesystems.domain.purepath import PurePath
 from cutty.projects.project import Project
 
 
-def storeproject(
-    project: Project,
-    outputdir: pathlib.Path,
-    outputdirisproject: bool,
-    fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
-) -> pathlib.Path:
-    """Store a project in the output directory."""
-    projectdir = outputdir if outputdirisproject else outputdir / project.name
-    storeproject2(
-        project,
-        projectdir,
-        outputdirisproject=outputdirisproject,
-        fileexists=fileexists,
-    )
-    return projectdir
-
-
 def storeproject2(
     project: Project,
     projectdir: pathlib.Path,

--- a/src/cutty/projects/store.py
+++ b/src/cutty/projects/store.py
@@ -14,17 +14,18 @@ def storeproject(
     fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
 ) -> pathlib.Path:
     """Store a project in the output directory."""
-    return storeproject2(project, outputdir, outputdirisproject, fileexists)
+    projectdir = outputdir if outputdirisproject else outputdir / project.name
+    return storeproject2(project, projectdir, outputdir, outputdirisproject, fileexists)
 
 
 def storeproject2(
     project: Project,
+    projectdir: pathlib.Path,
     outputdir: pathlib.Path,
     outputdirisproject: bool,
     fileexists: FileExistsPolicy = FileExistsPolicy.RAISE,
 ) -> pathlib.Path:
     """Store a project in the output directory."""
-    projectdir = outputdir if outputdirisproject else outputdir / project.name
     storage = createcookiecutterstorage(
         outputdir, projectdir, fileexists, project.hooks
     )

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -27,11 +27,5 @@ def createproject(
         template, extrabindings, interactive=interactive, createconfigfile=False
     )
 
-    outputdirisproject = False
-    projectdir = outputdir if outputdirisproject else outputdir / project.name
-    storeproject2(
-        project,
-        projectdir,
-        outputdirisproject=outputdirisproject,
-        fileexists=fileexists,
-    )
+    projectdir = outputdir / project.name
+    storeproject2(project, projectdir, outputdirisproject=False, fileexists=fileexists)

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -27,5 +27,9 @@ def createproject(
         template, extrabindings, interactive=interactive, createconfigfile=False
     )
 
-    projectdir = outputdir / project.name
-    storeproject2(project, projectdir, outputdirisproject=False, fileexists=fileexists)
+    storeproject2(
+        project,
+        outputdir / project.name,
+        outputdirisproject=False,
+        fileexists=fileexists,
+    )

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import generate
-from cutty.projects.store import storeproject2
+from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -27,7 +27,7 @@ def createproject(
         template, extrabindings, interactive=interactive, createconfigfile=False
     )
 
-    storeproject2(
+    storeproject(
         project,
         outputdir / project.name,
         outputdirisproject=False,

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import generate
-from cutty.projects.store import storeproject
+from cutty.projects.store import storeproject2
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -27,9 +27,11 @@ def createproject(
         template, extrabindings, interactive=interactive, createconfigfile=False
     )
 
-    storeproject(
+    outputdirisproject = False
+    projectdir = outputdir if outputdirisproject else outputdir / project.name
+    storeproject2(
         project,
-        outputdir,
-        outputdirisproject=False,
+        projectdir,
+        outputdirisproject=outputdirisproject,
         fileexists=fileexists,
     )

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -6,7 +6,7 @@ from typing import Optional
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.store import storeproject2
+from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -28,7 +28,7 @@ def createproject(
     project = generate(template, extrabindings, interactive=interactive)
 
     projectdir = outputdir if in_place else outputdir / project.name
-    storeproject2(
+    storeproject(
         project, projectdir, outputdirisproject=in_place, fileexists=fileexists
     )
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -27,13 +27,9 @@ def createproject(
 
     project = generate(template, extrabindings, interactive=interactive)
 
-    outputdirisproject = in_place
-    projectdir = outputdir if outputdirisproject else outputdir / project.name
+    projectdir = outputdir if in_place else outputdir / project.name
     storeproject2(
-        project,
-        projectdir,
-        outputdirisproject=outputdirisproject,
-        fileexists=fileexists,
+        project, projectdir, outputdirisproject=in_place, fileexists=fileexists
     )
 
     ProjectRepository.create(projectdir, template.metadata)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -6,7 +6,7 @@ from typing import Optional
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import generate
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.store import storeproject
+from cutty.projects.store import storeproject2
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -27,10 +27,12 @@ def createproject(
 
     project = generate(template, extrabindings, interactive=interactive)
 
-    projectdir = storeproject(
+    outputdirisproject = in_place
+    projectdir = outputdir if outputdirisproject else outputdir / project.name
+    storeproject2(
         project,
-        outputdir,
-        outputdirisproject=in_place,
+        projectdir,
+        outputdirisproject=outputdirisproject,
         fileexists=fileexists,
     )
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -47,9 +47,8 @@ def link(
 
     with repository.build(parent=repository.root) as builder:
         outputdir = builder.path
-        outputdirisproject = True
-        projectdir = outputdir if outputdirisproject else outputdir / project.name
-        storeproject2(project, projectdir, outputdirisproject=outputdirisproject)
+        projectdir = outputdir
+        storeproject2(project, projectdir)
         commit2 = builder.commit(createcommitmessage(template.metadata))
 
     repository.link(message=linkcommitmessage(template.metadata), commit=commit2)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -46,8 +46,7 @@ def link(
     repository = ProjectRepository(projectdir)
 
     with repository.build(parent=repository.root) as builder:
-        outputdir = builder.path
-        projectdir = outputdir
+        projectdir = builder.path
         storeproject2(project, projectdir)
         commit2 = builder.commit(createcommitmessage(template.metadata))
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -46,8 +46,7 @@ def link(
     repository = ProjectRepository(projectdir)
 
     with repository.build(parent=repository.root) as builder:
-        projectdir = builder.path
-        storeproject2(project, projectdir)
+        storeproject2(project, builder.path)
         commit2 = builder.commit(createcommitmessage(template.metadata))
 
     repository.link(message=linkcommitmessage(template.metadata), commit=commit2)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -10,7 +10,7 @@ from cutty.projects.projectconfig import readcookiecutterjson
 from cutty.projects.repository import createcommitmessage
 from cutty.projects.repository import linkcommitmessage
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.store import storeproject2
+from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -46,7 +46,7 @@ def link(
     repository = ProjectRepository(projectdir)
 
     with repository.build(parent=repository.root) as builder:
-        storeproject2(project, builder.path)
+        storeproject(project, builder.path)
         commit2 = builder.commit(createcommitmessage(template.metadata))
 
     repository.link(message=linkcommitmessage(template.metadata), commit=commit2)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -10,7 +10,7 @@ from cutty.projects.projectconfig import readcookiecutterjson
 from cutty.projects.repository import createcommitmessage
 from cutty.projects.repository import linkcommitmessage
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.store import storeproject
+from cutty.projects.store import storeproject2
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -46,7 +46,10 @@ def link(
     repository = ProjectRepository(projectdir)
 
     with repository.build(parent=repository.root) as builder:
-        storeproject(project, builder.path, outputdirisproject=True)
+        outputdir = builder.path
+        outputdirisproject = True
+        projectdir = outputdir if outputdirisproject else outputdir / project.name
+        storeproject2(project, projectdir, outputdirisproject=outputdirisproject)
         commit2 = builder.commit(createcommitmessage(template.metadata))
 
     repository.link(message=linkcommitmessage(template.metadata), commit=commit2)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -8,7 +8,7 @@ from cutty.projects.projectconfig import readprojectconfigfile
 from cutty.projects.repository import createcommitmessage
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.repository import updatecommitmessage
-from cutty.projects.store import storeproject2
+from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -35,14 +35,14 @@ def update(
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
     with repository.build(parent=repository.root) as builder:
-        storeproject2(project, builder.path)
+        storeproject(project, builder.path)
         commit = builder.commit(createcommitmessage(template.metadata))
 
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)
 
     with repository.build(parent=commit) as builder:
-        storeproject2(project, builder.path)
+        storeproject(project, builder.path)
         commit2 = builder.commit(updatecommitmessage(template.metadata))
 
     if commit2 != commit:

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -8,7 +8,7 @@ from cutty.projects.projectconfig import readprojectconfigfile
 from cutty.projects.repository import createcommitmessage
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.repository import updatecommitmessage
-from cutty.projects.store import storeproject
+from cutty.projects.store import storeproject2
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -35,14 +35,14 @@ def update(
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
     with repository.build(parent=repository.root) as builder:
-        storeproject(project, builder.path, outputdirisproject=True)
+        storeproject2(project, builder.path)
         commit = builder.commit(createcommitmessage(template.metadata))
 
     template = Template.load(projectconfig.template, revision, directory)
     project = generate(template, extrabindings, interactive=interactive)
 
     with repository.build(parent=commit) as builder:
-        storeproject(project, builder.path, outputdirisproject=True)
+        storeproject2(project, builder.path)
         commit2 = builder.commit(updatecommitmessage(template.metadata))
 
     if commit2 != commit:


### PR DESCRIPTION
- 🔨 [projects] Extract function `storeproject2`
- 🔨 [projects] Move `projectdir` assignment from `storeproject2` to `storeproject`
- 🔨 [projects] Do not return `projectdir` from `storeproject2`
- 🔨 [projects] Use keyword-only arguments for `outputdirisproject` and `fileexists`
- 🔨 [projects] Derive `outputdir` parameter in `storeproject2`
- 🔨 [projects] Add default argument for `outputdirisproject`
- 🔨 [services] Inline function `storeproject` in `cookiecutter`
- 🔨 [services] Inline variable `outputdirisproject` in `cookiecutter`
- 🔨 [services] Inline variable `projectdir` in `cookiecutter`
- 🔨 [services] Inline function `storeproject` in `create`
- 🔨 [services] Inline variable `outputdirisproject` in `create`
- 🔨 [services] Inline function `storeproject` in `link`
- 🔨 [services] Inline variable `outputdirisproject` in `link`
- 🔨 [services] Inline variable `outputdir` in `link`
- 🔨 [services] Inline variable `projectdir` in `link`
- 🔨 [services] Inline function `storeproject` in `update`
- 🔨 [projects] Remove function `storeproject`
- 🔨 [projects] Rename function `storeproject2`
