### PR TITLE
🔨 [projects] Hide root commit creation from `ProjectRepository` interface

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -74,8 +74,11 @@ class ProjectRepository:
         return str(oid)
 
     @contextmanager
-    def build(self, *, parent: str) -> Iterator[ProjectBuilder]:
+    def build(self, *, parent: Optional[str] = None) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
+        if parent is None:
+            parent = self.root
+
         branch = self.project.heads.create(
             UPDATE_BRANCH, self.project._repository[parent], force=True
         )

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -60,11 +60,6 @@ class ProjectRepository:
 
         return repository
 
-    @property
-    def root(self) -> str:
-        """Create an empty root commit."""
-        return self.createroot(updateref=None)
-
     def createroot(self, *, updateref: Optional[str] = "HEAD") -> str:
         """Create an empty root commit."""
         author = committer = self.project.default_signature
@@ -77,7 +72,7 @@ class ProjectRepository:
     def build(self, *, parent: Optional[str] = None) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
         if parent is None:
-            parent = self.root
+            parent = self.createroot(updateref=None)
 
         branch = self.project.heads.create(
             UPDATE_BRANCH, self.project._repository[parent], force=True

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -56,11 +56,11 @@ class ProjectRepository:
             repository = cls(projectdir)
 
         if repository.project._repository.head_is_unborn:
-            repository.createroot()
+            repository._createroot()
 
         return repository
 
-    def createroot(self, *, updateref: Optional[str] = "HEAD") -> str:
+    def _createroot(self, *, updateref: Optional[str] = "HEAD") -> str:
         """Create an empty root commit."""
         author = committer = self.project.default_signature
         repository = self.project._repository
@@ -72,7 +72,7 @@ class ProjectRepository:
     def build(self, *, parent: Optional[str] = None) -> Iterator[ProjectBuilder]:
         """Create a commit with a generated project."""
         if parent is None:
-            parent = self.createroot(updateref=None)
+            parent = self._createroot(updateref=None)
 
         branch = self.project.heads.create(
             UPDATE_BRANCH, self.project._repository[parent], force=True

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -30,7 +30,7 @@ def createproject(
     projectdir = outputdir if in_place else outputdir / project.name
     repository = ProjectRepository.create(projectdir)
 
-    with repository.build(parent=repository.root) as builder:
+    with repository.build() as builder:
         storeproject(project, builder.path, fileexists=fileexists)
         commit = builder.commit(message=createcommitmessage(template.metadata))
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -45,7 +45,7 @@ def link(
 
     repository = ProjectRepository(projectdir)
 
-    with repository.build(parent=repository.root) as builder:
+    with repository.build() as builder:
         storeproject(project, builder.path)
         commit2 = builder.commit(createcommitmessage(template.metadata))
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -34,7 +34,7 @@ def update(
     )
     project = generate(template, projectconfig.bindings, interactive=interactive)
 
-    with repository.build(parent=repository.root) as builder:
+    with repository.build() as builder:
         storeproject(project, builder.path)
         commit = builder.commit(createcommitmessage(template.metadata))
 

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -15,7 +15,7 @@ def linkproject(project: Repository, template: Template.Metadata) -> None:
     """Link a project to a project template."""
     repository = ProjectRepository(project.path)
 
-    with repository.build(parent=repository.root) as builder:
+    with repository.build() as builder:
         (builder.path / "cutty.json").touch()
         commit2 = builder.commit(createcommitmessage(template))
 

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -21,7 +21,7 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     """Update a project by applying changes between the generated trees."""
     project = ProjectRepository(projectdir)
 
-    with project.build(parent=project.root) as builder:
+    with project.build() as builder:
         commit = builder.commit(createcommitmessage(template))
 
     with project.build(parent=commit) as builder:
@@ -163,7 +163,7 @@ def test_updateproject_no_changes(
 
     repository = ProjectRepository(project.path)
 
-    with repository.build(parent=repository.root) as builder:
+    with repository.build() as builder:
         commit = builder.commit(createcommitmessage(template))
 
     with repository.build(parent=commit) as builder:


### PR DESCRIPTION
- 🔨 [projects] Use `ProjectRepository.root` as default `parent` for `build()`
- 🔨 [projects] Inline function `ProjectRepository.root`
- 🔨 [projects] Rename function `ProjectRepository.{ => _}createroot`
