### PR TITLE
✨ [services] Read project configuration from cutty.json if it exists, in `cutty link`

### DIFF
--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -33,6 +33,31 @@ def loadprojectconfig(projectdir: pathlib.Path) -> Optional[ProjectConfig]:
     return None
 
 
+def createprojectconfig(
+    projectdir: pathlib.Path,
+    location: Optional[str],
+    bindings: Sequence[Binding],
+    revision: Optional[str],
+    directory: Optional[pathlib.Path],
+) -> ProjectConfig:
+    """Assemble project configuration from parameters and the existing project."""
+    projectconfig = loadprojectconfig(projectdir)
+
+    if projectconfig is not None:
+        bindings = [*projectconfig.bindings, *bindings]
+
+        if location is None:
+            location = projectconfig.template
+
+        if directory is None:
+            directory = projectconfig.directory
+
+    if location is None:
+        raise TemplateNotSpecifiedError()
+
+    return ProjectConfig(location, bindings, revision, directory)
+
+
 def link(
     location: Optional[str],
     projectdir: pathlib.Path,
@@ -44,21 +69,9 @@ def link(
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
-    projectconfig = loadprojectconfig(projectdir)
-
-    if projectconfig is not None:
-        extrabindings = [*projectconfig.bindings, *extrabindings]
-
-        if location is None:
-            location = projectconfig.template
-
-        if directory is None:
-            directory = projectconfig.directory
-
-    if location is None:
-        raise TemplateNotSpecifiedError()
-
-    projectconfig = ProjectConfig(location, extrabindings, revision, directory)
+    projectconfig = createprojectconfig(
+        projectdir, location, extrabindings, revision, directory
+    )
 
     template = Template.load(
         projectconfig.template, projectconfig.revision, projectconfig.directory

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -20,6 +20,16 @@ class TemplateNotSpecifiedError(CuttyError):
     """The template was not specified."""
 
 
+def loadprojectconfig(projectdir: pathlib.Path) -> Optional[ProjectConfig]:
+    """Attempt to load the project configuration."""
+    projectconfig: Optional[ProjectConfig] = None
+    try:
+        projectconfig = readcookiecutterjson(projectdir)
+    except FileNotFoundError:
+        pass
+    return projectconfig
+
+
 def link(
     location: Optional[str],
     projectdir: pathlib.Path,
@@ -31,11 +41,7 @@ def link(
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
-    projectconfig: Optional[ProjectConfig] = None
-    try:
-        projectconfig = readcookiecutterjson(projectdir)
-    except FileNotFoundError:
-        pass
+    projectconfig = loadprojectconfig(projectdir)
 
     if projectconfig is not None:
         extrabindings = [*projectconfig.bindings, *extrabindings]

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -58,8 +58,12 @@ def link(
     if location is None:
         raise TemplateNotSpecifiedError()
 
-    template = Template.load(location, revision, directory)
-    project = generate(template, extrabindings, interactive=interactive)
+    projectconfig = ProjectConfig(location, extrabindings, revision, directory)
+
+    template = Template.load(
+        projectconfig.template, projectconfig.revision, projectconfig.directory
+    )
+    project = generate(template, projectconfig.bindings, interactive=interactive)
 
     repository = ProjectRepository(projectdir)
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -52,6 +52,9 @@ def link(
         if location is None:
             location = projectconfig.template
 
+        if directory is None:
+            directory = projectconfig.directory
+
     if location is None:
         raise TemplateNotSpecifiedError()
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -1,4 +1,5 @@
 """Link a project to a Cookiecutter template."""
+import contextlib
 import pathlib
 from collections.abc import Sequence
 from typing import Optional
@@ -22,10 +23,9 @@ class TemplateNotSpecifiedError(CuttyError):
 
 def loadprojectconfig(projectdir: pathlib.Path) -> Optional[ProjectConfig]:
     """Attempt to load the project configuration."""
-    try:
+    with contextlib.suppress(FileNotFoundError):
         return readcookiecutterjson(projectdir)
-    except FileNotFoundError:
-        pass
+
     return None
 
 

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -8,6 +8,7 @@ from cutty.projects.generate import generate
 from cutty.projects.messages import createcommitmessage
 from cutty.projects.messages import linkcommitmessage
 from cutty.projects.projectconfig import PROJECT_CONFIG_FILE
+from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.projectconfig import readcookiecutterjson
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
@@ -30,14 +31,17 @@ def link(
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
+    projectconfig: Optional[ProjectConfig] = None
     try:
         projectconfig = readcookiecutterjson(projectdir)
+    except FileNotFoundError:
+        pass
+
+    if projectconfig is not None:
         extrabindings = [*projectconfig.bindings, *extrabindings]
 
         if location is None:
             location = projectconfig.template
-    except FileNotFoundError:
-        pass
 
     if location is None:
         raise TemplateNotSpecifiedError()

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -22,12 +22,11 @@ class TemplateNotSpecifiedError(CuttyError):
 
 def loadprojectconfig(projectdir: pathlib.Path) -> Optional[ProjectConfig]:
     """Attempt to load the project configuration."""
-    projectconfig: Optional[ProjectConfig] = None
     try:
-        projectconfig = readcookiecutterjson(projectdir)
+        return readcookiecutterjson(projectdir)
     except FileNotFoundError:
         pass
-    return projectconfig
+    return None
 
 
 def link(

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -1,5 +1,4 @@
 """Link a project to a Cookiecutter template."""
-import contextlib
 import pathlib
 from collections.abc import Sequence
 from typing import Optional
@@ -31,12 +30,14 @@ def link(
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
-    with contextlib.suppress(FileNotFoundError):
+    try:
         projectconfig = readcookiecutterjson(projectdir)
         extrabindings = [*projectconfig.bindings, *extrabindings]
 
         if location is None:
             location = projectconfig.template
+    except FileNotFoundError:
+        pass
 
     if location is None:
         raise TemplateNotSpecifiedError()

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -11,6 +11,7 @@ from cutty.projects.messages import linkcommitmessage
 from cutty.projects.projectconfig import PROJECT_CONFIG_FILE
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.projectconfig import readcookiecutterjson
+from cutty.projects.projectconfig import readprojectconfigfile
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
@@ -23,6 +24,9 @@ class TemplateNotSpecifiedError(CuttyError):
 
 def loadprojectconfig(projectdir: pathlib.Path) -> Optional[ProjectConfig]:
     """Attempt to load the project configuration."""
+    with contextlib.suppress(FileNotFoundError):
+        return readprojectconfigfile(projectdir)
+
     with contextlib.suppress(FileNotFoundError):
         return readcookiecutterjson(projectdir)
 

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -126,6 +126,18 @@ def test_project_config_template(runcutty: RunCutty, template: Path) -> None:
     runcutty("link", "--cwd=example")
 
 
+def test_project_config_directory(runcutty: RunCutty, template: Path) -> None:
+    """It reads the template directory from cutty.json if it exists."""
+    directory = "a"
+    move_repository_files_to_subdirectory(template, directory)
+
+    runcutty("create", f"--template-directory={directory}", str(template))
+
+    updatefile(template / directory / "{{ cookiecutter.project }}" / "LICENSE")
+
+    runcutty("link", "--cwd=example")
+
+
 def test_legacy_project_config_bindings(runcutty: RunCutty, template: Path) -> None:
     """It reads bindings from .cookiecutter.json if it exists."""
     updatefile(

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -117,6 +117,15 @@ def test_commit_message_verb(runcutty: RunCutty, project: Path, template: Path) 
     assert "Link" in repository.head.commit.message
 
 
+def test_project_config_template(runcutty: RunCutty, template: Path) -> None:
+    """It reads the template from cutty.json if it exists."""
+    runcutty("create", str(template))
+
+    updatefile(template / "{{ cookiecutter.project }}" / "LICENSE")
+
+    runcutty("link", "--cwd=example")
+
+
 def test_legacy_project_config_bindings(runcutty: RunCutty, template: Path) -> None:
     """It reads bindings from .cookiecutter.json if it exists."""
     updatefile(

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -134,13 +134,13 @@ def test_project_config_directory(
     directory = "a"
     move_repository_files_to_subdirectory(template, directory)
 
-    runcutty("create", f"--template-directory={directory}", str(template))
+    option = f"--template-directory={directory}"
+    options = [option] if specify_template_directory else []
+
+    runcutty("create", option, str(template))
 
     updatefile(template / directory / "{{ cookiecutter.project }}" / "LICENSE")
 
-    options = (
-        [f"--template-directory={directory}"] if specify_template_directory else []
-    )
     runcutty("link", "--cwd=example", *options)
 
 

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -126,7 +126,10 @@ def test_project_config_template(runcutty: RunCutty, template: Path) -> None:
     runcutty("link", "--cwd=example")
 
 
-def test_project_config_directory(runcutty: RunCutty, template: Path) -> None:
+@pytest.mark.parametrize("specify_template_directory", [False, True])
+def test_project_config_directory(
+    runcutty: RunCutty, template: Path, specify_template_directory: bool
+) -> None:
     """It reads the template directory from cutty.json if it exists."""
     directory = "a"
     move_repository_files_to_subdirectory(template, directory)
@@ -135,7 +138,10 @@ def test_project_config_directory(runcutty: RunCutty, template: Path) -> None:
 
     updatefile(template / directory / "{{ cookiecutter.project }}" / "LICENSE")
 
-    runcutty("link", "--cwd=example")
+    options = (
+        [f"--template-directory={directory}"] if specify_template_directory else []
+    )
+    runcutty("link", "--cwd=example", *options)
 
 
 def test_legacy_project_config_bindings(runcutty: RunCutty, template: Path) -> None:


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty link` reading template from cutty.json
- 🔨 [services] Inline `contextlib.suppress` in `link`
- 🔨 [services] Slide statements out of `try...except` block
- 🔨 [services] Extract function `loadprojectconfig`
- 🔨 [services] Inline variable `projectconfig`
- 🔨 [services] Replace try...except block with `contextlib.suppress`
- ✨ [services] Read project configuration from cutty.json in `cutty link` if it exists
- ✅ [functional] Add test for `cutty link` with template directory from cutty.json
- ✨ [services] Read template directory from cutty.json in `cutty link` if it exists
- 🔨 [services] Extract variable `projectconfig`
- 🔨 [services] Extract function `createprojectconfig`
