### PR TITLE
🔨 [services] Reuse `projects.build` in `services.create`

### DIFF
--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -17,6 +17,20 @@ def createproject(config: ProjectConfig, *, interactive: bool) -> Project:
     return generate(template, config.bindings, interactive=interactive)
 
 
+def commitproject(
+    repository: ProjectRepository,
+    project: Project,
+    *,
+    parent: Optional[str] = None,
+    commitmessage: MessageBuilder,
+) -> str:
+    """Build the project, returning the commit ID."""
+    with repository.build(parent=parent) as builder:
+        storeproject(project, builder.path)
+
+        return builder.commit(commitmessage(project.template))
+
+
 def buildproject(
     repository: ProjectRepository,
     config: ProjectConfig,
@@ -28,6 +42,6 @@ def buildproject(
     """Build the project, returning the commit ID."""
     project = createproject(config, interactive=interactive)
 
-    with repository.build(parent=parent) as builder:
-        storeproject(project, builder.path)
-        return builder.commit(commitmessage(project.template))
+    return commitproject(
+        repository, project, parent=parent, commitmessage=commitmessage
+    )

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -3,10 +3,18 @@ from typing import Optional
 
 from cutty.projects.generate import generate
 from cutty.projects.messages import MessageBuilder
+from cutty.projects.project import Project
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
+
+
+def createproject(config: ProjectConfig, *, interactive: bool) -> Project:
+    """Create the project."""
+    template = Template.load(config.template, config.revision, config.directory)
+
+    return generate(template, config.bindings, interactive=interactive)
 
 
 def buildproject(
@@ -18,8 +26,7 @@ def buildproject(
     commitmessage: MessageBuilder,
 ) -> str:
     """Build the project, returning the commit ID."""
-    template = Template.load(config.template, config.revision, config.directory)
-    project = generate(template, config.bindings, interactive=interactive)
+    project = createproject(config, interactive=interactive)
 
     with repository.build(parent=parent) as builder:
         storeproject(project, builder.path)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -6,6 +6,7 @@ from typing import Optional
 from cutty.projects.build import commitproject
 from cutty.projects.generate import generate
 from cutty.projects.messages import createcommitmessage
+from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
@@ -22,9 +23,10 @@ def create(
     in_place: bool,
 ) -> None:
     """Generate projects from templates."""
-    template = Template.load(location, revision, directory)
+    config = ProjectConfig(location, extrabindings, revision, directory)
 
-    project = generate(template, extrabindings, interactive=interactive)
+    template = Template.load(config.template, config.revision, config.directory)
+    project = generate(template, config.bindings, interactive=interactive)
     projectdir = outputdir if in_place else outputdir / project.name
     repository = ProjectRepository.create(projectdir, message="Initial commit")
 

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -3,10 +3,10 @@ import pathlib
 from collections.abc import Sequence
 from typing import Optional
 
+from cutty.projects.build import commitproject
 from cutty.projects.generate import generate
 from cutty.projects.messages import createcommitmessage
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
@@ -28,8 +28,6 @@ def create(
     projectdir = outputdir if in_place else outputdir / project.name
     repository = ProjectRepository.create(projectdir, message="Initial commit")
 
-    with repository.build() as builder:
-        storeproject(project, builder.path)
-        commit = builder.commit(message=createcommitmessage(template.metadata))
+    commit = commitproject(repository, project, commitmessage=createcommitmessage)
 
     repository.import_(commit)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,11 +4,10 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.projects.build import commitproject
-from cutty.projects.generate import generate
+from cutty.projects.build import createproject
 from cutty.projects.messages import createcommitmessage
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.repository import ProjectRepository
-from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
 
@@ -25,8 +24,7 @@ def create(
     """Generate projects from templates."""
     config = ProjectConfig(location, extrabindings, revision, directory)
 
-    template = Template.load(config.template, config.revision, config.directory)
-    project = generate(template, config.bindings, interactive=interactive)
+    project = createproject(config, interactive=interactive)
     projectdir = outputdir if in_place else outputdir / project.name
     repository = ProjectRepository.create(projectdir, message="Initial commit")
 


### PR DESCRIPTION
- 🔨 [projects] Extract function `createproject` from `buildproject`
- 🔨 [projects] Extract function `commitproject` from `buildproject`
- 🔨 [services] Replace inline code in `create` with `commitproject`
- 🔨 [services] Extract variable `config` with `ProjectConfig`
- 🔨 [services] Replace inline code in `create` with `createproject`
