### PR TITLE
🔨 Add class `PackageRepository`, use context managers for packages

### DIFF
--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -1,9 +1,11 @@
 """Package."""
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Optional
 
+from cutty.compat.contextlib import contextmanager
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.pathfs import PathFilesystem
 from cutty.filesystems.domain.purepath import PurePath
@@ -26,3 +28,15 @@ class Package:
             Path(filesystem=PathFilesystem(path)),
             self.revision,
         )
+
+
+@dataclass
+class PackageRepository:
+    """A package repository."""
+
+    package: Package
+
+    @contextmanager
+    def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
+        """Retrieve the package with the given revision."""
+        yield self.package

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -72,20 +72,6 @@ class ProviderRegistry:
             package if directory is None else package.descend(directory)
         )
 
-    def __call__(
-        self,
-        rawlocation: str,
-        revision: Optional[Revision] = None,
-        fetchmode: FetchMode = FetchMode.ALWAYS,
-        directory: Optional[PurePath] = None,
-    ) -> Package:
-        """Return the package located at the given URL."""
-        repository = self.getrepository(
-            rawlocation, revision=revision, fetchmode=fetchmode, directory=directory
-        )
-        with repository.get(revision) as package:
-            return package
-
     def _extractprovidername(
         self, location: Location
     ) -> tuple[Optional[ProviderName], Location]:

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -12,6 +12,7 @@ from cutty.packages.domain.fetchers import FetchMode
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.locations import parselocation
 from cutty.packages.domain.package import Package
+from cutty.packages.domain.package import PackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.providers import ProviderFactory
 from cutty.packages.domain.providers import ProviderName
@@ -53,6 +54,24 @@ class ProviderRegistry:
             providerfactory.name: providerfactory for providerfactory in factories
         }
 
+    def getrepository(
+        self,
+        rawlocation: str,
+        revision: Optional[Revision] = None,
+        fetchmode: FetchMode = FetchMode.ALWAYS,
+        directory: Optional[PurePath] = None,
+    ) -> PackageRepository:
+        """Return the package repository located at the given URL."""
+        location = parselocation(rawlocation)
+
+        providername, location = self._extractprovidername(location)
+        providers = self._createproviders(fetchmode, providername)
+        package = provide(providers, location, revision)
+
+        return PackageRepository(
+            package if directory is None else package.descend(directory)
+        )
+
     def __call__(
         self,
         rawlocation: str,
@@ -61,13 +80,11 @@ class ProviderRegistry:
         directory: Optional[PurePath] = None,
     ) -> Package:
         """Return the package located at the given URL."""
