### PR TITLE
🔨[packages] Return `PackageRepository` from `Provider.provide`

### DIFF
--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -35,9 +35,6 @@ class Provider:
         self, location: Location, revision: Optional[Revision] = None
     ) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
-        if package := self(location, revision):
-            return PackageRepository(package)
-        return None
 
     def __call__(
         self, location: Location, revision: Optional[Revision] = None
@@ -92,6 +89,14 @@ class LocalProvider(BaseProvider):
         super().__init__(name, mount=mount, getrevision=getrevision)
         self.match = match
 
+    def provide(
+        self, location: Location, revision: Optional[Revision] = None
+    ) -> Optional[PackageRepository]:
+        """Retrieve the package repository at the given location."""
+        if package := self(location, revision):
+            return PackageRepository(package)
+        return None
+
     def __call__(
         self, location: Location, revision: Optional[Revision] = None
     ) -> Optional[Package]:
@@ -136,6 +141,14 @@ class RemoteProvider(BaseProvider):
         self.fetch = tuple(fetch)
         self.store = store
         self.fetchmode = fetchmode
+
+    def provide(
+        self, location: Location, revision: Optional[Revision] = None
+    ) -> Optional[PackageRepository]:
+        """Retrieve the package repository at the given location."""
+        if package := self(location, revision):
+            return PackageRepository(package)
+        return None
 
     def __call__(
         self, location: Location, revision: Optional[Revision] = None

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -19,6 +19,7 @@ from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.matchers import PathMatcher
 from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.package import Package
+from cutty.packages.domain.package import PackageRepository
 from cutty.packages.domain.revisions import Revision
 from cutty.packages.domain.stores import Store
 
@@ -29,6 +30,14 @@ class Provider:
     def __init__(self, name: str = "") -> None:
         """Initialize."""
         self.name = name
+
+    def provide(
+        self, location: Location, revision: Optional[Revision] = None
+    ) -> Optional[PackageRepository]:
+        """Retrieve the package repository at the given location."""
+        if package := self(location, revision):
+            return PackageRepository(package)
+        return None
 
     def __call__(
         self, location: Location, revision: Optional[Revision] = None

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -36,11 +36,6 @@ class Provider:
     ) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
 
-    def __call__(
-        self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[Package]:
-        """Return the package at the given location."""
-
 
 GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -134,14 +134,6 @@ class RemoteProvider(BaseProvider):
         self, location: Location, revision: Optional[Revision] = None
     ) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
-        if package := self(location, revision):
-            return PackageRepository(package)
-        return None
-
-    def __call__(
-        self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[Package]:
-        """Return the package at the given location."""
         if isinstance(location, URL):
             url = location
         elif location.exists():
@@ -152,7 +144,8 @@ class RemoteProvider(BaseProvider):
         if self.match is None or self.match(url):
             for fetcher in self.fetch:
                 if path := fetcher(url, self.store, revision, self.fetchmode):
-                    return self._loadpackage(location, revision, path)
+                    package = self._loadpackage(location, revision, path)
+                    return PackageRepository(package)
 
         return None
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -88,21 +88,14 @@ class LocalProvider(BaseProvider):
         self, location: Location, revision: Optional[Revision] = None
     ) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
-        if package := self(location, revision):
-            return PackageRepository(package)
-        return None
-
-    def __call__(
-        self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[Package]:
-        """Return the package at the given location."""
         try:
             path = location if isinstance(location, pathlib.Path) else aspath(location)
         except ValueError:
             return None
 
         if path.exists() and self.match(path):
-            return self._loadpackage(location, revision, path)
+            package = self._loadpackage(location, revision, path)
+            return PackageRepository(package)
 
         return None
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -57,6 +57,12 @@ class BaseProvider(Provider):
         self.mount = mount
         self.getrevision = getrevision
 
+    def _loadrepository(
+        self, location: Location, revision: Optional[Revision], path: pathlib.Path
+    ) -> PackageRepository:
+        package = self._loadpackage(location, revision, path)
+        return PackageRepository(package)
+
     def _loadpackage(
         self, location: Location, revision: Optional[Revision], path: pathlib.Path
     ) -> Package:
@@ -94,8 +100,7 @@ class LocalProvider(BaseProvider):
             return None
 
         if path.exists() and self.match(path):
-            package = self._loadpackage(location, revision, path)
-            return PackageRepository(package)
+            return self._loadrepository(location, revision, path)
 
         return None
 
@@ -144,8 +149,7 @@ class RemoteProvider(BaseProvider):
         if self.match is None or self.match(url):
             for fetcher in self.fetch:
                 if path := fetcher(url, self.store, revision, self.fetchmode):
-                    package = self._loadpackage(location, revision, path)
-                    return PackageRepository(package)
+                    return self._loadrepository(location, revision, path)
 
         return None
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -60,18 +60,14 @@ class BaseProvider(Provider):
     def _loadrepository(
         self, location: Location, revision: Optional[Revision], path: pathlib.Path
     ) -> PackageRepository:
-        package = self._loadpackage(location, revision, path)
-        return PackageRepository(package)
-
-    def _loadpackage(
-        self, location: Location, revision: Optional[Revision], path: pathlib.Path
-    ) -> Package:
         filesystem = self.mount(path, revision)
 
         if self.getrevision is not None:
             revision = self.getrevision(path, revision)
 
-        return Package(location.name, Path(filesystem=filesystem), revision)
+        package = Package(location.name, Path(filesystem=filesystem), revision)
+
+        return PackageRepository(package)
 
 
 class LocalProvider(BaseProvider):

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -26,7 +26,7 @@ class UnknownLocationError(CuttyError):
     location: Location
 
 
-def provide(
+def _provide(
     providers: Iterable[Provider],
     location: Location,
     revision: Optional[Revision] = None,
@@ -64,7 +64,7 @@ class ProviderRegistry:
 
         providername, location = self._extractprovidername(location)
         providers = self._createproviders(fetchmode, providername)
-        package = provide(providers, location, revision)
+        package = _provide(providers, location, revision)
 
         return PackageRepository(package)
 

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -32,8 +32,8 @@ def _provide(
 ) -> PackageRepository:
     """Provide the package repository located at the given URL."""
     for provider in providers:
-        if package := provider(location, revision):
-            return PackageRepository(package)
+        if repository := provider.provide(location, revision):
+            return repository
 
     raise UnknownLocationError(location)
 

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -10,7 +10,6 @@ from cutty.errors import CuttyError
 from cutty.packages.domain.fetchers import FetchMode
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.locations import parselocation
-from cutty.packages.domain.package import Package
 from cutty.packages.domain.package import PackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.providers import ProviderFactory
@@ -30,11 +29,11 @@ def _provide(
     providers: Iterable[Provider],
     location: Location,
     revision: Optional[Revision] = None,
-) -> Package:
-    """Provide the package located at the given URL."""
+) -> PackageRepository:
+    """Provide the package repository located at the given URL."""
     for provider in providers:
         if package := provider(location, revision):
-            return package
+            return PackageRepository(package)
 
     raise UnknownLocationError(location)
 
@@ -64,9 +63,7 @@ class ProviderRegistry:
 
         providername, location = self._extractprovidername(location)
         providers = self._createproviders(fetchmode, providername)
-        package = _provide(providers, location, revision)
-
-        return PackageRepository(package)
+        return _provide(providers, location, revision)
 
     def _extractprovidername(
         self, location: Location

--- a/tests/fixtures/packages/domain/providers.py
+++ b/tests/fixtures/packages/domain/providers.py
@@ -49,10 +49,12 @@ def constprovider(name: str, package: Package) -> Provider:
     return _
 
 
-def dictprovider(mapping: Optional[dict[str, Any]] = None) -> Provider:
+def dictprovider(
+    mapping: Optional[dict[str, Any]] = None, name: str = "dict"
+) -> Provider:
     """Provider that matches every URL with a package."""
 
-    @provider("dict")
+    @provider(name)
     def _(location: Location, revision: Optional[Revision]) -> Optional[Package]:
         filesystem = DictFilesystem(mapping or {})
         path = Path(filesystem=filesystem)

--- a/tests/fixtures/packages/domain/providers.py
+++ b/tests/fixtures/packages/domain/providers.py
@@ -30,14 +30,9 @@ def provider(name: str) -> Callable[[ProviderFunction], Provider]:
                 self, location: Location, revision: Optional[Revision] = None
             ) -> Optional[PackageRepository]:
                 """Retrieve the package repository at the given location."""
-                if package := self(location, revision):
+                if package := function(location, revision):
                     return PackageRepository(package)
                 return None
-
-            def __call__(
-                self, location: Location, revision: Optional[Revision] = None
-            ) -> Optional[Package]:
-                return function(location, revision)
 
         return _Provider()
 

--- a/tests/fixtures/packages/domain/providers.py
+++ b/tests/fixtures/packages/domain/providers.py
@@ -7,6 +7,7 @@ from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.package import Package
+from cutty.packages.domain.package import PackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.revisions import Revision
 
@@ -24,6 +25,14 @@ def provider(name: str) -> Callable[[ProviderFunction], Provider]:
         class _Provider(Provider):
             def __init__(self) -> None:
                 super().__init__(name)
+
+            def provide(
+                self, location: Location, revision: Optional[Revision] = None
+            ) -> Optional[PackageRepository]:
+                """Retrieve the package repository at the given location."""
+                if package := self(location, revision):
+                    return PackageRepository(package)
+                return None
 
             def __call__(
                 self, location: Location, revision: Optional[Revision] = None

--- a/tests/unit/packages/adapters/providers/test_disk.py
+++ b/tests/unit/packages/adapters/providers/test_disk.py
@@ -19,15 +19,16 @@ def repositorypath(tmp_path: Path) -> Path:
 def test_happy(repositorypath: Path) -> None:
     """It provides a repository from a local directory."""
     url = asurl(repositorypath)
-    package = diskprovider(url)
-    assert package is not None
+    repository = diskprovider.provide(url)
+    assert repository is not None
 
-    text = (package.path / "marker").read_text()
-    assert text == "Lorem"
+    with repository.get() as package:
+        text = (package.path / "marker").read_text()
+        assert text == "Lorem"
 
 
 def test_revision(repositorypath: Path) -> None:
     """It raises an exception when passed a revision."""
     url = asurl(repositorypath)
     with pytest.raises(Exception):
-        diskprovider(url, "v1.0")
+        diskprovider.provide(url, "v1.0")

--- a/tests/unit/packages/adapters/providers/test_disk.py
+++ b/tests/unit/packages/adapters/providers/test_disk.py
@@ -8,17 +8,17 @@ from cutty.packages.domain.locations import asurl
 
 
 @pytest.fixture
-def repository(tmp_path: Path) -> Path:
-    """Fixture for a repository."""
+def repositorypath(tmp_path: Path) -> Path:
+    """Fixture for a package repository."""
     path = tmp_path / "repository"
     path.mkdir()
     (path / "marker").write_text("Lorem")
     return path
 
 
-def test_happy(repository: Path) -> None:
+def test_happy(repositorypath: Path) -> None:
     """It provides a repository from a local directory."""
-    url = asurl(repository)
+    url = asurl(repositorypath)
     package = diskprovider(url)
     assert package is not None
 
@@ -26,8 +26,8 @@ def test_happy(repository: Path) -> None:
     assert text == "Lorem"
 
 
-def test_revision(repository: Path) -> None:
+def test_revision(repositorypath: Path) -> None:
     """It raises an exception when passed a revision."""
-    url = asurl(repository)
+    url = asurl(repositorypath)
     with pytest.raises(Exception):
         diskprovider(url, "v1.0")

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -41,7 +41,7 @@ def test_local_happy(url: URL, revision: Optional[str], expected: str) -> None:
 
     with repository.get(revision) as package:
         text = (package.path / "marker").read_text()
-        assert text == expected
+        assert expected == text
 
 
 def test_local_not_matching(tmp_path: pathlib.Path) -> None:
@@ -99,7 +99,7 @@ def test_remote_happy(
 
     with repository.get(revision) as package:
         text = (package.path / "marker").read_text()
-        assert text == expected
+        assert expected == text
 
 
 def test_remote_revision_tag(gitprovider: Provider, url: URL) -> None:

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -124,8 +124,7 @@ def test_remote_revision_commit(store: Store, url: URL) -> None:
 
 def test_remote_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
-    url = URL("mailto:you@example.com")
     gitprovider = gitproviderfactory(store)
-    repository = gitprovider.provide(url)
+    repository = gitprovider.provide(URL("mailto:you@example.com"))
 
     assert repository is None

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -15,7 +15,6 @@ from cutty.packages.domain.stores import Store
 from cutty.util.git import Repository
 from tests.util.git import updatefile
 
-
 signature = pygit2.Signature("you", "you@example.com")
 
 
@@ -35,42 +34,51 @@ def url(tmp_path: pathlib.Path) -> URL:
 @pytest.mark.parametrize(("revision", "expected"), [("v1.0", "Lorem"), (None, "Ipsum")])
 def test_local_happy(url: URL, revision: Optional[str], expected: str) -> None:
     """It provides a package from a local directory."""
-    package = localgitprovider(url, revision)
-    assert package is not None
+    repository = localgitprovider.provide(url, revision)
 
-    text = (package.path / "marker").read_text()
-    assert text == expected
+    assert repository is not None
+
+    with repository.get(revision) as package:
+        text = (package.path / "marker").read_text()
+        assert text == expected
 
 
 def test_local_not_matching(tmp_path: pathlib.Path) -> None:
     """It returns None if the path is not a git repository."""
     url = asurl(tmp_path)
-    package = localgitprovider(url)
-    assert package is None
+    repository = localgitprovider.provide(url)
+
+    assert repository is None
 
 
 def test_local_invalid_revision(url: URL) -> None:
     """It raises an exception."""
     with pytest.raises(CuttyError):
-        localgitprovider(url, "invalid")
+        localgitprovider.provide(url, "invalid")
 
 
 def test_local_revision_tag(url: URL) -> None:
     """It returns the tag name."""
-    package = localgitprovider(url, "HEAD^")
-    assert package is not None
-    assert package.revision == "v1.0"
+    repository = localgitprovider.provide(url, "HEAD^")
+
+    assert repository is not None
+
+    with repository.get("HEAD^") as package:
+        assert package.revision == "v1.0"
 
 
 def test_local_revision_commit(url: URL) -> None:
     """It returns seven or more hexadecimal digits."""
-    package = localgitprovider(url)
-    assert (
-        package is not None
-        and package.revision is not None
-        and len(package.revision) >= 7
-        and all(c in string.hexdigits for c in package.revision)
-    )
+    repository = localgitprovider.provide(url)
+
+    assert repository is not None
+
+    with repository.get() as package:
+        assert (
+            package.revision is not None
+            and len(package.revision) >= 7
+            and all(c in string.hexdigits for c in package.revision)
+        )
 
 
 @pytest.mark.parametrize(("revision", "expected"), [("v1.0", "Lorem"), (None, "Ipsum")])
@@ -79,35 +87,45 @@ def test_remote_happy(
 ) -> None:
     """It fetches a git repository into storage."""
     gitprovider = gitproviderfactory(store)
-    package = gitprovider(url, revision)
-    assert package is not None
+    repository = gitprovider.provide(url, revision)
 
-    text = (package.path / "marker").read_text()
-    assert text == expected
+    assert repository is not None
+
+    with repository.get(revision) as package:
+        text = (package.path / "marker").read_text()
+        assert text == expected
 
 
 def test_remote_revision_tag(store: Store, url: URL) -> None:
     """It returns the tag name."""
     gitprovider = gitproviderfactory(store)
-    package = gitprovider(url, "HEAD^")
-    assert package is not None and package.revision == "v1.0"
+    repository = gitprovider.provide(url, "HEAD^")
+
+    assert repository is not None
+
+    with repository.get("HEAD^") as package:
+        assert package.revision == "v1.0"
 
 
 def test_remote_revision_commit(store: Store, url: URL) -> None:
     """It returns seven or more hexadecimal digits."""
     gitprovider = gitproviderfactory(store)
-    package = gitprovider(url)
-    assert (
-        package is not None
-        and package.revision is not None
-        and len(package.revision) >= 7
-        and all(c in string.hexdigits for c in package.revision)
-    )
+    repository = gitprovider.provide(url)
+
+    assert repository is not None
+
+    with repository.get() as package:
+        assert (
+            package.revision is not None
+            and len(package.revision) >= 7
+            and all(c in string.hexdigits for c in package.revision)
+        )
 
 
 def test_remote_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
     url = URL("mailto:you@example.com")
     gitprovider = gitproviderfactory(store)
-    package = gitprovider(url)
-    assert package is None
+    repository = gitprovider.provide(url)
+
+    assert repository is None

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -59,13 +59,13 @@ def test_local_not_matching(tmp_path: pathlib.Path) -> None:
 
 
 def test_local_invalid_revision(url: URL) -> None:
-    """It raises an exception."""
+    """It raises an exception if the revision is invalid."""
     with pytest.raises(CuttyError):
         localgitprovider.provide(url, "invalid")
 
 
 def test_local_revision_tag(url: URL) -> None:
-    """It returns the tag name."""
+    """It retrieves the tag name as the package revision."""
     repository = localgitprovider.provide(url, "HEAD^")
 
     assert repository is not None
@@ -75,7 +75,7 @@ def test_local_revision_tag(url: URL) -> None:
 
 
 def test_local_revision_commit(url: URL) -> None:
-    """It returns seven or more hexadecimal digits."""
+    """It retrieves the short hash as the package revision."""
     repository = localgitprovider.provide(url)
 
     assert repository is not None
@@ -90,7 +90,7 @@ def test_local_revision_commit(url: URL) -> None:
 
 @pytest.fixture
 def gitprovider(store: Store) -> Provider:
-    """Return a git provider."""
+    """Fixture for a git provider."""
     return gitproviderfactory(store)
 
 
@@ -115,7 +115,7 @@ def test_remote_happy(
 
 
 def test_remote_revision_tag(gitprovider: Provider, url: URL) -> None:
-    """It returns the tag name."""
+    """It retrieves the tag name as the package revision."""
     repository = gitprovider.provide(url, "HEAD^")
 
     assert repository is not None
@@ -125,7 +125,7 @@ def test_remote_revision_tag(gitprovider: Provider, url: URL) -> None:
 
 
 def test_remote_revision_commit(gitprovider: Provider, url: URL) -> None:
-    """It returns seven or more hexadecimal digits."""
+    """It retrieves the short hash as the package revision."""
     repository = gitprovider.provide(url)
 
     assert repository is not None

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -32,7 +32,13 @@ def url(tmp_path: pathlib.Path) -> URL:
     return asurl(path)
 
 
-@pytest.mark.parametrize(("revision", "expected"), [("v1.0", "Lorem"), (None, "Ipsum")])
+@pytest.mark.parametrize(
+    ("revision", "expected"),
+    [
+        ("v1.0", "Lorem"),
+        (None, "Ipsum"),
+    ],
+)
 def test_local_happy(url: URL, revision: Optional[str], expected: str) -> None:
     """It provides a package from a local directory."""
     repository = localgitprovider.provide(url, revision)
@@ -88,7 +94,13 @@ def gitprovider(store: Store) -> Provider:
     return gitproviderfactory(store)
 
 
-@pytest.mark.parametrize(("revision", "expected"), [("v1.0", "Lorem"), (None, "Ipsum")])
+@pytest.mark.parametrize(
+    ("revision", "expected"),
+    [
+        ("v1.0", "Lorem"),
+        (None, "Ipsum"),
+    ],
+)
 def test_remote_happy(
     gitprovider: Provider, url: URL, revision: Optional[str], expected: str
 ) -> None:

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -121,8 +121,7 @@ def test_revision_multiple_tags(store: Store, hg: Hg, tmp_path: pathlib.Path) ->
 
 def test_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
-    url = URL("mailto:you@example.com")
     hgprovider = hgproviderfactory(store)
-    repository = hgprovider.provide(url)
+    repository = hgprovider.provide(URL("mailto:you@example.com"))
 
     assert repository is None

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -37,7 +37,13 @@ def hgrepository(hg: Hg, session_tmp_path: pathlib.Path) -> pathlib.Path:
     return path
 
 
-@pytest.mark.parametrize(("revision", "expected"), [("v1.0", "Lorem"), (None, "Ipsum")])
+@pytest.mark.parametrize(
+    ("revision", "expected"),
+    [
+        ("v1.0", "Lorem"),
+        (None, "Ipsum"),
+    ],
+)
 def test_happy(
     store: Store, hgrepository: pathlib.Path, revision: Optional[str], expected: str
 ) -> None:

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -55,7 +55,7 @@ def test_happy(
 
     with repository.get(revision) as package:
         text = (package.path / "marker").read_text()
-        assert text == expected
+        assert expected == text
 
 
 def is_mercurial_shorthash(revision: str) -> bool:

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -40,7 +40,7 @@ def hgrepository(hg: Hg, session_tmp_path: pathlib.Path) -> pathlib.Path:
 
 @pytest.fixture
 def hgprovider(store: Store) -> Provider:
-    """Return a Mercurial provider."""
+    """Fixture for a Mercurial provider."""
     return hgproviderfactory(store)
 
 
@@ -73,7 +73,7 @@ def is_mercurial_shorthash(revision: str) -> bool:
 
 
 def test_revision_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
-    """It returns the short changeset identification hash."""
+    """It retrieves the short hash as the package revision."""
     repository = hgprovider.provide(hgrepository)
 
     assert repository is not None
@@ -83,7 +83,7 @@ def test_revision_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> No
 
 
 def test_revision_tag(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
-    """It returns the tag name."""
+    """It retrieves the tag name as the package revision."""
     repository = hgprovider.provide(hgrepository, "tip~2")
 
     assert repository is not None
@@ -93,7 +93,7 @@ def test_revision_tag(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
 
 
 def test_revision_no_tags(hgprovider: Provider, hg: Hg, tmp_path: pathlib.Path) -> None:
-    """It returns the changeset hash in a repository without tags."""
+    """It retrieves the short hash as the package revision when there are no tags."""
     path = tmp_path / "repository"
     path.mkdir()
     (path / "marker").touch()
@@ -113,7 +113,7 @@ def test_revision_no_tags(hgprovider: Provider, hg: Hg, tmp_path: pathlib.Path) 
 def test_revision_multiple_tags(
     hgprovider: Provider, hg: Hg, tmp_path: pathlib.Path
 ) -> None:
-    """It returns the tag names separated by colon."""
+    """It retrieves multiple tag names separated by colon as the package revision."""
     path = tmp_path / "repository"
     path.mkdir()
     (path / "marker").touch()

--- a/tests/unit/packages/adapters/providers/test_zip.py
+++ b/tests/unit/packages/adapters/providers/test_zip.py
@@ -26,39 +26,45 @@ def url(tmp_path: Path) -> URL:
 
 def test_local_happy(url: URL) -> None:
     """It provides a package from a local directory."""
-    package = localzipprovider(url)
-    assert package is not None
+    repository = localzipprovider.provide(url)
 
-    text = (package.path / "marker").read_text()
-    assert text == "Lorem"
+    assert repository is not None
+
+    with repository.get() as package:
+        text = (package.path / "marker").read_text()
+        assert text == "Lorem"
 
 
 def test_local_revision(url: URL) -> None:
     """It raises an exception when passed a revision."""
     with pytest.raises(Exception):
-        localzipprovider(url, "v1.0")
+        localzipprovider.provide(url, "v1.0")
 
 
 def test_local_not_matching(tmp_path: Path) -> None:
     """It returns None if the path is not a zip package."""
     url = asurl(tmp_path)
-    package = localzipprovider(url)
-    assert package is None
+    repository = localzipprovider.provide(url)
+
+    assert repository is None
 
 
 def test_remote_happy(store: Store, url: URL) -> None:
     """It fetches a zip package into storage."""
     zipprovider = zipproviderfactory(store)
-    package = zipprovider(url)
-    assert package is not None
+    repository = zipprovider.provide(url)
 
-    text = (package.path / "marker").read_text()
-    assert text == "Lorem"
+    assert repository is not None
+
+    with repository.get() as package:
+        text = (package.path / "marker").read_text()
+        assert text == "Lorem"
 
 
 def test_remote_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
     url = URL("mailto:you@example.com")
     zipprovider = zipproviderfactory(store)
-    package = zipprovider(url)
-    assert package is None
+    repository = zipprovider.provide(url)
+
+    assert repository is None

--- a/tests/unit/packages/adapters/providers/test_zip.py
+++ b/tests/unit/packages/adapters/providers/test_zip.py
@@ -8,6 +8,7 @@ from yarl import URL
 from cutty.packages.adapters.providers.zip import localzipprovider
 from cutty.packages.adapters.providers.zip import zipproviderfactory
 from cutty.packages.domain.locations import asurl
+from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.stores import Store
 
 
@@ -48,9 +49,14 @@ def test_local_not_matching(tmp_path: Path) -> None:
     assert repository is None
 
 
-def test_remote_happy(store: Store, url: URL) -> None:
+@pytest.fixture
+def zipprovider(store: Store) -> Provider:
+    """Return a zip provider."""
+    return zipproviderfactory(store)
+
+
+def test_remote_happy(zipprovider: Provider, url: URL) -> None:
     """It fetches a zip package into storage."""
-    zipprovider = zipproviderfactory(store)
     repository = zipprovider.provide(url)
 
     assert repository is not None
@@ -60,9 +66,8 @@ def test_remote_happy(store: Store, url: URL) -> None:
         assert "Lorem" == text
 
 
-def test_remote_not_matching(store: Store) -> None:
+def test_remote_not_matching(zipprovider: Provider) -> None:
     """It returns None if the URL scheme is not recognized."""
-    zipprovider = zipproviderfactory(store)
     repository = zipprovider.provide(URL("mailto:you@example.com"))
 
     assert repository is None

--- a/tests/unit/packages/adapters/providers/test_zip.py
+++ b/tests/unit/packages/adapters/providers/test_zip.py
@@ -43,8 +43,7 @@ def test_local_revision(url: URL) -> None:
 
 def test_local_not_matching(tmp_path: Path) -> None:
     """It returns None if the path is not a zip package."""
-    url = asurl(tmp_path)
-    repository = localzipprovider.provide(url)
+    repository = localzipprovider.provide(asurl(tmp_path))
 
     assert repository is None
 
@@ -63,8 +62,7 @@ def test_remote_happy(store: Store, url: URL) -> None:
 
 def test_remote_not_matching(store: Store) -> None:
     """It returns None if the URL scheme is not recognized."""
-    url = URL("mailto:you@example.com")
     zipprovider = zipproviderfactory(store)
-    repository = zipprovider.provide(url)
+    repository = zipprovider.provide(URL("mailto:you@example.com"))
 
     assert repository is None

--- a/tests/unit/packages/adapters/providers/test_zip.py
+++ b/tests/unit/packages/adapters/providers/test_zip.py
@@ -26,7 +26,7 @@ def url(tmp_path: Path) -> URL:
 
 
 def test_local_happy(url: URL) -> None:
-    """It provides a package from a local directory."""
+    """It provides a package repository from a local directory."""
     repository = localzipprovider.provide(url)
 
     assert repository is not None
@@ -43,7 +43,7 @@ def test_local_revision(url: URL) -> None:
 
 
 def test_local_not_matching(tmp_path: Path) -> None:
-    """It returns None if the path is not a zip package."""
+    """It returns None if the path is not a zip archive."""
     repository = localzipprovider.provide(asurl(tmp_path))
 
     assert repository is None
@@ -51,12 +51,12 @@ def test_local_not_matching(tmp_path: Path) -> None:
 
 @pytest.fixture
 def zipprovider(store: Store) -> Provider:
-    """Return a zip provider."""
+    """Fixture for a zip provider."""
     return zipproviderfactory(store)
 
 
 def test_remote_happy(zipprovider: Provider, url: URL) -> None:
-    """It fetches a zip package into storage."""
+    """It fetches the package repository into storage."""
     repository = zipprovider.provide(url)
 
     assert repository is not None

--- a/tests/unit/packages/adapters/providers/test_zip.py
+++ b/tests/unit/packages/adapters/providers/test_zip.py
@@ -32,7 +32,7 @@ def test_local_happy(url: URL) -> None:
 
     with repository.get() as package:
         text = (package.path / "marker").read_text()
-        assert text == "Lorem"
+        assert "Lorem" == text
 
 
 def test_local_revision(url: URL) -> None:
@@ -57,7 +57,7 @@ def test_remote_happy(store: Store, url: URL) -> None:
 
     with repository.get() as package:
         text = (package.path / "marker").read_text()
-        assert text == "Lorem"
+        assert "Lorem" == text
 
 
 def test_remote_not_matching(store: Store) -> None:

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -14,7 +14,6 @@ from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.providers import ProviderStore
 from cutty.packages.domain.providers import RemoteProviderFactory
-from cutty.packages.domain.registry import provide
 from cutty.packages.domain.registry import ProviderRegistry
 from tests.fixtures.packages.domain.providers import constprovider
 from tests.fixtures.packages.domain.providers import dictprovider
@@ -36,10 +35,15 @@ pytest_plugins = [
         [nullprovider, Provider("null2")],
     ],
 )
-def test_provide_fail(providers: list[Provider]) -> None:
+def test_provide_fail(providerstore: ProviderStore, providers: list[Provider]) -> None:
     """It raises an exception."""
+    registry = ProviderRegistry(
+        providerstore,
+        factories=[ConstProviderFactory(provider) for provider in providers],
+    )
+
     with pytest.raises(Exception):
-        provide(providers, URL())
+        registry.getrepository("")
 
 
 @pytest.mark.parametrize(
@@ -51,11 +55,17 @@ def test_provide_fail(providers: list[Provider]) -> None:
         [dictprovider({}), dictprovider({"marker": ""}, name="dict2")],
     ],
 )
-def test_provide_pass(providers: list[Provider]) -> None:
+def test_provide_pass(providerstore: ProviderStore, providers: list[Provider]) -> None:
     """It returns a path to the filesystem."""
-    package = provide(providers, URL())
-    assert package.path.is_dir()
-    assert not (package.path / "marker").is_file()
+    registry = ProviderRegistry(
+        providerstore,
+        factories=[ConstProviderFactory(provider) for provider in providers],
+    )
+
+    repository = registry.getrepository("")
+    with repository.get() as package:
+        assert package.path.is_dir()
+        assert not (package.path / "marker").is_file()
 
 
 def test_none(providerstore: ProviderStore, url: URL) -> None:

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -33,7 +33,7 @@ pytest_plugins = [
     [
         [],
         [nullprovider],
-        [nullprovider, nullprovider],
+        [nullprovider, Provider("null2")],
     ],
 )
 def test_provide_fail(providers: list[Provider]) -> None:
@@ -48,7 +48,7 @@ def test_provide_fail(providers: list[Provider]) -> None:
         [dictprovider({})],
         [dictprovider({}), nullprovider],
         [nullprovider, dictprovider({})],
-        [dictprovider({}), dictprovider({"marker": ""})],
+        [dictprovider({}), dictprovider({"marker": ""}, name="dict2")],
     ],
 )
 def test_provide_pass(providers: list[Provider]) -> None:


### PR DESCRIPTION
- 🔨 [packages] Extract optional parameter `name` from `dictprovider`
- ✅ [packages] Use distinct provider names in `provide` tests
- ✅ [packages] Adapt `provide` tests to operate on `ProviderRegistry` instead
- 🔨 [packages] Rename function `{ => _}provide`
- 🔨 [packages] Return `PackageRepository` from `_provide`
- 🔨 [packages] Extract function `Provider.provide` returning `PackageRepository`
- 🔨 [packages] Use `Provider.provide` in `test_providers`
- 🔨 [packages] Rename fixture `repository{ => path}` in `test_disk`
- 🔨 [packages] Use `Provider.provide` in `test_disk`
- 🔨 [packages] Use `Provider.provide` in `test_git`
- 🔨 [packages] Inline variable `url` in `test_git`
- 🔨 [packages] Extract fixture `gitprovider` in `test_git`
- 🔨 [packages] Slide `==` operands
- 🔨 [packages] Reformat test parametrization in `test_git`
- 💡 [packages] Improve docstrings in `test_git`
- 🔨 [packages] Use `Provider.provide` in `test_mercurial`
- 🔨 [packages] Inline variable `url` in `test_mercurial`
- 🔨 [packages] Reformat test parametrization in `test_mercurial`
- 🔨 [packages] Slide `==` operands in `test_mercurial`
- 🔨 [packages] Extract fixture `hgprovider` in `test_mercurial`
- 🔨 [packages] Use `Provider.provide` in `test_zip`
- 🔨 [packages] Inline variable `url` in `test_zip`
- 🔨 [packages] Slide `==` operands in `test_zip`
- 🔨 [packages] Extract fixture `zipprovider` in `test_zip`
- 💡 [packages] Improve docstrings in `test_zip`
- 💡 [packages] Improve docstrings in `test_mercurial`
- 🔨 [packages] Implement method `Provider.provide` in subclasses
- 🔨 [packages] Inline function `__call__` in `@provider` from fixtures
- 🔨 [packages] Remove function `Provider.__call__`
- 🔨 [packages] Inline function `LocalProvider.__call__`
- 🔨 [packages] Inline function `RemoteProvider.__call__`
- 🔨 [packages] Extract function `BaseProvider._loadrepository`
- 🔨 [packages] Inline function `BaseProvider._loadpackage`
