### PR TITLE
🔨 [packages] Minor refactorings

### DIFF
--- a/src/cutty/packages/adapters/storage.py
+++ b/src/cutty/packages/adapters/storage.py
@@ -15,8 +15,8 @@ from typing import Optional
 from yarl import URL
 
 from cutty.packages.adapters.registry import defaultproviderfactories
-from cutty.packages.domain.providers import ProviderStore
 from cutty.packages.domain.registry import ProviderRegistry
+from cutty.packages.domain.registry import ProviderStore
 from cutty.packages.domain.stores import Store
 
 

--- a/src/cutty/packages/adapters/storage.py
+++ b/src/cutty/packages/adapters/storage.py
@@ -15,7 +15,6 @@ from typing import Optional
 from yarl import URL
 
 from cutty.packages.adapters.registry import defaultproviderfactories
-from cutty.packages.domain.providers import ProviderName
 from cutty.packages.domain.providers import ProviderStore
 from cutty.packages.domain.registry import ProviderRegistry
 from cutty.packages.domain.stores import Store
@@ -84,12 +83,12 @@ class PackageStorage:
         self.path.mkdir(parents=True, exist_ok=True)
         self.timer = timer
 
-    def _getrepositorypath(self, url: URL, *, provider: ProviderName) -> pathlib.Path:
+    def _getrepositorypath(self, url: URL, *, provider: str) -> pathlib.Path:
         """Return the path to the package repository."""
         h = hashurl(url)
         return self.path / "repositories" / provider / h[:2] / h[2:]
 
-    def get(self, url: URL, *, provider: ProviderName) -> Optional[StorageRecord]:
+    def get(self, url: URL, *, provider: str) -> Optional[StorageRecord]:
         """Retrieve storage for a package repository."""
         path = self._getrepositorypath(url, provider=provider)
         if not path.exists():
@@ -101,7 +100,7 @@ class PackageStorage:
 
         return record
 
-    def allocate(self, url: URL, *, provider: ProviderName) -> StorageRecord:
+    def allocate(self, url: URL, *, provider: str) -> StorageRecord:
         """Allocate storage for a package repository."""
         path = self._getrepositorypath(url, provider=provider)
         path.mkdir(parents=True)

--- a/src/cutty/packages/domain/locations.py
+++ b/src/cutty/packages/domain/locations.py
@@ -2,6 +2,7 @@
 import os.path
 import pathlib
 import platform
+from typing import Optional
 from typing import Union
 
 from yarl import URL
@@ -96,3 +97,11 @@ def parselocation(location: str) -> Location:
             return url
 
     return path
+
+
+def pathfromlocation(location: Location) -> Optional[pathlib.Path]:
+    """Convert location to filesystem path."""
+    try:
+        return location if isinstance(location, pathlib.Path) else aspath(location)
+    except ValueError:
+        return None

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -38,15 +38,3 @@ class PackageRepository(abc.ABC):
     @abc.abstractmethod
     def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
         """Retrieve the package with the given revision."""
-
-
-@dataclass
-class SinglePackageRepository(PackageRepository):
-    """A package repository with a single package."""
-
-    package: Package
-
-    @contextmanager
-    def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
-        """Retrieve the package with the given revision."""
-        yield self.package

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -13,9 +13,9 @@ from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.filesystems.domain.path import Path
 from cutty.packages.domain.fetchers import Fetcher
-from cutty.packages.domain.locations import aspath
 from cutty.packages.domain.locations import asurl
 from cutty.packages.domain.locations import Location
+from cutty.packages.domain.locations import pathfromlocation
 from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.matchers import PathMatcher
 from cutty.packages.domain.mounters import Mounter
@@ -111,13 +111,9 @@ class LocalProvider(BaseProvider):
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
-        try:
-            path = location if isinstance(location, pathlib.Path) else aspath(location)
-        except ValueError:
-            return None
-
-        if path.exists() and self.match(path):
-            return self._loadrepository(location, path)
+        if path := pathfromlocation(location):
+            if path.exists() and self.match(path):
+                return self._loadrepository(location, path)
 
         return None
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -166,10 +166,6 @@ class RemoteProvider(BaseProvider):
         return None
 
 
