### PR TITLE
🔨 Delay filesystem mounting to `PackageRepository.get`

### DIFF
--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -32,7 +32,7 @@ class Package:
 
 @dataclass
 class SinglePackageRepository:
-    """A package repository."""
+    """A package repository with a single package."""
 
     package: Package
 

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -1,6 +1,7 @@
 """Package."""
 from __future__ import annotations
 
+import abc
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Optional
@@ -30,8 +31,17 @@ class Package:
         )
 
 
+class PackageRepository(abc.ABC):
+    """A package repository."""
+
+    @contextmanager
+    @abc.abstractmethod
+    def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
+        """Retrieve the package with the given revision."""
+
+
 @dataclass
-class SinglePackageRepository:
+class SinglePackageRepository(PackageRepository):
     """A package repository with a single package."""
 
     package: Package

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -31,7 +31,7 @@ class Package:
 
 
 @dataclass
-class PackageRepository:
+class SinglePackageRepository:
     """A package repository."""
 
     package: Package

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -19,7 +19,7 @@ from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.matchers import PathMatcher
 from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.package import Package
-from cutty.packages.domain.package import PackageRepository
+from cutty.packages.domain.package import SinglePackageRepository
 from cutty.packages.domain.revisions import Revision
 from cutty.packages.domain.stores import Store
 
@@ -33,7 +33,7 @@ class Provider:
 
     def provide(
         self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[PackageRepository]:
+    ) -> Optional[SinglePackageRepository]:
         """Retrieve the package repository at the given location."""
 
 
@@ -59,7 +59,7 @@ class BaseProvider(Provider):
 
     def _loadrepository(
         self, location: Location, revision: Optional[Revision], path: pathlib.Path
-    ) -> PackageRepository:
+    ) -> SinglePackageRepository:
         filesystem = self.mount(path, revision)
 
         if self.getrevision is not None:
@@ -67,7 +67,7 @@ class BaseProvider(Provider):
 
         package = Package(location.name, Path(filesystem=filesystem), revision)
 
-        return PackageRepository(package)
+        return SinglePackageRepository(package)
 
 
 class LocalProvider(BaseProvider):
@@ -88,7 +88,7 @@ class LocalProvider(BaseProvider):
 
     def provide(
         self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[PackageRepository]:
+    ) -> Optional[SinglePackageRepository]:
         """Retrieve the package repository at the given location."""
         try:
             path = location if isinstance(location, pathlib.Path) else aspath(location)
@@ -133,7 +133,7 @@ class RemoteProvider(BaseProvider):
 
     def provide(
         self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[PackageRepository]:
+    ) -> Optional[SinglePackageRepository]:
         """Retrieve the package repository at the given location."""
         if isinstance(location, URL):
             url = location

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -19,6 +19,7 @@ from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.matchers import PathMatcher
 from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.package import Package
+from cutty.packages.domain.package import PackageRepository
 from cutty.packages.domain.package import SinglePackageRepository
 from cutty.packages.domain.revisions import Revision
 from cutty.packages.domain.stores import Store
@@ -33,7 +34,7 @@ class Provider:
 
     def provide(
         self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[SinglePackageRepository]:
+    ) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
 
 
@@ -59,7 +60,7 @@ class BaseProvider(Provider):
 
     def _loadrepository(
         self, location: Location, revision: Optional[Revision], path: pathlib.Path
-    ) -> SinglePackageRepository:
+    ) -> PackageRepository:
         filesystem = self.mount(path, revision)
 
         if self.getrevision is not None:
@@ -88,7 +89,7 @@ class LocalProvider(BaseProvider):
 
     def provide(
         self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[SinglePackageRepository]:
+    ) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
         try:
             path = location if isinstance(location, pathlib.Path) else aspath(location)
@@ -133,7 +134,7 @@ class RemoteProvider(BaseProvider):
 
     def provide(
         self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[SinglePackageRepository]:
+    ) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
         if isinstance(location, URL):
             url = location

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -10,7 +10,7 @@ from cutty.errors import CuttyError
 from cutty.packages.domain.fetchers import FetchMode
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.locations import parselocation
-from cutty.packages.domain.package import PackageRepository
+from cutty.packages.domain.package import SinglePackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.providers import ProviderFactory
 from cutty.packages.domain.providers import ProviderName
@@ -29,7 +29,7 @@ def _provide(
     providers: Iterable[Provider],
     location: Location,
     revision: Optional[Revision] = None,
-) -> PackageRepository:
+) -> SinglePackageRepository:
     """Provide the package repository located at the given URL."""
     for provider in providers:
         if repository := provider.provide(location, revision):
@@ -57,7 +57,7 @@ class ProviderRegistry:
         rawlocation: str,
         revision: Optional[Revision] = None,
         fetchmode: FetchMode = FetchMode.ALWAYS,
-    ) -> PackageRepository:
+    ) -> SinglePackageRepository:
         """Return the package repository located at the given URL."""
         location = parselocation(rawlocation)
 

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -10,7 +10,7 @@ from cutty.errors import CuttyError
 from cutty.packages.domain.fetchers import FetchMode
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.locations import parselocation
-from cutty.packages.domain.package import SinglePackageRepository
+from cutty.packages.domain.package import PackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.providers import ProviderFactory
 from cutty.packages.domain.providers import ProviderName
@@ -29,7 +29,7 @@ def _provide(
     providers: Iterable[Provider],
     location: Location,
     revision: Optional[Revision] = None,
-) -> SinglePackageRepository:
+) -> PackageRepository:
     """Provide the package repository located at the given URL."""
     for provider in providers:
         if repository := provider.provide(location, revision):
