### PR TITLE
🔨 Do not pass revision to `Provider.provide` and `ProviderRegistry.getrepository`

### DIFF
--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -88,7 +88,7 @@ class BaseProvider(Provider):
         self.getrevision = getrevision
 
     def _loadrepository(
-        self, location: Location, revision: Optional[Revision], path: pathlib.Path
+        self, location: Location, path: pathlib.Path
     ) -> PackageRepository:
         return DefaultPackageRepository(
             location.name, path, mount=self.mount, getrevision=self.getrevision
@@ -121,7 +121,7 @@ class LocalProvider(BaseProvider):
             return None
 
         if path.exists() and self.match(path):
-            return self._loadrepository(location, revision, path)
+            return self._loadrepository(location, path)
 
         return None
 
@@ -170,7 +170,7 @@ class RemoteProvider(BaseProvider):
         if self.match is None or self.match(url):
             for fetcher in self.fetch:
                 if path := fetcher(url, self.store, self.fetchmode):
-                    return self._loadrepository(location, revision, path)
+                    return self._loadrepository(location, path)
 
         return None
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -33,13 +33,7 @@ class Provider:
         """Initialize."""
         self.name = name
 
-    def provide(
-        self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[PackageRepository]:
-        """Retrieve the package repository at the given location."""
-        return self.provide2(location)
-
-    def provide2(self, location: Location) -> Optional[PackageRepository]:
+    def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
 
 
@@ -115,7 +109,7 @@ class LocalProvider(BaseProvider):
         super().__init__(name, mount=mount, getrevision=getrevision)
         self.match = match
 
-    def provide2(self, location: Location) -> Optional[PackageRepository]:
+    def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
         try:
             path = location if isinstance(location, pathlib.Path) else aspath(location)
@@ -158,7 +152,7 @@ class RemoteProvider(BaseProvider):
         self.store = store
         self.fetchmode = fetchmode
 
-    def provide2(self, location: Location) -> Optional[PackageRepository]:
+    def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
         if isinstance(location, URL):
             url = location

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -37,6 +37,10 @@ class Provider:
         self, location: Location, revision: Optional[Revision] = None
     ) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
+        return self.provide2(location)
+
+    def provide2(self, location: Location) -> Optional[PackageRepository]:
+        """Retrieve the package repository at the given location."""
 
 
 GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]
@@ -111,9 +115,7 @@ class LocalProvider(BaseProvider):
         super().__init__(name, mount=mount, getrevision=getrevision)
         self.match = match
 