-ProviderName = str
-ProviderStore = Callable[[ProviderName], Store]
-
-
 class ProviderFactory(abc.ABC):
     """Provider factory."""
 

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -34,7 +34,7 @@ class ProviderRegistry:
         self.registry = {factory.name: factory for factory in factories}
 
     def getrepository(self, rawlocation: str) -> PackageRepository:
-        """Return the package repository located at the given URL."""
+        """Return the package repository located at the given location."""
         name, location = self._parselocation(rawlocation)
 
         for provider in self._createproviders(name):
@@ -46,7 +46,7 @@ class ProviderRegistry:
     def _parselocation(
         self, rawlocation: str
     ) -> tuple[Optional[ProviderName], Location]:
-        """Split off the provider name from the URL scheme, if any."""
+        """Parse the location and provider name, if any."""
         location = parselocation(rawlocation)
 
         if isinstance(location, URL):

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -37,9 +37,8 @@ class ProviderRegistry:
         """Return the package repository located at the given URL."""
         location = parselocation(rawlocation)
         name, location = self._extractname(location)
-        providers = self._createproviders(name)
 
-        for provider in providers:
+        for provider in self._createproviders(name):
             if repository := provider.provide(location):
                 return repository
 

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -12,7 +12,6 @@ from cutty.packages.domain.locations import parselocation
 from cutty.packages.domain.package import PackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.providers import ProviderFactory
-from cutty.packages.domain.providers import ProviderName
 from cutty.packages.domain.providers import ProviderStore
 
 
@@ -43,9 +42,7 @@ class ProviderRegistry:
 
         raise UnknownLocationError(location)
 
-    def _parselocation(
-        self, rawlocation: str
-    ) -> tuple[Optional[ProviderName], Location]:
+    def _parselocation(self, rawlocation: str) -> tuple[Optional[str], Location]:
         """Parse the location and provider name, if any."""
         location = parselocation(rawlocation)
 
@@ -57,7 +54,7 @@ class ProviderRegistry:
 
         return None, location
 
-    def _createproviders(self, name: Optional[ProviderName]) -> Iterator[Provider]:
+    def _createproviders(self, name: Optional[str]) -> Iterator[Provider]:
         """Create providers."""
         if name is not None:
             factory = self.registry[name]

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -1,4 +1,5 @@
 """The provider registry is the main entry point of cutty.packages."""
+from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -12,7 +13,7 @@ from cutty.packages.domain.locations import parselocation
 from cutty.packages.domain.package import PackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.providers import ProviderFactory
-from cutty.packages.domain.providers import ProviderStore
+from cutty.packages.domain.stores import Store
 
 
 @dataclass
@@ -20,6 +21,10 @@ class UnknownLocationError(CuttyError):
     """The package location could not be processed by any provider."""
 
     location: Location
+
+
+ProviderName = str
+ProviderStore = Callable[[ProviderName], Store]
 
 
 class ProviderRegistry:

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -35,7 +35,7 @@ class ProviderRegistry:
 
     def getrepository(self, rawlocation: str) -> PackageRepository:
         """Return the package repository located at the given URL."""
-        name, location = self._extractname(rawlocation)
+        name, location = self._parselocation(rawlocation)
 
         for provider in self._createproviders(name):
             if repository := provider.provide(location):
@@ -43,7 +43,9 @@ class ProviderRegistry:
 
         raise UnknownLocationError(location)
 
-    def _extractname(self, rawlocation: str) -> tuple[Optional[ProviderName], Location]:
+    def _parselocation(
+        self, rawlocation: str
+    ) -> tuple[Optional[ProviderName], Location]:
         """Split off the provider name from the URL scheme, if any."""
         location = parselocation(rawlocation)
 

--- a/src/cutty/packages/domain/registry.py
+++ b/src/cutty/packages/domain/registry.py
@@ -35,8 +35,7 @@ class ProviderRegistry:
 
     def getrepository(self, rawlocation: str) -> PackageRepository:
         """Return the package repository located at the given URL."""
-        location = parselocation(rawlocation)
-        name, location = self._extractname(location)
+        name, location = self._extractname(rawlocation)
 
         for provider in self._createproviders(name):
             if repository := provider.provide(location):
@@ -44,10 +43,10 @@ class ProviderRegistry:
 
         raise UnknownLocationError(location)
 