-        location = parselocation(rawlocation)
-
-        providername, location = self._extractprovidername(location)
-        providers = self._createproviders(fetchmode, providername)
-        package = provide(providers, location, revision)
-
-        return package if directory is None else package.descend(directory)
+        repository = self.getrepository(
+            rawlocation, revision=revision, fetchmode=fetchmode, directory=directory
+        )
+        with repository.get(revision) as package:
+            return package
 
     def _extractprovidername(
         self, location: Location

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -14,7 +14,8 @@ def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Project:
     """Create the project."""
-    template = Template.load(config.template, config.revision, config.directory)
+    with Template.load2(config.template, config.revision, config.directory) as template:
+        pass
 
     return generate(
         template,

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -12,16 +12,6 @@ from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 
 
-def createproject(
-    config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
-) -> Project:
-    """Create the project."""
-    with createproject2(
-        config, interactive=interactive, createconfigfile=createconfigfile
-    ) as project:
-        return project
-
-
 @contextmanager
 def createproject2(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
@@ -59,8 +49,7 @@ def buildproject(
     commitmessage: MessageBuilder,
 ) -> str:
     """Build the project, returning the commit ID."""
-    project = createproject(config, interactive=interactive)
-
-    return commitproject(
-        repository, project, parent=parent, commitmessage=commitmessage
-    )
+    with createproject2(config, interactive=interactive) as project:
+        return commitproject(
+            repository, project, parent=parent, commitmessage=commitmessage
+        )

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -10,11 +10,18 @@ from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 
 
-def createproject(config: ProjectConfig, *, interactive: bool) -> Project:
+def createproject(
+    config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
+) -> Project:
     """Create the project."""
     template = Template.load(config.template, config.revision, config.directory)
 
-    return generate(template, config.bindings, interactive=interactive)
+    return generate(
+        template,
+        config.bindings,
+        interactive=interactive,
+        createconfigfile=createconfigfile,
+    )
 
 
 def commitproject(

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -13,7 +13,7 @@ from cutty.projects.template import Template
 
 
 @contextmanager
-def createproject2(
+def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Iterator[Project]:
     """Create the project."""
@@ -49,7 +49,7 @@ def buildproject(
     commitmessage: MessageBuilder,
 ) -> str:
     """Build the project, returning the commit ID."""
-    with createproject2(config, interactive=interactive) as project:
+    with createproject(config, interactive=interactive) as project:
         return commitproject(
             repository, project, parent=parent, commitmessage=commitmessage
         )

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -14,7 +14,7 @@ def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Project:
     """Create the project."""
-    with Template.load2(config.template, config.revision, config.directory) as template:
+    with Template.load(config.template, config.revision, config.directory) as template:
         pass
 
     return generate(

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -1,6 +1,8 @@
 """Building projects in a repository."""
+from collections.abc import Iterator
 from typing import Optional
 
+from cutty.compat.contextlib import contextmanager
 from cutty.projects.generate import generate
 from cutty.projects.messages import MessageBuilder
 from cutty.projects.project import Project
@@ -14,15 +16,24 @@ def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Project:
     """Create the project."""
-    with Template.load(config.template, config.revision, config.directory) as template:
-        pass
+    with createproject2(
+        config, interactive=interactive, createconfigfile=createconfigfile
+    ) as project:
+        return project
 
-    return generate(
-        template,
-        config.bindings,
-        interactive=interactive,
-        createconfigfile=createconfigfile,
-    )
+
+@contextmanager
+def createproject2(
+    config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
+) -> Iterator[Project]:
+    """Create the project."""
+    with Template.load(config.template, config.revision, config.directory) as template:
+        yield generate(
+            template,
+            config.bindings,
+            interactive=interactive,
+            createconfigfile=createconfigfile,
+        )
 
 
 def commitproject(

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -37,6 +37,16 @@ class Template:
         directory: Optional[pathlib.Path],
     ) -> Template:
         """Load a project template."""
+        return cls.load2(template, revision, directory)
+
+    @classmethod
+    def load2(
+        cls,
+        template: str,
+        revision: Optional[str],
+        directory: Optional[pathlib.Path],
+    ) -> Template:
+        """Load a project template."""
         cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
         packageprovider = getdefaultpackageprovider(cachedir)
         repository = packageprovider.getrepository(

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -33,7 +33,7 @@ class Template:
 
     @classmethod
     @contextmanager
-    def load2(
+    def load(
         cls,
         template: str,
         revision: Optional[str],

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -32,17 +32,6 @@ class Template:
     root: Path
 
     @classmethod
-    def load(
-        cls,
-        template: str,
-        revision: Optional[str],
-        directory: Optional[pathlib.Path],
-    ) -> Template:
-        """Load a project template."""
-        with cls.load2(template, revision, directory) as template2:
-            return template2
-
-    @classmethod
     @contextmanager
     def load2(
         cls,

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -39,11 +39,13 @@ class Template:
         """Load a project template."""
         cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
         packageprovider = getdefaultpackageprovider(cachedir)
-        package = packageprovider(
+        repository = packageprovider.getrepository(
             template,
             revision=revision,
             directory=(PurePath(*directory.parts) if directory is not None else None),
         )
+        with repository.get(revision) as package:
+            pass
 
         metadata = cls.Metadata(template, directory, package.name, package.revision)
         return cls(metadata, package.path)

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -4,10 +4,9 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.generate import generate
+from cutty.projects.build import createproject
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.store import storeproject
-from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
 
 
@@ -23,11 +22,8 @@ def create(
 ) -> None:
     """Generate projects from Cookiecutter templates."""
     config = ProjectConfig(location, extrabindings, checkout, directory)
-    template = Template.load(config.template, config.revision, config.directory)
 
-    project = generate(
-        template, config.bindings, interactive=interactive, createconfigfile=False
-    )
+    project = createproject(config, interactive=interactive, createconfigfile=False)
 
     storeproject(
         project,

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.build import createproject2
+from cutty.projects.build import createproject
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.store import storeproject
 from cutty.templates.domain.bindings import Binding
@@ -23,7 +23,7 @@ def create(
     """Generate projects from Cookiecutter templates."""
     config = ProjectConfig(location, extrabindings, checkout, directory)
 
-    with createproject2(
+    with createproject(
         config, interactive=interactive, createconfigfile=False
     ) as project:
         storeproject(

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.projects.generate import generate
+from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.store import storeproject
 from cutty.projects.template import Template
 from cutty.templates.domain.bindings import Binding
@@ -21,10 +22,11 @@ def create(
     fileexists: FileExistsPolicy,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
-    template = Template.load(location, checkout, directory)
+    config = ProjectConfig(location, extrabindings, checkout, directory)
+    template = Template.load(config.template, config.revision, config.directory)
 
     project = generate(
-        template, extrabindings, interactive=interactive, createconfigfile=False
+        template, config.bindings, interactive=interactive, createconfigfile=False
     )
 
     storeproject(

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.filestorage.adapters.disk import FileExistsPolicy
-from cutty.projects.build import createproject
+from cutty.projects.build import createproject2
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.store import storeproject
 from cutty.templates.domain.bindings import Binding
@@ -23,11 +23,12 @@ def create(
     """Generate projects from Cookiecutter templates."""
     config = ProjectConfig(location, extrabindings, checkout, directory)
 
-    project = createproject(config, interactive=interactive, createconfigfile=False)
-
-    storeproject(
-        project,
-        outputdir / project.name,
-        outputdirisproject=False,
-        fileexists=fileexists,
-    )
+    with createproject2(
+        config, interactive=interactive, createconfigfile=False
+    ) as project:
+        storeproject(
+            project,
+            outputdir / project.name,
+            outputdirisproject=False,
+            fileexists=fileexists,
+        )

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.projects.build import commitproject
-from cutty.projects.build import createproject2
+from cutty.projects.build import createproject
 from cutty.projects.messages import createcommitmessage
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.repository import ProjectRepository
@@ -24,7 +24,7 @@ def create(
     """Generate projects from templates."""
     config = ProjectConfig(location, extrabindings, revision, directory)
 
-    with createproject2(config, interactive=interactive) as project:
+    with createproject(config, interactive=interactive) as project:
         projectdir = outputdir if in_place else outputdir / project.name
         repository = ProjectRepository.create(projectdir, message="Initial commit")
         commit = commitproject(repository, project, commitmessage=createcommitmessage)

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Optional
 
 from cutty.projects.build import commitproject
-from cutty.projects.build import createproject
+from cutty.projects.build import createproject2
 from cutty.projects.messages import createcommitmessage
 from cutty.projects.projectconfig import ProjectConfig
 from cutty.projects.repository import ProjectRepository
@@ -24,10 +24,9 @@ def create(
     """Generate projects from templates."""
     config = ProjectConfig(location, extrabindings, revision, directory)
 
-    project = createproject(config, interactive=interactive)
-    projectdir = outputdir if in_place else outputdir / project.name
-    repository = ProjectRepository.create(projectdir, message="Initial commit")
-
-    commit = commitproject(repository, project, commitmessage=createcommitmessage)
+    with createproject2(config, interactive=interactive) as project:
+        projectdir = outputdir if in_place else outputdir / project.name
+        repository = ProjectRepository.create(projectdir, message="Initial commit")
+        commit = commitproject(repository, project, commitmessage=createcommitmessage)
 
     repository.import_(commit)


### PR DESCRIPTION
- 🔨 [packages] Add stub class `PackageRepository`
- 🔨 [packages] Extract function `ProviderRegistry.getrepository` from `__call__`
- 🔨 [packages] Inline function `ProviderRegistry.__call__`
- 🔨 [projects] Extract function `Template.load2`
- 🔨 [projects] Return context manager from `Template.load2`
- 🔨 [services] Extract variable `config` in `cookiecutter.create`
- 🔨 [projects] Add optional parameter `createconfigfile` in `createproject`
- 🔨 [services] Replace inline code in `cookiecutter.create` with `createproject`
- 🔨 [projects] Inline function `Template.load`
- 🔨 [projects] Rename function `Template.load2`
- 🔨 [projects] Extract function `createproject2` returning context manager
- 🔨 [projects] Inline function `createproject`
- 🔨 [projects] Rename function `createproject2`
