### PR TITLE
🔨 [projects] Merge function `ProjectRepository.link` into `ProjectRepository.import_`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -84,7 +84,7 @@ class ProjectRepository:
         finally:
             self.project.heads.pop(branch.name)
 
-    def import2(self, commit: str, *, message: str, paths: Iterable[Path]) -> None:
+    def import2(self, commit: str, *, paths: Iterable[Path]) -> None:
         """Import changes to the project made by the given commit."""
         commit2 = self.project._repository[commit]
 
@@ -93,7 +93,7 @@ class ProjectRepository:
             self.project._repository.index.add(path)
 
         self.project.commit(
-            message=message,
+            message=commit2.message,
             author=commit2.author,
             committer=self.project.default_signature,
             stageallfiles=False,

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -84,7 +84,7 @@ class ProjectRepository:
         finally:
             self.project.heads.pop(branch.name)
 
-    def import2(self, commit: str, *, paths: Iterable[Path] = ()) -> None:
+    def import_(self, commit: str, *, paths: Iterable[Path] = ()) -> None:
         """Import changes to the project made by the given commit."""
         cherry = self.project._repository[commit]
 
@@ -102,10 +102,6 @@ class ProjectRepository:
             committer=self.project.default_signature,
             stageallfiles=False,
         )
-
-    def import_(self, commit: str) -> None:
-        """Import changes to the project made by the given commit."""
-        self.import2(commit)
 
     def continueupdate(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -86,19 +86,19 @@ class ProjectRepository:
 
     def import2(self, commit: str, *, paths: Iterable[Path]) -> None:
         """Import changes to the project made by the given commit."""
-        commit2 = self.project._repository[commit]
+        cherry = self.project._repository[commit]
 
         if not paths:
-            self.project.cherrypick(commit2)
+            self.project.cherrypick(cherry)
             return
 
         for path in paths:
-            (self.project.path / path).write_bytes((commit2.tree / path).data)
+            (self.project.path / path).write_bytes((cherry.tree / path).data)
             self.project._repository.index.add(path)
 
         self.project.commit(
-            message=commit2.message,
-            author=commit2.author,
+            message=cherry.message,
+            author=cherry.author,
             committer=self.project.default_signature,
             stageallfiles=False,
         )

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -86,11 +86,11 @@ class ProjectRepository:
 
     def import2(self, commit: str, *, paths: Iterable[Path]) -> None:
         """Import changes to the project made by the given commit."""
-        if not paths:
-            self.project.cherrypick(self.project._repository[commit])
-            return
-
         commit2 = self.project._repository[commit]
+
+        if not paths:
+            self.project.cherrypick(commit2)
+            return
 
         for path in paths:
             (self.project.path / path).write_bytes((commit2.tree / path).data)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -84,7 +84,7 @@ class ProjectRepository:
         finally:
             self.project.heads.pop(branch.name)
 
-    def import2(self, commit: str, *, paths: Iterable[Path]) -> None:
+    def import2(self, commit: str, *, paths: Iterable[Path] = ()) -> None:
         """Import changes to the project made by the given commit."""
         cherry = self.project._repository[commit]
 
@@ -105,7 +105,7 @@ class ProjectRepository:
 
     def import_(self, commit: str) -> None:
         """Import changes to the project made by the given commit."""
-        self.import2(commit, paths=[])
+        self.import2(commit)
 
     def continueupdate(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -86,6 +86,10 @@ class ProjectRepository:
 
     def import2(self, commit: str, *, paths: Iterable[Path]) -> None:
         """Import changes to the project made by the given commit."""
+        if not paths:
+            self.project.cherrypick(self.project._repository[commit])
+            return
+
         commit2 = self.project._repository[commit]
 
         for path in paths:
@@ -101,7 +105,7 @@ class ProjectRepository:
 
     def import_(self, commit: str) -> None:
         """Import changes to the project made by the given commit."""
-        self.project.cherrypick(self.project._repository[commit])
+        self.import2(commit, paths=[])
 
     def continueupdate(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -84,13 +84,13 @@ class ProjectRepository:
         finally:
             self.project.heads.pop(branch.name)
 
-    def import2(self, commit: str, *, message: str, files: Iterable[Path]) -> None:
+    def import2(self, commit: str, *, message: str, paths: Iterable[Path]) -> None:
         """Import changes to the project made by the given commit."""
         commit2 = self.project._repository[commit]
 
-        for filename in files:
-            (self.project.path / filename).write_bytes((commit2.tree / filename).data)
-            self.project._repository.index.add(filename)
+        for path in paths:
+            (self.project.path / path).write_bytes((commit2.tree / path).data)
+            self.project._repository.index.add(path)
 
         self.project.commit(
             message=message,

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -84,10 +84,6 @@ class ProjectRepository:
         finally:
             self.project.heads.pop(branch.name)
 
-    def link(self, commit: str, *files: Path, message: str) -> None:
-        """Update the project configuration."""
-        self.import2(commit, message=message, files=files)
-
     def import2(self, commit: str, *, message: str, files: Iterable[Path]) -> None:
         """Import changes to the project made by the given commit."""
         commit2 = self.project._repository[commit]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -1,6 +1,7 @@
 """Project repositories."""
 from __future__ import annotations
 
+from collections.abc import Iterable
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -85,6 +86,10 @@ class ProjectRepository:
 
     def link(self, commit: str, *files: Path, message: str) -> None:
         """Update the project configuration."""
+        self.import2(commit, message=message, files=files)
+
+    def import2(self, commit: str, *, message: str, files: Iterable[Path]) -> None:
+        """Import changes to the project made by the given commit."""
         commit2 = self.project._repository[commit]
 
         for filename in files:

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from cutty.errors import CuttyError
 from cutty.projects.generate import generate
-from cutty.projects.messages import createcommitmessage
 from cutty.projects.messages import linkcommitmessage
 from cutty.projects.projectconfig import PROJECT_CONFIG_FILE
 from cutty.projects.projectconfig import ProjectConfig
@@ -82,7 +81,7 @@ def link(
 
     with repository.build() as builder:
         storeproject(project, builder.path)
-        commit = builder.commit(createcommitmessage(template.metadata))
+        commit = builder.commit(linkcommitmessage(template.metadata))
 
     repository.import2(
         commit,

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -83,4 +83,4 @@ def link(
         storeproject(project, builder.path)
         commit = builder.commit(linkcommitmessage(template.metadata))
 
-    repository.import2(commit, paths=[pathlib.Path(PROJECT_CONFIG_FILE)])
+    repository.import_(commit, paths=[pathlib.Path(PROJECT_CONFIG_FILE)])

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -84,8 +84,8 @@ def link(
         storeproject(project, builder.path)
         commit = builder.commit(createcommitmessage(template.metadata))
 
-    repository.link(
+    repository.import2(
         commit,
-        pathlib.Path(PROJECT_CONFIG_FILE),
+        files=[pathlib.Path(PROJECT_CONFIG_FILE)],
         message=linkcommitmessage(template.metadata),
     )

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -83,8 +83,4 @@ def link(
         storeproject(project, builder.path)
         commit = builder.commit(linkcommitmessage(template.metadata))
 
-    repository.import2(
-        commit,
-        paths=[pathlib.Path(PROJECT_CONFIG_FILE)],
-        message=linkcommitmessage(template.metadata),
-    )
+    repository.import2(commit, paths=[pathlib.Path(PROJECT_CONFIG_FILE)])

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -86,6 +86,6 @@ def link(
 
     repository.import2(
         commit,
-        files=[pathlib.Path(PROJECT_CONFIG_FILE)],
+        paths=[pathlib.Path(PROJECT_CONFIG_FILE)],
         message=linkcommitmessage(template.metadata),
     )

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -21,8 +21,8 @@ def linkproject(project: Repository, template: Template.Metadata) -> None:
         (builder.path / "cutty.json").touch()
         commit = builder.commit(createcommitmessage(template))
 
-    repository.link(
-        commit, Path(PROJECT_CONFIG_FILE), message=linkcommitmessage(template)
+    repository.import2(
+        commit, files=[Path(PROJECT_CONFIG_FILE)], message=linkcommitmessage(template)
     )
 
 

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -20,9 +20,7 @@ def linkproject(project: Repository, template: Template.Metadata) -> None:
         (builder.path / "cutty.json").touch()
         commit = builder.commit(linkcommitmessage(template))
 
-    repository.import2(
-        commit, paths=[Path(PROJECT_CONFIG_FILE)], message=linkcommitmessage(template)
-    )
+    repository.import2(commit, paths=[Path(PROJECT_CONFIG_FILE)])
 
 
 def test_linkproject_commit(

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -2,7 +2,6 @@
 import dataclasses
 from pathlib import Path
 
-from cutty.projects.messages import createcommitmessage
 from cutty.projects.messages import linkcommitmessage
 from cutty.projects.projectconfig import PROJECT_CONFIG_FILE
 from cutty.projects.repository import ProjectRepository
@@ -19,7 +18,7 @@ def linkproject(project: Repository, template: Template.Metadata) -> None:
 
     with repository.build() as builder:
         (builder.path / "cutty.json").touch()
-        commit = builder.commit(createcommitmessage(template))
+        commit = builder.commit(linkcommitmessage(template))
 
     repository.import2(
         commit, paths=[Path(PROJECT_CONFIG_FILE)], message=linkcommitmessage(template)

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -22,7 +22,7 @@ def linkproject(project: Repository, template: Template.Metadata) -> None:
         commit = builder.commit(createcommitmessage(template))
 
     repository.import2(
-        commit, files=[Path(PROJECT_CONFIG_FILE)], message=linkcommitmessage(template)
+        commit, paths=[Path(PROJECT_CONFIG_FILE)], message=linkcommitmessage(template)
     )
 
 

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -20,7 +20,7 @@ def linkproject(project: Repository, template: Template.Metadata) -> None:
         (builder.path / "cutty.json").touch()
         commit = builder.commit(linkcommitmessage(template))
 
-    repository.import2(commit, paths=[Path(PROJECT_CONFIG_FILE)])
+    repository.import_(commit, paths=[Path(PROJECT_CONFIG_FILE)])
 
 
 def test_linkproject_commit(


### PR DESCRIPTION
- 🔨 [projects] Extract function `ProjectRepository.import2` from `link`
- 🔨 [projects] Inline function `ProjectRepository.link`
- 🔨 [projects] Rename parameter `files` to `paths` in `ProjectRepository.import2`
- 🔨 [projects] [services] Use link commit message with `ProjectBuilder.commit`
- 🔨 [projects] Remove parameter `message` from `ProjectRepository.import2`
- 🔨 [projects] Extract `ProjectRepository.import_` into `ProjectRepository.import2` with empty `paths`
- 🔨 [projects] Replace query with temp
- 🔨 [projects] Rename variable `commit2` to `cherry`
- 🔨 [projects] Add default argument for `paths`
- 🔨 [projects] Rename function `ProjectRepository.import{2 => _}`
