### PR TITLE
🔨 Move `hg update` from `hgfetcher` to mounter

### DIFF
--- a/src/cutty/packages/adapters/fetchers/mercurial.py
+++ b/src/cutty/packages/adapters/fetchers/mercurial.py
@@ -80,6 +80,3 @@ def hgfetcher(
         hg("pull", cwd=destination)
     else:
         hg("clone", "--noupdate", str(url), str(destination))
-
-    options = ["--rev", revision] if revision is not None else []
-    hg("update", *options, cwd=destination)

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -26,10 +26,11 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
     return result.stdout
 
 
-def _defaultmount(path: pathlib.Path, revision: Optional[Revision]) -> Filesystem:
+def mount(path: pathlib.Path, revision: Optional[Revision]) -> Filesystem:
+    """Mount the working directory as a disk filesystem."""
     return DiskFilesystem(path)
 
 
 hgproviderfactory = RemoteProviderFactory(
-    "hg", fetch=[hgfetcher], getrevision=getrevision, mount=_defaultmount
+    "hg", fetch=[hgfetcher], getrevision=getrevision, mount=mount
 )

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from cutty.packages.adapters.fetchers.mercurial import findhg
 from cutty.packages.adapters.fetchers.mercurial import hgfetcher
+from cutty.packages.domain.providers import _defaultmount
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.revisions import Revision
 
@@ -25,5 +26,5 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
 
 
 hgproviderfactory = RemoteProviderFactory(
-    "hg", fetch=[hgfetcher], getrevision=getrevision
+    "hg", fetch=[hgfetcher], getrevision=getrevision, mount=_defaultmount
 )

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -28,6 +28,11 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
 
 def mount(path: pathlib.Path, revision: Optional[Revision]) -> Filesystem:
     """Mount the working directory as a disk filesystem."""
+    hg = findhg()
+
+    options = ["--rev", revision] if revision is not None else []
+    hg("update", *options, cwd=path)
+
     return DiskFilesystem(path)
 
 

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -2,9 +2,10 @@
 import pathlib
 from typing import Optional
 
+from cutty.filesystems.adapters.disk import DiskFilesystem
+from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.packages.adapters.fetchers.mercurial import findhg
 from cutty.packages.adapters.fetchers.mercurial import hgfetcher
-from cutty.packages.domain.providers import _defaultmount
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.revisions import Revision
 
@@ -23,6 +24,10 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
         cwd=path,
     )
     return result.stdout
