### PR TITLE
🔨 Move `Package.descend` from `ProviderRegistry` to `Template`

### DIFF
--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -53,7 +53,7 @@ class ProviderRegistry:
             providerfactory.name: providerfactory for providerfactory in factories
         }
 
-    def getrepository2(
+    def getrepository(
         self,
         rawlocation: str,
         revision: Optional[Revision] = None,

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -7,7 +7,6 @@ from typing import Optional
 from yarl import URL
 
 from cutty.errors import CuttyError
-from cutty.filesystems.domain.purepath import PurePath
 from cutty.packages.domain.fetchers import FetchMode
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.locations import parselocation
@@ -53,23 +52,6 @@ class ProviderRegistry:
         self.registry = {
             providerfactory.name: providerfactory for providerfactory in factories
         }
-
-    def getrepository(
-        self,
-        rawlocation: str,
-        revision: Optional[Revision] = None,
-        fetchmode: FetchMode = FetchMode.ALWAYS,
-        directory: Optional[PurePath] = None,
-    ) -> PackageRepository:
-        """Return the package repository located at the given URL."""
-        repository = self.getrepository2(
-            rawlocation, revision=revision, fetchmode=fetchmode
-        )
-
-        with repository.get(revision) as package:
-            return PackageRepository(
-                package if directory is None else package.descend(directory)
-            )
 
     def getrepository2(
         self,

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -62,16 +62,20 @@ class ProviderRegistry:
         directory: Optional[PurePath] = None,
     ) -> PackageRepository:
         """Return the package repository located at the given URL."""
-        return self.getrepository2(
-            rawlocation, revision=revision, fetchmode=fetchmode, directory=directory
+        repository = self.getrepository2(
+            rawlocation, revision=revision, fetchmode=fetchmode
         )
+
+        with repository.get(revision) as package:
+            return PackageRepository(
+                package if directory is None else package.descend(directory)
+            )
 
     def getrepository2(
         self,
         rawlocation: str,
         revision: Optional[Revision] = None,
         fetchmode: FetchMode = FetchMode.ALWAYS,
-        directory: Optional[PurePath] = None,
     ) -> PackageRepository:
         """Return the package repository located at the given URL."""
         location = parselocation(rawlocation)
@@ -80,9 +84,7 @@ class ProviderRegistry:
         providers = self._createproviders(fetchmode, providername)
         package = provide(providers, location, revision)
 
-        return PackageRepository(
-            package if directory is None else package.descend(directory)
-        )
+        return PackageRepository(package)
 
     def _extractprovidername(
         self, location: Location

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -62,6 +62,18 @@ class ProviderRegistry:
         directory: Optional[PurePath] = None,
     ) -> PackageRepository:
         """Return the package repository located at the given URL."""
+        return self.getrepository2(
+            rawlocation, revision=revision, fetchmode=fetchmode, directory=directory
+        )
+
+    def getrepository2(
+        self,
+        rawlocation: str,
+        revision: Optional[Revision] = None,
+        fetchmode: FetchMode = FetchMode.ALWAYS,
+        directory: Optional[PurePath] = None,
+    ) -> PackageRepository:
+        """Return the package repository located at the given URL."""
         location = parselocation(rawlocation)
 
         providername, location = self._extractprovidername(location)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -42,13 +42,12 @@ class Template:
         """Load a project template."""
         cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
         packageprovider = getdefaultpackageprovider(cachedir)
-        repository = packageprovider.getrepository(
-            template,
-            revision=revision,
-            directory=(PurePath(*directory.parts) if directory is not None else None),
-        )
+        repository = packageprovider.getrepository2(template, revision=revision)
 
         with repository.get(revision) as package:
+            if directory is not None:
+                package = package.descend(PurePath(*directory.parts))
+
             metadata = cls.Metadata(template, directory, package.name, package.revision)
 
             yield cls(metadata, package.path)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -42,7 +42,7 @@ class Template:
         """Load a project template."""
         cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
         packageprovider = getdefaultpackageprovider(cachedir)
-        repository = packageprovider.getrepository2(template, revision=revision)
+        repository = packageprovider.getrepository(template, revision=revision)
 
         with repository.get(revision) as package:
             if directory is not None:

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -62,7 +62,7 @@ def test_none(providerstore: ProviderStore, url: URL) -> None:
     """It raises an exception if the registry is empty."""
     registry = ProviderRegistry(providerstore, factories=[])
     with pytest.raises(Exception):
-        registry.getrepository2(str(url))
+        registry.getrepository(str(url))
 
 
 def test_with_url(
@@ -71,7 +71,7 @@ def test_with_url(
     """It returns a provider that allows traversing repositories."""
     providerfactory = RemoteProviderFactory("default", fetch=[emptyfetcher])
     registry = ProviderRegistry(providerstore, [providerfactory])
-    repository = registry.getrepository2(str(url))
+    repository = registry.getrepository(str(url))
 
     with repository.get() as package:
         assert not list(package.path.iterdir())
@@ -92,7 +92,7 @@ def test_with_path(
     )
 
     registry = ProviderRegistry(providerstore, [providerfactory])
-    repository = registry.getrepository2(str(directory))
+    repository = registry.getrepository(str(directory))
 
     with repository.get(str(directory)) as package:
         [entry] = package.path.iterdir()
@@ -111,7 +111,7 @@ def test_with_provider_specific_url(
     ]
     registry = ProviderRegistry(providerstore, factories)
     with pytest.raises(Exception):
-        registry.getrepository2(str(url))
+        registry.getrepository(str(url))
 
 
 def test_unknown_provider_in_url_scheme(providerstore: ProviderStore, url: URL) -> None:
@@ -122,7 +122,7 @@ def test_unknown_provider_in_url_scheme(providerstore: ProviderStore, url: URL) 
     factories = [ConstProviderFactory(constprovider("default", package))]
     registry = ProviderRegistry(providerstore, factories)
     url = url.with_scheme(f"invalid+{url.scheme}")
-    repository = registry.getrepository2(str(url))
+    repository = registry.getrepository(str(url))
 
     with repository.get() as package2:
         assert package == package2
@@ -132,14 +132,14 @@ def test_provider_specific_file_url(providerstore: ProviderStore) -> None:
     """It does not crash when rewriting provider-specific file:// URLs."""
     # https://github.com/aio-libs/yarl/issues/280
     registry = ProviderRegistry(providerstore, [ConstProviderFactory(dictprovider())])
-    registry.getrepository2("dict+file:///path/to/repository.zip")  # does not raise
+    registry.getrepository("dict+file:///path/to/repository.zip")  # does not raise
 
 
 def test_name_from_url(providerstore: ProviderStore, emptyfetcher: Fetcher) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = RemoteProviderFactory("default", fetch=[emptyfetcher])
     registry = ProviderRegistry(providerstore, [providerfactory])
-    repository = registry.getrepository2(
+    repository = registry.getrepository(
         "https://example.com/path/to/example?query#fragment"
     )
 

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -62,7 +62,7 @@ def test_none(providerstore: ProviderStore, url: URL) -> None:
     """It raises an exception if the registry is empty."""
     registry = ProviderRegistry(providerstore, factories=[])
     with pytest.raises(Exception):
-        registry.getrepository(str(url))
+        registry.getrepository2(str(url))
 
 
 def test_with_url(
@@ -71,7 +71,7 @@ def test_with_url(
     """It returns a provider that allows traversing repositories."""
     providerfactory = RemoteProviderFactory("default", fetch=[emptyfetcher])
     registry = ProviderRegistry(providerstore, [providerfactory])
-    repository = registry.getrepository(str(url))
+    repository = registry.getrepository2(str(url))
 
     with repository.get() as package:
         assert not list(package.path.iterdir())
@@ -92,7 +92,7 @@ def test_with_path(
     )
 
     registry = ProviderRegistry(providerstore, [providerfactory])
-    repository = registry.getrepository(str(directory))
+    repository = registry.getrepository2(str(directory))
 
     with repository.get(str(directory)) as package:
         [entry] = package.path.iterdir()
@@ -111,7 +111,7 @@ def test_with_provider_specific_url(
     ]
     registry = ProviderRegistry(providerstore, factories)
     with pytest.raises(Exception):
-        registry.getrepository(str(url))
+        registry.getrepository2(str(url))
 
 
 def test_unknown_provider_in_url_scheme(providerstore: ProviderStore, url: URL) -> None:
@@ -122,7 +122,7 @@ def test_unknown_provider_in_url_scheme(providerstore: ProviderStore, url: URL) 
     factories = [ConstProviderFactory(constprovider("default", package))]
     registry = ProviderRegistry(providerstore, factories)
     url = url.with_scheme(f"invalid+{url.scheme}")
-    repository = registry.getrepository(str(url))
+    repository = registry.getrepository2(str(url))
 
     with repository.get() as package2:
         assert package == package2
@@ -132,14 +132,14 @@ def test_provider_specific_file_url(providerstore: ProviderStore) -> None:
     """It does not crash when rewriting provider-specific file:// URLs."""
     # https://github.com/aio-libs/yarl/issues/280
     registry = ProviderRegistry(providerstore, [ConstProviderFactory(dictprovider())])
-    registry.getrepository("dict+file:///path/to/repository.zip")  # does not raise
+    registry.getrepository2("dict+file:///path/to/repository.zip")  # does not raise
 
 
 def test_name_from_url(providerstore: ProviderStore, emptyfetcher: Fetcher) -> None:
     """It returns a provider that allows traversing repositories."""
     providerfactory = RemoteProviderFactory("default", fetch=[emptyfetcher])
     registry = ProviderRegistry(providerstore, [providerfactory])
-    repository = registry.getrepository(
+    repository = registry.getrepository2(
         "https://example.com/path/to/example?query#fragment"
     )
 


### PR DESCRIPTION
- 🔨 [packages] Extract function `ProviderRegistry.getrepository2`
- 🔨 [packages] Remove parameter `directory` from `ProviderRegistry.getrepository2`
- 🔨 [packages] Inline function `ProviderRegistry.getrepository`
- 🔨 [packages] Rename function `ProviderRegistry.getrepository2`