-    def _extractname(
-        self, location: Location
-    ) -> tuple[Optional[ProviderName], Location]:
+    def _extractname(self, rawlocation: str) -> tuple[Optional[ProviderName], Location]:
         """Split off the provider name from the URL scheme, if any."""
+        location = parselocation(rawlocation)
+
         if isinstance(location, URL):
             name, _, scheme = location.scheme.rpartition("+")
 

--- a/tests/fixtures/packages/domain/providers.py
+++ b/tests/fixtures/packages/domain/providers.py
@@ -1,6 +1,7 @@
 """Fixtures for cutty.packages.domain.providers."""
 from collections.abc import Callable
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Any
 from typing import Optional
 
@@ -10,7 +11,6 @@ from cutty.filesystems.domain.path import Path
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.package import Package
 from cutty.packages.domain.package import PackageRepository
-from cutty.packages.domain.package import SinglePackageRepository
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.revisions import Revision
 
@@ -40,6 +40,18 @@ def provider(name: str) -> Callable[[ProviderFunction], Provider]:
 
 nullprovider = Provider("null")
 """Provider that matches no location."""
+
+
+@dataclass
+class SinglePackageRepository(PackageRepository):
+    """A package repository with a single package."""
+
+    package: Package
+
+    @contextmanager
+    def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
+        """Retrieve the package with the given revision."""
+        yield self.package
 
 
 def constprovider(name: str, package: Package) -> Provider:

--- a/tests/fixtures/packages/domain/stores.py
+++ b/tests/fixtures/packages/domain/stores.py
@@ -4,7 +4,7 @@ import pathlib
 import pytest
 from yarl import URL
 
-from cutty.packages.domain.providers import ProviderStore
+from cutty.packages.domain.registry import ProviderStore
 from cutty.packages.domain.stores import Store
 
 

--- a/tests/fixtures/packages/domain/stores.py
+++ b/tests/fixtures/packages/domain/stores.py
@@ -4,7 +4,6 @@ import pathlib
 import pytest
 from yarl import URL
 
-from cutty.packages.domain.providers import ProviderName
 from cutty.packages.domain.providers import ProviderStore
 from cutty.packages.domain.stores import Store
 
@@ -25,7 +24,7 @@ def store(tmp_path: pathlib.Path) -> Store:
 def providerstore(store: Store) -> ProviderStore:
     """Fixture for a simple provider store."""
 
-    def _(providername: ProviderName) -> Store:
+    def _(providername: str) -> Store:
         return store
 
     return _

--- a/tests/unit/packages/adapters/test_storage.py
+++ b/tests/unit/packages/adapters/test_storage.py
@@ -10,7 +10,7 @@ from cutty.packages.adapters.storage import getdefaultproviderstore
 from cutty.packages.adapters.storage import hashurl
 from cutty.packages.adapters.storage import PackageStorage
 from cutty.packages.adapters.storage import StorageRecord
-from cutty.packages.domain.providers import ProviderStore
+from cutty.packages.domain.registry import ProviderStore
 
 
 @pytest.fixture

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -12,9 +12,9 @@ from cutty.packages.domain.package import Package
 from cutty.packages.domain.providers import ConstProviderFactory
 from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import Provider
-from cutty.packages.domain.providers import ProviderStore
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.registry import ProviderRegistry
+from cutty.packages.domain.registry import ProviderStore
 from tests.fixtures.packages.domain.providers import constprovider
 from tests.fixtures.packages.domain.providers import dictprovider
 from tests.fixtures.packages.domain.providers import nullprovider


### PR DESCRIPTION
- 🔨 [packages] Extract function `pathfromlocation`
- 🔨 [packages] Move class `SinglePackageRepository` to fixtures
- 🔨 [packages] Inline variable `providers` in `ProviderRegistry.getrepository`
- 🔨 [packages] Move `parselocation` call to `ProviderRegistry._extractname`
- 🔨 [packages] Rename function `ProviderRegistry._{extractname => parselocation}`
- 💡 [packages] Improve docstrings in `ProviderRegistry`
- 🔨 [packages] Inline type alias `ProviderName` in `ProviderRegistry`
- 🔨 [packages] Inline type alias `ProviderName` in `PackageStorage`
- 🔨 [packages] Inline type alias `ProviderName` in `providerstore` fixture
- 🔨 [packages] Move type alias `ProviderStore` to `registry`