+
+
+def _defaultmount(path: pathlib.Path, revision: Optional[Revision]) -> Filesystem:
+    return DiskFilesystem(path)
 
 
 hgproviderfactory = RemoteProviderFactory(

--- a/tests/unit/packages/adapters/fetchers/test_mercurial.py
+++ b/tests/unit/packages/adapters/fetchers/test_mercurial.py
@@ -114,9 +114,3 @@ def test_fetch_error(url: URL, hg: Hg, store: Store, skip_on_http_errors: None) 
     """It raises an exception."""
     with pytest.raises(CuttyError):
         hgfetcher(url, store)
-
-
-def test_revision_not_found(url: URL, hg: Hg, store: Store) -> None:
-    """It raises an exception."""
-    with pytest.raises(CuttyError):
-        hgfetcher(url, store, "invalid")

--- a/tests/unit/packages/adapters/fetchers/test_mercurial.py
+++ b/tests/unit/packages/adapters/fetchers/test_mercurial.py
@@ -8,8 +8,6 @@ import pytest
 from yarl import URL
 
 from cutty.errors import CuttyError
-from cutty.filesystems.adapters.disk import DiskFilesystem
-from cutty.filesystems.domain.path import Path
 from cutty.packages.adapters.fetchers.mercurial import Hg
 from cutty.packages.adapters.fetchers.mercurial import hgfetcher
 from cutty.packages.domain.locations import asurl
@@ -42,10 +40,8 @@ def url(sessionrepository: pathlib.Path) -> URL:
 def test_happy(url: URL, store: Store) -> None:
     """It clones the Mercurial repository."""
     destination = hgfetcher(url, store)
-    assert destination is not None
 
-    path = Path("marker", filesystem=DiskFilesystem(destination))
-    assert path.read_text() == "Lorem"
+    assert destination is not None and (destination / ".hg").is_dir()
 
 
 def test_not_matched(store: Store) -> None:
@@ -76,17 +72,19 @@ def test_update(repository: pathlib.Path, hg: Hg, store: Store) -> None:
     # First fetch.
     hgfetcher(asurl(repository), store)
 
-    # Remove the marker file.
+    # Create a commit in the upstream repository.
     hg("rm", "marker", cwd=repository)
     hg("commit", "--message=Remove the marker file", cwd=repository)
+
+    upstreamhead = hg("heads", "--template={node}", cwd=repository).stdout
 
     # Second fetch.
     destination = hgfetcher(asurl(repository), store)
     assert destination is not None
 
-    # Check that the marker file is gone.
-    path = Path("marker", filesystem=DiskFilesystem(destination))
-    assert not (path / "marker").is_file()
+    # Check that upstream and downstream heads are identical.
+    downstreamhead = hg("heads", "--template={node}", cwd=destination).stdout
+    assert upstreamhead == downstreamhead
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -137,3 +137,20 @@ def test_not_matching(hgprovider: Provider) -> None:
     repository = hgprovider.provide(URL("mailto:you@example.com"))
 
     assert repository is None
+
+
+def test_update(hgprovider: Provider, hgrepository: pathlib.Path, hg: Hg) -> None:
+    """It updates the repository from a previous fetch."""
+
+    def fetchrevision(revision: Optional[str]) -> Optional[str]:
+        repository = hgprovider.provide(hgrepository, revision)
+
+        assert repository is not None
+
+        with repository.get(revision) as package:
+            return package.revision
+
+    revision1 = fetchrevision("v1.0")
+    revision2 = fetchrevision(None)
+
+    assert revision1 != revision2

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -8,6 +8,7 @@ from yarl import URL
 
 from cutty.packages.adapters.fetchers.mercurial import Hg
 from cutty.packages.adapters.providers.mercurial import hgproviderfactory
+from cutty.packages.domain.fetchers import FetchMode
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.stores import Store
 
@@ -139,8 +140,10 @@ def test_not_matching(hgprovider: Provider) -> None:
     assert repository is None
 
 
-def test_update(hgprovider: Provider, hgrepository: pathlib.Path, hg: Hg) -> None:
+@pytest.mark.parametrize("fetchmode", [FetchMode.ALWAYS, FetchMode.AUTO])
+def test_update(hgrepository: pathlib.Path, store: Store, fetchmode: FetchMode) -> None:
     """It updates the repository from a previous fetch."""
+    hgprovider = hgproviderfactory(store, fetchmode)
 
     def fetchrevision(revision: Optional[str]) -> Optional[str]:
         repository = hgprovider.provide(hgrepository, revision)

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -6,6 +6,7 @@ from typing import Optional
 import pytest
 from yarl import URL
 
+from cutty.errors import CuttyError
 from cutty.packages.adapters.fetchers.mercurial import Hg
 from cutty.packages.adapters.providers.mercurial import hgproviderfactory
 from cutty.packages.domain.fetchers import FetchMode
@@ -157,3 +158,9 @@ def test_update(hgrepository: pathlib.Path, store: Store, fetchmode: FetchMode) 
     revision2 = fetchrevision(None)
 
     assert revision1 != revision2
+
+
+def test_revision_not_found(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
+    """It raises an exception."""
+    with pytest.raises(CuttyError):
+        hgprovider.provide(hgrepository, "invalid")


### PR DESCRIPTION
- 🔨 [packages] Explicitly pass default mounter for `hgproviderfactory`
- 🔨 [packages] Copy function `_defaultmount` to `providers.mercurial`
- 🔨 [packages] Rename function `{_default => }mount`
- ✅ [packages] Do not assume working directory in `hgfetcher` tests
- ✅ [packages] Add test for `hgprovider` with multiple revisions
- ✅ [packages] Add failing test for `hgprovider` with `FetchMode.AUTO`
- 🐛 [packages] Fix missing `hg update` with fetch=auto
- ✅ [packages] Adapt test for invalid revision replacing `hg{fetcher => provider}`
