### PR TITLE
🔨 [packages] Refactor `ProviderRegistry` for readability`

### DIFF
--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -34,9 +34,7 @@ class ProviderRegistry:
     ) -> None:
         """Initialize."""
         self.store = store
-        self.registry = {
-            providerfactory.name: providerfactory for providerfactory in factories
-        }
+        self.registry = {factory.name: factory for factory in factories}
 
     def getrepository(
         self, rawlocation: str, fetchmode: FetchMode = FetchMode.ALWAYS

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -28,9 +28,7 @@ class ProviderRegistry:
     """The provider registry retrieves packages using registered providers."""
 
     def __init__(
-        self,
-        store: ProviderStore,
-        factories: Iterable[ProviderFactory],
+        self, store: ProviderStore, factories: Iterable[ProviderFactory]
     ) -> None:
         """Initialize."""
         self.store = store

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -79,11 +79,11 @@ class ProviderRegistry:
     ) -> Iterator[Provider]:
         """Create providers."""
         if name is not None:
-            providerfactory = self.registry[name]
-            yield self._createprovider(providerfactory, fetchmode)
+            factory = self.registry[name]
+            yield self._createprovider(factory, fetchmode)
         else:
-            for providerfactory in self.registry.values():
-                yield self._createprovider(providerfactory, fetchmode)
+            for factory in self.registry.values():
+                yield self._createprovider(factory, fetchmode)
 
     def _createprovider(
         self,

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -41,7 +41,7 @@ class ProviderRegistry:
     ) -> PackageRepository:
         """Return the package repository located at the given URL."""
         location = parselocation(rawlocation)
-        name, location = self._extractprovidername(location)
+        name, location = self._extractname(location)
         providers = self._createproviders(fetchmode, name)
 
         for provider in providers:
@@ -50,7 +50,7 @@ class ProviderRegistry:
 
         raise UnknownLocationError(location)
 
-    def _extractprovidername(
+    def _extractname(
         self, location: Location
     ) -> tuple[Optional[ProviderName], Location]:
         """Split off the provider name from the URL scheme, if any."""

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -81,18 +81,18 @@ class ProviderRegistry:
         return factory(store, fetchmode)
 
 
-def _withscheme(location: URL, scheme: str) -> URL:
-    if location.raw_host is not None:
-        return location.with_scheme(scheme)
+def _withscheme(url: URL, scheme: str) -> URL:
+    if url.raw_host is not None:
+        return url.with_scheme(scheme)
 
     # yarl does not allow scheme replacement in URLs without host
     # https://github.com/aio-libs/yarl/issues/280
-    location = URL.build(
+    url = URL.build(
         scheme=scheme,
-        authority=location.raw_authority,
-        path=location.raw_path,
-        query_string=location.raw_query_string,
-        fragment=location.raw_fragment,
+        authority=url.raw_authority,
+        path=url.raw_path,
+        query_string=url.raw_query_string,
+        fragment=url.raw_fragment,
         encoded=True,
     )
-    return location
+    return url

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -82,16 +82,17 @@ class ProviderRegistry:
 
 
 def _withscheme(location: URL, scheme: str) -> URL:
-    if location.raw_host is None:
-        # yarl does not allow scheme replacement in URLs without host
-        # https://github.com/aio-libs/yarl/issues/280
-        location = URL.build(
-            scheme=scheme,
-            authority=location.raw_authority,
-            path=location.raw_path,
-            query_string=location.raw_query_string,
-            fragment=location.raw_fragment,
-            encoded=True,
-        )
-        return location
-    return location.with_scheme(scheme)
+    if location.raw_host is not None:
+        return location.with_scheme(scheme)
+
+    # yarl does not allow scheme replacement in URLs without host
+    # https://github.com/aio-libs/yarl/issues/280
+    location = URL.build(
+        scheme=scheme,
+        authority=location.raw_authority,
+        path=location.raw_path,
+        query_string=location.raw_query_string,
+        fragment=location.raw_fragment,
+        encoded=True,
+    )
+    return location

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -75,13 +75,11 @@ class ProviderRegistry:
         return None, location
 
     def _createproviders(
-        self,
-        fetchmode: FetchMode,
-        providername: Optional[ProviderName],
+        self, fetchmode: FetchMode, name: Optional[ProviderName]
     ) -> Iterator[Provider]:
         """Create providers."""
-        if providername is not None:
-            providerfactory = self.registry[providername]
+        if name is not None:
+            providerfactory = self.registry[name]
             yield self._createprovider(providerfactory, fetchmode)
         else:
             for providerfactory in self.registry.values():

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -41,8 +41,8 @@ class ProviderRegistry:
     ) -> PackageRepository:
         """Return the package repository located at the given URL."""
         location = parselocation(rawlocation)
-        providername, location = self._extractprovidername(location)
-        providers = self._createproviders(fetchmode, providername)
+        name, location = self._extractprovidername(location)
+        providers = self._createproviders(fetchmode, name)
 
         for provider in providers:
             if repository := provider.provide(location):
@@ -55,9 +55,9 @@ class ProviderRegistry:
     ) -> tuple[Optional[ProviderName], Location]:
         """Split off the provider name from the URL scheme, if any."""
         if isinstance(location, URL):
-            providername, _, scheme = location.scheme.rpartition("+")
+            name, _, scheme = location.scheme.rpartition("+")
 
-            if providername and providername in self.registry:
+            if name and name in self.registry:
                 if location.raw_host is None:
                     # yarl does not allow scheme replacement in URLs without host
                     # https://github.com/aio-libs/yarl/issues/280
@@ -69,8 +69,8 @@ class ProviderRegistry:
                         fragment=location.raw_fragment,
                         encoded=True,
                     )
-                    return providername, location
-                return providername, location.with_scheme(scheme)
+                    return name, location
+                return name, location.with_scheme(scheme)
 
         return None, location
 

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -86,10 +86,8 @@ class ProviderRegistry:
                 yield self._createprovider(factory, fetchmode)
 
     def _createprovider(
-        self,
-        providerfactory: ProviderFactory,
-        fetchmode: FetchMode,
+        self, factory: ProviderFactory, fetchmode: FetchMode
     ) -> Provider:
         """Create a provider."""
-        store = self.store(providerfactory.name)
-        return providerfactory(store, fetchmode)
+        store = self.store(factory.name)
+        return factory(store, fetchmode)

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -58,19 +58,7 @@ class ProviderRegistry:
             name, _, scheme = location.scheme.rpartition("+")
 
             if name and name in self.registry:
-                if location.raw_host is None:
-                    # yarl does not allow scheme replacement in URLs without host
-                    # https://github.com/aio-libs/yarl/issues/280
-                    location = URL.build(
-                        scheme=scheme,
-                        authority=location.raw_authority,
-                        path=location.raw_path,
-                        query_string=location.raw_query_string,
-                        fragment=location.raw_fragment,
-                        encoded=True,
-                    )
-                    return name, location
-                return name, location.with_scheme(scheme)
+                return name, _withscheme(location, scheme)
 
         return None, location
 
@@ -91,3 +79,19 @@ class ProviderRegistry:
         """Create a provider."""
         store = self.store(factory.name)
         return factory(store, fetchmode)
+
+
+def _withscheme(location: URL, scheme: str) -> URL:
+    if location.raw_host is None:
+        # yarl does not allow scheme replacement in URLs without host
+        # https://github.com/aio-libs/yarl/issues/280
+        location = URL.build(
+            scheme=scheme,
+            authority=location.raw_authority,
+            path=location.raw_path,
+            query_string=location.raw_query_string,
+            fragment=location.raw_fragment,
+            encoded=True,
+        )
+        return location
+    return location.with_scheme(scheme)

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -24,15 +24,6 @@ class UnknownLocationError(CuttyError):
     location: Location
 
 
-def _provide(providers: Iterable[Provider], location: Location) -> PackageRepository:
-    """Provide the package repository located at the given URL."""
-    for provider in providers:
-        if repository := provider.provide(location):
-            return repository
-
-    raise UnknownLocationError(location)
-
-
 class ProviderRegistry:
     """The provider registry retrieves packages using registered providers."""
 
@@ -52,10 +43,14 @@ class ProviderRegistry:
     ) -> PackageRepository:
         """Return the package repository located at the given URL."""
         location = parselocation(rawlocation)
-
         providername, location = self._extractprovidername(location)
         providers = self._createproviders(fetchmode, providername)
-        return _provide(providers, location)
+
+        for provider in providers:
+            if repository := provider.provide(location):
+                return repository
+
+        raise UnknownLocationError(location)
 
     def _extractprovidername(
         self, location: Location


### PR DESCRIPTION
- 🔨 [packages] Inline function `_provide`
- 🔨 [packages] Rename variable `{provider => }factory`
- 🔨 [packages] Rename variable `{provider => }name`
- 🔨 [packages] Rename parameter `{provider => }name`
- 🔨 [packages] Rename variable `{provider => }factory`
- 🔨 [packages] Rename parameter `{provider => }factory`
- 🔨 [packages] Rename function `ProviderRegistry._extract{provider => }name`
- 🔨 [packages] Extract function `_withscheme`
- 🔨 [packages] Slide branches in `_withscheme`
- 🔨 [packages] Rename parameter `{location => url}` in `_withscheme`
- 🔨 [packages] Reformat parameters in `ProviderRegistry`
