### PR TITLE
💥 [entrypoints] Remove options `cutty create --skip-if-file-exists` and `--overwrite-if-exists`

### DIFF
--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.services.cookiecutter import createproject
+from cutty.services.cookiecutter import create
 from cutty.templates.domain.bindings import Binding
 
 
@@ -104,7 +104,7 @@ def cookiecutter(
 
     fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
 
-    createproject(
+    create(
         location,
         output_dir,
         extrabindings=extrabindings,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.cookiecutter import extra_context_callback
-from cutty.services.create import createproject
+from cutty.services.create import create as service_create
 from cutty.templates.domain.bindings import Binding
 
 
@@ -60,7 +60,7 @@ def create(
     if cwd is None:
         cwd = pathlib.Path.cwd()
 
-    createproject(
+    service_create(
         template,
         cwd,
         extrabindings=extrabindings,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,7 +5,6 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.cookiecutter import extra_context_callback
-from cutty.entrypoints.cli.cookiecutter import fileexistspolicy
 from cutty.services.create import createproject
 from cutty.templates.domain.bindings import Binding
 
@@ -61,7 +60,6 @@ def create(
     if cwd is None:
         cwd = pathlib.Path.cwd()
 
-    fileexists = fileexistspolicy(False, False)
     createproject(
         template,
         cwd,
@@ -69,6 +67,5 @@ def create(
         interactive=not non_interactive,
         revision=revision,
         directory=template_directory,
-        fileexists=fileexists,
         in_place=in_place,
     )

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -40,13 +40,6 @@ from cutty.templates.domain.bindings import Binding
     ),
 )
 @click.option(
-    "-s",
-    "--skip-if-file-exists",
-    is_flag=True,
-    default=False,
-    help="Skip the files in the corresponding directories if they already exist.",
-)
-@click.option(
     "-i",
     "--in-place",
     is_flag=True,
@@ -60,7 +53,6 @@ def create(
     revision: Optional[str],
     cwd: Optional[pathlib.Path],
     template_directory: Optional[pathlib.Path],
-    skip_if_file_exists: bool,
     in_place: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
@@ -69,7 +61,7 @@ def create(
     if cwd is None:
         cwd = pathlib.Path.cwd()
 
-    fileexists = fileexistspolicy(False, skip_if_file_exists)
+    fileexists = fileexistspolicy(False, False)
     createproject(
         template,
         cwd,

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -40,13 +40,6 @@ from cutty.templates.domain.bindings import Binding
     ),
 )
 @click.option(
-    "-f",
-    "--overwrite-if-exists",
-    is_flag=True,
-    default=False,
-    help="Overwrite the contents of the output directory if it already exists.",
-)
-@click.option(
     "-s",
     "--skip-if-file-exists",
     is_flag=True,
@@ -67,7 +60,6 @@ def create(
     revision: Optional[str],
     cwd: Optional[pathlib.Path],
     template_directory: Optional[pathlib.Path],
-    overwrite_if_exists: bool,
     skip_if_file_exists: bool,
     in_place: bool,
 ) -> None:
@@ -77,7 +69,7 @@ def create(
     if cwd is None:
         cwd = pathlib.Path.cwd()
 
-    fileexists = fileexistspolicy(overwrite_if_exists, skip_if_file_exists)
+    fileexists = fileexistspolicy(False, skip_if_file_exists)
     createproject(
         template,
         cwd,

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -10,7 +10,7 @@ from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
 
-def createproject(
+def create(
     location: str,
     outputdir: pathlib.Path,
     *,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -11,7 +11,7 @@ from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
 
-def createproject(
+def create(
     location: str,
     outputdir: pathlib.Path,
     *,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -3,7 +3,6 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
-from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import generate
 from cutty.projects.messages import createcommitmessage
 from cutty.projects.repository import ProjectRepository
@@ -20,7 +19,6 @@ def createproject(
     interactive: bool,
     revision: Optional[str],
     directory: Optional[pathlib.Path],
-    fileexists: FileExistsPolicy,
     in_place: bool,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
@@ -31,7 +29,7 @@ def createproject(
     repository = ProjectRepository.create(projectdir, message="Initial commit")
 
     with repository.build() as builder:
-        storeproject(project, builder.path, fileexists=fileexists)
+        storeproject(project, builder.path)
         commit = builder.commit(message=createcommitmessage(template.metadata))
 
     repository.import_(commit)

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -150,3 +150,16 @@ def test_untracked_files(runcutty: RunCutty, template: Path) -> None:
     runcutty("create", str(template))
 
     assert untracked.name not in project.head.commit.tree
+
+
+def test_untracked_project_files(runcutty: RunCutty, template: Path) -> None:
+    """It bails out to avoid overwriting uncommitted changes."""
+    project = Repository.init(Path("example"))
+
+    untracked = project.path / "cutty.json"
+    untracked.touch()
+
+    with pytest.raises(Exception, match="uncommitted change"):
+        runcutty("create", str(template))
+
+    assert {untracked.relative_to(project.path)} == project_files(project.path)

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -163,3 +163,17 @@ def test_untracked_project_files(runcutty: RunCutty, template: Path) -> None:
         runcutty("create", str(template))
 
     assert {untracked.relative_to(project.path)} == project_files(project.path)
+
+
+def test_existing_project_files(runcutty: RunCutty, template: Path) -> None:
+    """It does not overwrite existing files."""
+    project = Path("example")
+    project.mkdir()
+
+    existing = project / "cutty.json"
+    existing.touch()
+
+    with pytest.raises(Exception, match="uncommitted change"):
+        runcutty("create", str(template))
+
+    assert {existing.relative_to(project)} == project_files(project)

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -177,3 +177,16 @@ def test_existing_project_files(runcutty: RunCutty, template: Path) -> None:
         runcutty("create", str(template))
 
     assert {existing.relative_to(project)} == project_files(project)
+
+
+def test_conflict(runcutty: RunCutty, template: Path) -> None:
+    """It produces conflict markers if files have conflicting changes."""
+    project = Repository.init(Path("example"))
+    conflicting = project.path / "cutty.json"
+
+    updatefile(conflicting, "null")
+
+    with pytest.raises(Exception, match="conflict"):
+        runcutty("create", str(template))
+
+    assert ">>>>" in conflicting.read_text()


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty create` with untracked project files
- ✅ [functional] Add test for `cutty create` with existing project files
- ✅ [functional] Add test for `cutty create` with conflicting changes
- 💥 [entrypoints] Remove option `cutty create --overwrite-if-exists`
- 💥 [entrypoints] Remove option `cutty create --skip-if-file-exists`
- 🔨 [services] Remove parameter `fileexists` from `createproject`
- 🔨 [services] Rename functions `{create,cookiecutter}.create{project => }`
