### PR TITLE
🔨 [projects] Extract function `buildproject` from `services.{update,link}`

### DIFF
--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -1,0 +1,26 @@
+"""Building projects in a repository."""
+from typing import Optional
+
+from cutty.projects.generate import generate
+from cutty.projects.messages import MessageBuilder
+from cutty.projects.projectconfig import ProjectConfig
+from cutty.projects.repository import ProjectRepository
+from cutty.projects.store import storeproject
+from cutty.projects.template import Template
+
+
+def buildproject(
+    repository: ProjectRepository,
+    config: ProjectConfig,
+    *,
+    interactive: bool,
+    parent: Optional[str] = None,
+    commitmessage: MessageBuilder,
+) -> str:
+    """Build the project, returning the commit ID."""
+    template = Template.load(config.template, config.revision, config.directory)
+    project = generate(template, config.bindings, interactive=interactive)
+
+    with repository.build(parent=parent) as builder:
+        storeproject(project, builder.path)
+        return builder.commit(commitmessage(template.metadata))

--- a/src/cutty/projects/messages.py
+++ b/src/cutty/projects/messages.py
@@ -1,5 +1,10 @@
 """Commit messages."""
+from collections.abc import Callable
+
 from cutty.projects.template import Template
+
+
+MessageBuilder = Callable[[Template.Metadata], str]
 
 
 def createcommitmessage(template: Template.Metadata) -> str:

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -72,12 +72,12 @@ def link(
         projectdir, location, extrabindings, revision, directory
     )
 
+    repository = ProjectRepository(projectdir)
+
     template = Template.load(
         projectconfig.template, projectconfig.revision, projectconfig.directory
     )
     project = generate(template, projectconfig.bindings, interactive=interactive)
-
-    repository = ProjectRepository(projectdir)
 
     with repository.build() as builder:
         storeproject(project, builder.path)

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -5,15 +5,13 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.errors import CuttyError
-from cutty.projects.generate import generate
+from cutty.projects.build import buildproject
 from cutty.projects.messages import linkcommitmessage
 from cutty.projects.projectconfig import PROJECT_CONFIG_FILE
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.projectconfig import readcookiecutterjson
 from cutty.projects.projectconfig import readprojectconfigfile
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.store import storeproject
-from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
 
