### PR TITLE
💥 [entrypoints] Remove option `cutty update --skip`

### DIFF
--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -48,12 +48,6 @@ from cutty.templates.domain.bindings import Binding
     help="Resume updating after conflict resolution.",
 )
 @click.option(
-    "--skip",
-    is_flag=True,
-    default=False,
-    help="Skip the current update.",
-)
-@click.option(
     "--abort",
     is_flag=True,
     default=False,
@@ -66,7 +60,6 @@ def update(
     revision: Optional[str],
     template_directory: Optional[pathlib.Path],
     continue_: bool,
-    skip: bool,
     abort: bool,
 ) -> None:
     """Update a project with changes from its template."""
@@ -77,10 +70,6 @@ def update(
 
     if continue_:
         project.continueupdate()
-        return
-
-    if skip:
-        project.skipupdate()
         return
 
     if abort:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -10,7 +10,6 @@ import pygit2
 
 from cutty.compat.contextlib import contextmanager
 from cutty.errors import CuttyError
-from cutty.projects.projectconfig import PROJECT_CONFIG_FILE
 from cutty.util.git import Repository
 
 
@@ -112,16 +111,6 @@ class ProjectRepository:
             message=commit.message,
             author=commit.author,
             committer=self.project.default_signature,
-        )
-
-    def skipupdate(self) -> None:
-        """Skip an update with conflicts."""
-        if not (commit := self.project.cherrypickhead):
-            raise NoUpdateInProgressError()
-
-        self.project.resetcherrypick()
-        self.link(
-            str(commit.id), Path(PROJECT_CONFIG_FILE), message=f"Skip: {commit.message}"
         )
 
     def abortupdate(self) -> None:

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -335,14 +335,15 @@ def test_continue(runcutty: RunCutty, templateproject: Path, project: Path) -> N
 
 
 def test_skip(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
-    """It skips the update."""
+    """It skips the update with `cutty update --abort && cutty link`."""
     updatefile(project / "LICENSE", "a")
     updatefile(templateproject / "LICENSE", "b")
 
     with pytest.raises(Exception, match="conflict"):
         runcutty("update", f"--cwd={project}")
 
-    runcutty("update", f"--cwd={project}", "--skip")
+    runcutty("update", f"--cwd={project}", "--abort")
+    runcutty("link", f"--cwd={project}")
 
     updatefile(templateproject / "INSTALL")
 

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -38,12 +38,6 @@ def continueupdate(projectdir: Path) -> None:
     project.continueupdate()
 
 
-def skipupdate(projectdir: Path) -> None:
-    """Skip an update with conflicts."""
-    project = ProjectRepository(projectdir)
-    project.skipupdate()
-
-
 def abortupdate(projectdir: Path) -> None:
     """Abort an update with conflicts."""
     project = ProjectRepository(projectdir)

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -90,17 +90,6 @@ def test_continueupdate_state_cleanup(repository: Repository, path: Path) -> Non
     assert repository.cherrypickhead is None
 
 
-def test_skipupdate(repository: Repository, path: Path) -> None:
-    """It uses our version."""
-    updatefile(repository.path / "cutty.json")
-    createconflict(repository, path, ours="a", theirs="b")
-
-    skipupdate(repository.path)
-
-    blob = repository.head.commit.tree / path.name
-    assert blob.data.decode() == "a"
-
-
 def test_abortupdate(repository: Repository, path: Path) -> None:
     """It uses our version."""
     createconflict(repository, path, ours="a", theirs="b")


### PR DESCRIPTION
- ✅ [functional] Replace `cutty update --skip` by `cutty update --abort; cutty link`
- 💥 [entrypoints] Remove option `cutty update --skip`
- 🔥 [projects] Remove test for `ProjectRepository.skipupdate`
- 🔥 [projects] Remove test helper `skipupdate`
- 🔥 [projects] Remove function `ProjectRepository.skipupdate`