-    def provide(
-        self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[PackageRepository]:
+    def provide2(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
         try:
             path = location if isinstance(location, pathlib.Path) else aspath(location)
@@ -156,9 +158,7 @@ class RemoteProvider(BaseProvider):
         self.store = store
         self.fetchmode = fetchmode
 
-    def provide(
-        self, location: Location, revision: Optional[Revision] = None
-    ) -> Optional[PackageRepository]:
+    def provide2(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
         if isinstance(location, URL):
             url = location

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -15,7 +15,6 @@ from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.providers import ProviderFactory
 from cutty.packages.domain.providers import ProviderName
 from cutty.packages.domain.providers import ProviderStore
-from cutty.packages.domain.revisions import Revision
 
 
 @dataclass
@@ -49,10 +48,7 @@ class ProviderRegistry:
         }
 
     def getrepository(
-        self,
-        rawlocation: str,
-        revision: Optional[Revision] = None,
-        fetchmode: FetchMode = FetchMode.ALWAYS,
+        self, rawlocation: str, fetchmode: FetchMode = FetchMode.ALWAYS
     ) -> PackageRepository:
         """Return the package repository located at the given URL."""
         location = parselocation(rawlocation)

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -32,7 +32,7 @@ def _provide(
 ) -> PackageRepository:
     """Provide the package repository located at the given URL."""
     for provider in providers:
-        if repository := provider.provide(location, revision):
+        if repository := provider.provide(location):
             return repository
 
     raise UnknownLocationError(location)

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -25,11 +25,7 @@ class UnknownLocationError(CuttyError):
     location: Location
 
 
-def _provide(
-    providers: Iterable[Provider],
-    location: Location,
-    revision: Optional[Revision] = None,
-) -> PackageRepository:
+def _provide(providers: Iterable[Provider], location: Location) -> PackageRepository:
     """Provide the package repository located at the given URL."""
     for provider in providers:
         if repository := provider.provide(location):
@@ -63,7 +59,7 @@ class ProviderRegistry:
 
         providername, location = self._extractprovidername(location)
         providers = self._createproviders(fetchmode, providername)
-        return _provide(providers, location, revision)
+        return _provide(providers, location)
 
     def _extractprovidername(
         self, location: Location

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -42,7 +42,7 @@ class Template:
         """Load a project template."""
         cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
         packageprovider = getdefaultpackageprovider(cachedir)
-        repository = packageprovider.getrepository(template, revision=revision)
+        repository = packageprovider.getrepository(template)
 
         with repository.get(revision) as package:
             if directory is not None:

--- a/tests/fixtures/packages/domain/providers.py
+++ b/tests/fixtures/packages/domain/providers.py
@@ -1,8 +1,10 @@
 """Fixtures for cutty.packages.domain.providers."""
 from collections.abc import Callable
+from collections.abc import Iterator
 from typing import Any
 from typing import Optional
 
+from cutty.compat.contextlib import contextmanager
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.packages.domain.locations import Location
@@ -16,7 +18,7 @@ from cutty.packages.domain.revisions import Revision
 pytest_plugins = ["tests.fixtures.packages.domain.stores"]
 
 
-ProviderFunction = Callable[[Location, Optional[Revision]], Optional[Package]]
+ProviderFunction = Callable[[Location], Optional[PackageRepository]]
 
 
 def provider(name: str) -> Callable[[ProviderFunction], Provider]:
@@ -27,13 +29,9 @@ def provider(name: str) -> Callable[[ProviderFunction], Provider]:
             def __init__(self) -> None:
                 super().__init__(name)
 
-            def provide(
-                self, location: Location, revision: Optional[Revision] = None
-            ) -> Optional[PackageRepository]:
+            def provide2(self, location: Location) -> Optional[PackageRepository]:
                 """Retrieve the package repository at the given location."""
-                if package := function(location, revision):
-                    return SinglePackageRepository(package)
-                return None
+                return function(location)
 
         return _Provider()
 
@@ -48,8 +46,8 @@ def constprovider(name: str, package: Package) -> Provider:
     """Provider that returns the same package always."""
 
     @provider(name)
-    def _(location: Location, revision: Optional[Revision]) -> Optional[Package]:
-        return package
+    def _(location: Location) -> Optional[PackageRepository]:
+        return SinglePackageRepository(package)
 
     return _
 
@@ -60,9 +58,14 @@ def dictprovider(
     """Provider that matches every URL with a package."""
 
     @provider(name)
-    def _(location: Location, revision: Optional[Revision]) -> Optional[Package]:
-        filesystem = DictFilesystem(mapping or {})
-        path = Path(filesystem=filesystem)
-        return Package(location.name, path, revision)
+    def _(location: Location) -> Optional[PackageRepository]:
+        class _PackageRepository(PackageRepository):
+            @contextmanager
+            def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
+                filesystem = DictFilesystem(mapping or {})
+                path = Path(filesystem=filesystem)
+                yield Package(location.name, path, revision)
+
+        return _PackageRepository()
 
     return _

--- a/tests/fixtures/packages/domain/providers.py
+++ b/tests/fixtures/packages/domain/providers.py
@@ -29,7 +29,7 @@ def provider(name: str) -> Callable[[ProviderFunction], Provider]:
             def __init__(self) -> None:
                 super().__init__(name)
 
-            def provide2(self, location: Location) -> Optional[PackageRepository]:
+            def provide(self, location: Location) -> Optional[PackageRepository]:
                 """Retrieve the package repository at the given location."""
                 return function(location)
 

--- a/tests/unit/packages/adapters/providers/test_disk.py
+++ b/tests/unit/packages/adapters/providers/test_disk.py
@@ -31,6 +31,6 @@ def test_revision(repositorypath: Path) -> None:
     """It raises an exception when passed a revision."""
     url = asurl(repositorypath)
     with pytest.raises(Exception):
-        if repository := diskprovider.provide(url, "v1.0"):
+        if repository := diskprovider.provide(url):
             with repository.get("v1.0"):
                 pass

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -41,7 +41,7 @@ def url(tmp_path: pathlib.Path) -> URL:
 )
 def test_local_happy(url: URL, revision: Optional[str], expected: str) -> None:
     """It provides a package from a local directory."""
-    repository = localgitprovider.provide(url, revision)
+    repository = localgitprovider.provide(url)
 
     assert repository is not None
 
@@ -61,14 +61,14 @@ def test_local_not_matching(tmp_path: pathlib.Path) -> None:
 def test_local_invalid_revision(url: URL) -> None:
     """It raises an exception if the revision is invalid."""
     with pytest.raises(CuttyError):
-        if repository := localgitprovider.provide(url, "invalid"):
+        if repository := localgitprovider.provide(url):
             with repository.get("invalid"):
                 pass
 
 
 def test_local_revision_tag(url: URL) -> None:
     """It retrieves the tag name as the package revision."""
-    repository = localgitprovider.provide(url, "HEAD^")
+    repository = localgitprovider.provide(url)
 
     assert repository is not None
 
@@ -107,7 +107,7 @@ def test_remote_happy(
     gitprovider: Provider, url: URL, revision: Optional[str], expected: str
 ) -> None:
     """It fetches a git repository into storage."""
-    repository = gitprovider.provide(url, revision)
+    repository = gitprovider.provide(url)
 
     assert repository is not None
 
@@ -118,7 +118,7 @@ def test_remote_happy(
 
 def test_remote_revision_tag(gitprovider: Provider, url: URL) -> None:
     """It retrieves the tag name as the package revision."""
-    repository = gitprovider.provide(url, "HEAD^")
+    repository = gitprovider.provide(url)
 
     assert repository is not None
 

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -60,7 +60,7 @@ def test_happy(
     expected: str,
 ) -> None:
     """It fetches a hg repository into storage."""
-    repository = hgprovider.provide(hgrepository, revision)
+    repository = hgprovider.provide(hgrepository)
 
     assert repository is not None
 
@@ -86,7 +86,7 @@ def test_revision_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> No
 
 def test_revision_tag(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     """It retrieves the tag name as the package revision."""
-    repository = hgprovider.provide(hgrepository, "tip~2")
+    repository = hgprovider.provide(hgrepository)
 
     assert repository is not None
 
@@ -126,7 +126,7 @@ def test_revision_multiple_tags(
     hg("tag", "--rev=0", "tag1", cwd=path)
     hg("tag", "--rev=0", "tag2", cwd=path)
 
-    repository = hgprovider.provide(path, "tip~2")
+    repository = hgprovider.provide(path)
 
     assert repository is not None
 
@@ -147,7 +147,7 @@ def test_update(hgrepository: pathlib.Path, store: Store, fetchmode: FetchMode) 
     hgprovider = hgproviderfactory(store, fetchmode)
 
     def fetchrevision(revision: Optional[str]) -> Optional[str]:
-        repository = hgprovider.provide(hgrepository, revision)
+        repository = hgprovider.provide(hgrepository)
 
         assert repository is not None
 
@@ -163,6 +163,6 @@ def test_update(hgrepository: pathlib.Path, store: Store, fetchmode: FetchMode) 
 def test_revision_not_found(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     """It raises an exception."""
     with pytest.raises(CuttyError):
-        if repository := hgprovider.provide(hgrepository, "invalid"):
+        if repository := hgprovider.provide(hgrepository):
             with repository.get("invalid"):
                 pass

--- a/tests/unit/packages/adapters/providers/test_zip.py
+++ b/tests/unit/packages/adapters/providers/test_zip.py
@@ -39,7 +39,7 @@ def test_local_happy(url: URL) -> None:
 def test_local_revision(url: URL) -> None:
     """It raises an exception when passed a revision."""
     with pytest.raises(Exception):
-        if repository := localzipprovider.provide(url, "v1.0"):
+        if repository := localzipprovider.provide(url):
             with repository.get("v1.0"):
                 pass
 

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -71,7 +71,7 @@ def test_localprovider_revision(tmp_path: pathlib.Path, diskmounter: Mounter) ->
     provider = LocalProvider(match=lambda path: True, mount=diskmounter)
 
     with pytest.raises(Exception):
-        if repository := provider.provide(url, "v1.0.0"):
+        if repository := provider.provide(url):
             with repository.get("v1.0.0"):
                 pass
 
@@ -174,7 +174,7 @@ def test_remoteproviderfactory_mounter(
 
     providerfactory = RemoteProviderFactory(fetch=[emptyfetcher], mount=jsonmounter)
     provider = providerfactory(store)
-    repository = provider.provide(url, revision)
+    repository = provider.provide(url)
 
     assert repository is not None
 


### PR DESCRIPTION
- 🔨 [packages] Remove parameter `revision` from `_loadrepository`
- 🔨 [packages] Add function `Provider.provide2` without `revision` parameter
- 🔨 [packages] Do not pass `revision` to `Provider.provide`
- 🔨 [packages] Remove parameter `revision` from `_provide`
- 🔨 [packages] Remove parameter `revision` from `Provider.provide`
- 🔨 [packages] Remove parameter `revision` from `ProviderRegistry.getrepository`
