### PR TITLE
☑️ [functional] Add another test for `cutty create` with untracked files

### DIFF
--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -138,3 +138,15 @@ def test_existing_files(runcutty: RunCutty, template: Path) -> None:
 
     project = Repository.open(existing.parent)
     assert existing.name not in project.head.commit.tree
+
+
+def test_untracked_files(runcutty: RunCutty, template: Path) -> None:
+    """It does not commit untracked files."""
+    project = Repository.init(Path("example"))
+
+    untracked = project.path / "untracked-file"
+    untracked.touch()
+
+    runcutty("create", str(template))
+
+    assert untracked.name not in project.head.commit.tree

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -137,4 +137,4 @@ def test_existing_files(runcutty: RunCutty, template: Path) -> None:
     runcutty("create", str(template))
 
     project = Repository.open(existing.parent)
-    assert Path(existing.name) not in project.head.commit.tree
+    assert existing.name not in project.head.commit.tree

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -420,7 +420,9 @@ def test_no_branches(runcutty: RunCutty, templateproject: Path, project: Path) -
     assert branches == list(repository.heads)
 
 
-def test_dirty(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
+def test_untracked_files(
+    runcutty: RunCutty, templateproject: Path, project: Path
+) -> None:
     """It does not commit untracked files."""
     untracked = project / "untracked-file"
     untracked.touch()


### PR DESCRIPTION
- 🔨 [functional] Simplify test for `cutty create` with existing files
- ✅ [functional] Add test for `cutty create` with untracked files
- 🔨 [functional] Rename test for `cutty update` with untracked files