@@ -74,11 +72,11 @@ def link(
 
     repository = ProjectRepository(projectdir)
 
-    template = Template.load(config.template, config.revision, config.directory)
-    project = generate(template, config.bindings, interactive=interactive)
-
-    with repository.build() as builder:
-        storeproject(project, builder.path)
-        commit = builder.commit(linkcommitmessage(template.metadata))
+    commit = buildproject(
+        repository,
+        config,
+        interactive=interactive,
+        commitmessage=linkcommitmessage,
+    )
 
     repository.import_(commit, paths=[pathlib.Path(PROJECT_CONFIG_FILE)])

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -40,16 +40,16 @@ def createprojectconfig(
     directory: Optional[pathlib.Path],
 ) -> ProjectConfig:
     """Assemble project configuration from parameters and the existing project."""
-    projectconfig = loadprojectconfig(projectdir)
+    config = loadprojectconfig(projectdir)
 
-    if projectconfig is not None:
-        bindings = [*projectconfig.bindings, *bindings]
+    if config is not None:
+        bindings = [*config.bindings, *bindings]
 
         if location is None:
-            location = projectconfig.template
+            location = config.template
 
         if directory is None:
-            directory = projectconfig.directory
+            directory = config.directory
 
     if location is None:
         raise TemplateNotSpecifiedError()
@@ -68,16 +68,14 @@ def link(
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a Cookiecutter template."""
-    projectconfig = createprojectconfig(
+    config = createprojectconfig(
         projectdir, location, extrabindings, revision, directory
     )
 
     repository = ProjectRepository(projectdir)
 
-    template = Template.load(
-        projectconfig.template, projectconfig.revision, projectconfig.directory
-    )
-    project = generate(template, projectconfig.bindings, interactive=interactive)
+    template = Template.load(config.template, config.revision, config.directory)
+    project = generate(template, config.bindings, interactive=interactive)
 
     with repository.build() as builder:
         storeproject(project, builder.path)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 from cutty.projects.generate import generate
+from cutty.projects.messages import MessageBuilder
 from cutty.projects.messages import updatecommitmessage
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.projectconfig import readprojectconfigfile
@@ -19,6 +20,7 @@ def _create(
     *,
     interactive: bool,
     parent: Optional[str] = None,
+    commitmessage: MessageBuilder = updatecommitmessage,
 ) -> str:
     """Create the project and return the commit ID."""
     template = Template.load(config.template, config.revision, config.directory)
@@ -26,7 +28,7 @@ def _create(
 
     with repository.build(parent=parent) as builder:
         storeproject(project, builder.path)
-        return builder.commit(updatecommitmessage(template.metadata))
+        return builder.commit(commitmessage(template.metadata))
 
 
 def update(

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -16,6 +16,7 @@ from cutty.templates.domain.bindings import Binding
 def _create(
     repository: ProjectRepository,
     config: ProjectConfig,
+    *,
     interactive: bool,
     parent: Optional[str] = None,
 ) -> str:
@@ -48,8 +49,8 @@ def update(
 
     repository = ProjectRepository(projectdir)
 
-    parent = _create(repository, config1, interactive)
-    commit = _create(repository, config2, interactive, parent=parent)
+    parent = _create(repository, config1, interactive=interactive)
+    commit = _create(repository, config2, interactive=interactive, parent=parent)
 
     if commit != parent:
         repository.import_(commit)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -4,30 +4,11 @@ from pathlib import Path
 from typing import Optional
 
 from cutty.projects.build import buildproject
-from cutty.projects.messages import MessageBuilder
 from cutty.projects.messages import updatecommitmessage
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.projectconfig import readprojectconfigfile
 from cutty.projects.repository import ProjectRepository
 from cutty.templates.domain.bindings import Binding
-
-
-def _create(
-    repository: ProjectRepository,
-    config: ProjectConfig,
-    *,
-    interactive: bool,
-    parent: Optional[str] = None,
-    commitmessage: MessageBuilder,
-) -> str:
-    """Create the project and return the commit ID."""
-    return buildproject(
-        repository,
-        config,
-        interactive=interactive,
-        parent=parent,
-        commitmessage=commitmessage,
-    )
 
 
 def update(
@@ -50,14 +31,14 @@ def update(
 
     repository = ProjectRepository(projectdir)
 
-    parent = _create(
+    parent = buildproject(
         repository,
         config1,
         interactive=interactive,
         commitmessage=updatecommitmessage,
     )
 
-    commit = _create(
+    commit = buildproject(
         repository,
         config2,
         interactive=interactive,

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -20,7 +20,7 @@ def _create(
     *,
     interactive: bool,
     parent: Optional[str] = None,
-    commitmessage: MessageBuilder = updatecommitmessage,
+    commitmessage: MessageBuilder,
 ) -> str:
     """Create the project and return the commit ID."""
     template = Template.load(config.template, config.revision, config.directory)
@@ -51,8 +51,20 @@ def update(
 
     repository = ProjectRepository(projectdir)
 
-    parent = _create(repository, config1, interactive=interactive)
-    commit = _create(repository, config2, interactive=interactive, parent=parent)
+    parent = _create(
+        repository,
+        config1,
+        interactive=interactive,
+        commitmessage=updatecommitmessage,
+    )
+
+    commit = _create(
+        repository,
+        config2,
+        interactive=interactive,
+        commitmessage=updatecommitmessage,
+        parent=parent,
+    )
 
     if commit != parent:
         repository.import_(commit)

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -3,14 +3,12 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Optional
 
-from cutty.projects.generate import generate
+from cutty.projects.build import buildproject
 from cutty.projects.messages import MessageBuilder
 from cutty.projects.messages import updatecommitmessage
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.projectconfig import readprojectconfigfile
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.store import storeproject
-from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
 
@@ -23,12 +21,13 @@ def _create(
     commitmessage: MessageBuilder,
 ) -> str:
     """Create the project and return the commit ID."""
-    template = Template.load(config.template, config.revision, config.directory)
-    project = generate(template, config.bindings, interactive=interactive)
-
-    with repository.build(parent=parent) as builder:
-        storeproject(project, builder.path)
-        return builder.commit(commitmessage(template.metadata))
+    return buildproject(
+        repository,
+        config,
+        interactive=interactive,
+        parent=parent,
+        commitmessage=commitmessage,
+    )
 
 
 def update(


### PR DESCRIPTION
- 🔨 [projects] Add type alias `MessageBuilder`
- 🔨 [services] Use keyword-only arguments in function `update._create`
- 🔨 [services] Extract optional parameter `commitmessage` for `_create`
- 🔨 [services] Require parameter `commitmessage` in `update._create`
- 🔨 [projects] Extract function `build.buildmessage` from `services.update._create`
- 🔨 [services] Inline function `_create`
- 🔨 [services] Slide statement in `link`
- 🔨 [services] Rename variable `{project => }config` in `link`
- 🔨 [services] Replace inline code in `link` with call to `buildproject`
