### PR TITLE
🔨 [packages] Use `hg archive` to mount Mercurial repository revisions

### DIFF
--- a/src/cutty/packages/adapters/fetchers/mercurial.py
+++ b/src/cutty/packages/adapters/fetchers/mercurial.py
@@ -76,4 +76,4 @@ def hgfetcher(url: URL, destination: pathlib.Path) -> None:
     if destination.exists():
         hg("pull", cwd=destination)
     else:
-        hg("clone", "--noupdate", str(url), str(destination))
+        hg("clone", str(url), str(destination))

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -54,7 +54,11 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
         revision = "HEAD"
 
     repository = pygit2.Repository(path)
-    commit = repository.revparse_single(revision).peel(pygit2.Commit)
+
+    try:
+        commit = repository.revparse_single(revision).peel(pygit2.Commit)
+    except KeyError:
+        raise RevisionNotFoundError(revision)
 
     try:
         revision = repository.describe(

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -40,10 +40,7 @@ def mount(path: pathlib.Path, revision: Optional[Revision]) -> Iterator[GitFiles
     revision. If ``revision`` is None, HEAD is used instead.
     """
     if revision is not None:
-        try:
-            yield GitFilesystem(path, revision)
-        except KeyError:
-            raise RevisionNotFoundError(revision)
+        yield GitFilesystem(path, revision)
     else:
         yield GitFilesystem(path)
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -60,11 +60,13 @@ class DefaultPackageRepository(PackageRepository):
     @contextmanager
     def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
         """Retrieve the package with the given revision."""
-        with self.mount(self.path, revision) as filesystem:
-            if self.getrevision is not None:
-                revision = self.getrevision(self.path, revision)
+        if self.getrevision is not None:
+            resolved_revision = self.getrevision(self.path, revision)
+        else:
+            resolved_revision = revision
 
-            yield Package(self.name, Path(filesystem=filesystem), revision)
+        with self.mount(self.path, revision) as filesystem:
+            yield Package(self.name, Path(filesystem=filesystem), resolved_revision)
 
 
 class BaseProvider(Provider):


### PR DESCRIPTION
- 🔨 [packages] Use `hg archive` to mount Mercurial repository revisions
- 🔨 [packages] Clone Mercurial repositories with working directory
- ✨ [packages] Raise `RevisionNotFound` in `getrevision` in git providers
- 🔨 [packages] Do not handle unknown revisions in `providers.git.mount`
- 🔨 [packages] Resolve revision before mounting the package filesystem