@@ -57,7 +57,7 @@ class ProviderRegistry:
         rawlocation: str,
         revision: Optional[Revision] = None,
         fetchmode: FetchMode = FetchMode.ALWAYS,
-    ) -> SinglePackageRepository:
+    ) -> PackageRepository:
         """Return the package repository located at the given URL."""
         location = parselocation(rawlocation)
 

--- a/tests/fixtures/packages/domain/providers.py
+++ b/tests/fixtures/packages/domain/providers.py
@@ -7,6 +7,7 @@ from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.package import Package
+from cutty.packages.domain.package import PackageRepository
 from cutty.packages.domain.package import SinglePackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.revisions import Revision
@@ -28,7 +29,7 @@ def provider(name: str) -> Callable[[ProviderFunction], Provider]:
 
             def provide(
                 self, location: Location, revision: Optional[Revision] = None
-            ) -> Optional[SinglePackageRepository]:
+            ) -> Optional[PackageRepository]:
                 """Retrieve the package repository at the given location."""
                 if package := function(location, revision):
                     return SinglePackageRepository(package)

--- a/tests/fixtures/packages/domain/providers.py
+++ b/tests/fixtures/packages/domain/providers.py
@@ -7,7 +7,7 @@ from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.package import Package
-from cutty.packages.domain.package import PackageRepository
+from cutty.packages.domain.package import SinglePackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.revisions import Revision
 
@@ -28,10 +28,10 @@ def provider(name: str) -> Callable[[ProviderFunction], Provider]:
 
             def provide(
                 self, location: Location, revision: Optional[Revision] = None
-            ) -> Optional[PackageRepository]:
+            ) -> Optional[SinglePackageRepository]:
                 """Retrieve the package repository at the given location."""
                 if package := function(location, revision):
-                    return PackageRepository(package)
+                    return SinglePackageRepository(package)
                 return None
 
         return _Provider()

--- a/tests/unit/packages/adapters/providers/test_disk.py
+++ b/tests/unit/packages/adapters/providers/test_disk.py
@@ -31,4 +31,6 @@ def test_revision(repositorypath: Path) -> None:
     """It raises an exception when passed a revision."""
     url = asurl(repositorypath)
     with pytest.raises(Exception):
-        diskprovider.provide(url, "v1.0")
+        if repository := diskprovider.provide(url, "v1.0"):
+            with repository.get("v1.0"):
+                pass

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -61,7 +61,9 @@ def test_local_not_matching(tmp_path: pathlib.Path) -> None:
 def test_local_invalid_revision(url: URL) -> None:
     """It raises an exception if the revision is invalid."""
     with pytest.raises(CuttyError):
-        localgitprovider.provide(url, "invalid")
+        if repository := localgitprovider.provide(url, "invalid"):
+            with repository.get("invalid"):
+                pass
 
 
 def test_local_revision_tag(url: URL) -> None:

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -163,4 +163,6 @@ def test_update(hgrepository: pathlib.Path, store: Store, fetchmode: FetchMode) 
 def test_revision_not_found(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     """It raises an exception."""
     with pytest.raises(CuttyError):
-        hgprovider.provide(hgrepository, "invalid")
+        if repository := hgprovider.provide(hgrepository, "invalid"):
+            with repository.get("invalid"):
+                pass

--- a/tests/unit/packages/adapters/providers/test_zip.py
+++ b/tests/unit/packages/adapters/providers/test_zip.py
@@ -39,7 +39,9 @@ def test_local_happy(url: URL) -> None:
 def test_local_revision(url: URL) -> None:
     """It raises an exception when passed a revision."""
     with pytest.raises(Exception):
-        localzipprovider.provide(url, "v1.0")
+        if repository := localzipprovider.provide(url, "v1.0"):
+            with repository.get("v1.0"):
+                pass
 
 
 def test_local_not_matching(tmp_path: Path) -> None:

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -71,7 +71,9 @@ def test_localprovider_revision(tmp_path: pathlib.Path, diskmounter: Mounter) ->
     provider = LocalProvider(match=lambda path: True, mount=diskmounter)
 
     with pytest.raises(Exception):
-        provider.provide(url, "v1.0.0")
+        if repository := provider.provide(url, "v1.0.0"):
+            with repository.get("v1.0.0"):
+                pass
 
 
 def test_localprovider_package_revision(

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -178,7 +178,7 @@ def test_remoteproviderfactory_mounter(
 
     assert repository is not None
 
-    with repository.get() as package:
+    with repository.get(revision) as package:
         assert (package.path / "marker").read_text() == "Lorem"
 
 

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -104,7 +104,7 @@ def test_with_path(
     registry = ProviderRegistry(providerstore, [providerfactory])
     repository = registry.getrepository(str(directory))
 
-    with repository.get(str(directory)) as package:
+    with repository.get() as package:
         [entry] = package.path.iterdir()
 
     assert entry.name == "marker"


### PR DESCRIPTION
- 🔨 [packages] Rename class `{ => Single}PackageRepository`
- 💡 [packages] Improve docstring for `SinglePackageRepository`
- 🔨 [packages] Extract interface `PackageRepository`
- 🔨 [packages] Replace `SinglePackageRepository` with `PackageRepository` in function signatures
- 🔨 [packages] Implement `PackageRepository` in `_loadrepository` mounting in `get`
- ✅ [packages] Adapt tests for invalid revisions
- ✅ [packages] Fix missing revision in `repository.get` in `test_providers`
- ✅ [packages] Fix bogus revision in `repository.get` in `test_registry`
- 🔨 [packages] Extract class `DefaultPackageRepository` from `_loadrepository`
