### PR TITLE
✨ [services] Add command `cutty import` to apply individual template changes

### DIFF
--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -3,6 +3,7 @@ from cutty.entrypoints.cli._main import main
 from cutty.entrypoints.cli.cookiecutter import cookiecutter
 from cutty.entrypoints.cli.create import create
 from cutty.entrypoints.cli.errors import fatal
+from cutty.entrypoints.cli.import_ import import_
 from cutty.entrypoints.cli.link import link
 from cutty.entrypoints.cli.update import update
 
@@ -12,5 +13,6 @@ registercommand = main.command()
 for command in [create, update, link, cookiecutter]:
     registercommand(fatal(command))
 
+main.command("import")(import_)
 
 __all__ = ["main"]

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -1,20 +1,15 @@
 """Command-line interface."""
-import click
-
 from cutty.entrypoints.cli._main import main
 from cutty.entrypoints.cli.cookiecutter import cookiecutter
 from cutty.entrypoints.cli.create import create
-from cutty.entrypoints.cli.errors import fatal
 from cutty.entrypoints.cli.import_ import import_
 from cutty.entrypoints.cli.link import link
 from cutty.entrypoints.cli.update import update
 
 
 for command in [create, update, link, cookiecutter]:
-    command2 = click.command()(fatal(command))
-    main.add_command(command2)
+    main.add_command(command)
 
-command2 = click.command("import")(import_)
-main.add_command(command2)
+main.add_command(import_)
 
 __all__ = ["main"]

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -1,4 +1,6 @@
 """Command-line interface."""
+import click
+
 from cutty.entrypoints.cli._main import main
 from cutty.entrypoints.cli.cookiecutter import cookiecutter
 from cutty.entrypoints.cli.create import create
@@ -9,8 +11,10 @@ from cutty.entrypoints.cli.update import update
 
 
 for command in [create, update, link, cookiecutter]:
-    main.command()(fatal(command))
+    command2 = click.command()(fatal(command))
+    main.add_command(command2)
 
-main.command("import")(import_)
+command2 = click.command("import")(import_)
+main.add_command(command2)
 
 __all__ = ["main"]

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -8,10 +8,8 @@ from cutty.entrypoints.cli.link import link
 from cutty.entrypoints.cli.update import update
 
 
-registercommand = main.command()
-
 for command in [create, update, link, cookiecutter]:
-    registercommand(fatal(command))
+    main.command()(fatal(command))
 
 main.command("import")(import_)
 

--- a/src/cutty/entrypoints/cli/__init__.py
+++ b/src/cutty/entrypoints/cli/__init__.py
@@ -7,9 +7,7 @@ from cutty.entrypoints.cli.link import link
 from cutty.entrypoints.cli.update import update
 
 
-for command in [create, update, link, cookiecutter]:
+for command in [create, update, link, cookiecutter, import_]:
     main.add_command(command)
-
-main.add_command(import_)
 
 __all__ = ["main"]

--- a/src/cutty/entrypoints/cli/cookiecutter.py
+++ b/src/cutty/entrypoints/cli/cookiecutter.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import click
 
+from cutty.entrypoints.cli.errors import fatal
 from cutty.filestorage.adapters.disk import FileExistsPolicy
 from cutty.services.cookiecutter import create
 from cutty.templates.domain.bindings import Binding
@@ -42,6 +43,7 @@ def fileexistspolicy(
     )
 
 
+@click.command()
 @click.argument("location", metavar="TEMPLATE")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
@@ -86,6 +88,7 @@ def fileexistspolicy(
     default=False,
     help="Skip the files in the corresponding directories if they already exist.",
 )
+@fatal
 def cookiecutter(
     location: str,
     extra_context: dict[str, str],

--- a/src/cutty/entrypoints/cli/create.py
+++ b/src/cutty/entrypoints/cli/create.py
@@ -5,10 +5,12 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.cookiecutter import extra_context_callback
+from cutty.entrypoints.cli.errors import fatal
 from cutty.services.create import create as service_create
 from cutty.templates.domain.bindings import Binding
 
 
+@click.command()
 @click.argument("template")
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
@@ -45,6 +47,7 @@ from cutty.templates.domain.bindings import Binding
     default=False,
     help="Strip the leading path component from generated files.",
 )
+@fatal
 def create(
     template: str,
     extra_context: dict[str, str],

--- a/src/cutty/entrypoints/cli/import_.py
+++ b/src/cutty/entrypoints/cli/import_.py
@@ -1,10 +1,16 @@
 """Command-line interface for importing changesets into projects."""
+from pathlib import Path
+
 import click
 
 from cutty.entrypoints.cli.errors import fatal
+from cutty.services.update import update
 
 
 @click.command("import")
 @fatal
 def import_() -> None:
     """Import changesets from templates into projects."""
+    update(
+        Path.cwd(), extrabindings=(), interactive=True, revision=None, directory=None
+    )

--- a/src/cutty/entrypoints/cli/import_.py
+++ b/src/cutty/entrypoints/cli/import_.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.errors import fatal
-from cutty.services.update import update
+from cutty.services.import_ import import_ as service
 
 
 @click.command("import")
@@ -17,10 +17,4 @@ from cutty.services.update import update
 @fatal
 def import_(revision: Optional[str]) -> None:
     """Import changesets from templates into projects."""
-    update(
-        Path.cwd(),
-        extrabindings=(),
-        interactive=True,
-        revision=revision,
-        directory=None,
-    )
+    service(Path.cwd(), revision=revision)

--- a/src/cutty/entrypoints/cli/import_.py
+++ b/src/cutty/entrypoints/cli/import_.py
@@ -1,0 +1,5 @@
+"""Command-line interface for importing changesets into projects."""
+
+
+def import_() -> None:
+    """Import changesets from templates into projects."""

--- a/src/cutty/entrypoints/cli/import_.py
+++ b/src/cutty/entrypoints/cli/import_.py
@@ -1,5 +1,6 @@
 """Command-line interface for importing changesets into projects."""
 from pathlib import Path
+from typing import Optional
 
 import click
 
@@ -8,9 +9,18 @@ from cutty.services.update import update
 
 
 @click.command("import")
+@click.option(
+    "--revision",
+    metavar="REV",
+    help="Branch, tag, or commit hash of the template repository.",
+)
 @fatal
-def import_() -> None:
+def import_(revision: Optional[str]) -> None:
     """Import changesets from templates into projects."""
     update(
-        Path.cwd(), extrabindings=(), interactive=True, revision=None, directory=None
+        Path.cwd(),
+        extrabindings=(),
+        interactive=True,
+        revision=revision,
+        directory=None,
     )

--- a/src/cutty/entrypoints/cli/import_.py
+++ b/src/cutty/entrypoints/cli/import_.py
@@ -1,5 +1,10 @@
 """Command-line interface for importing changesets into projects."""
+import click
+
+from cutty.entrypoints.cli.errors import fatal
 
 
+@click.command("import")
+@fatal
 def import_() -> None:
     """Import changesets from templates into projects."""

--- a/src/cutty/entrypoints/cli/link.py
+++ b/src/cutty/entrypoints/cli/link.py
@@ -5,10 +5,12 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.cookiecutter import extra_context_callback
+from cutty.entrypoints.cli.errors import fatal
 from cutty.services.link import link as service_link
 from cutty.templates.domain.bindings import Binding
 
 
+@click.command()
 @click.argument("template", required=False)
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
@@ -40,6 +42,7 @@ from cutty.templates.domain.bindings import Binding
         "cookiecutter.json file."
     ),
 )
+@fatal
 def link(
     template: Optional[str],
     extra_context: dict[str, str],

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -5,11 +5,13 @@ from typing import Optional
 import click
 
 from cutty.entrypoints.cli.cookiecutter import extra_context_callback
+from cutty.entrypoints.cli.errors import fatal
 from cutty.projects.repository import ProjectRepository
 from cutty.services.update import update as service_update
 from cutty.templates.domain.bindings import Binding
 
 
+@click.command()
 @click.argument("extra-context", nargs=-1, callback=extra_context_callback)
 @click.option(
     "--non-interactive",
@@ -53,6 +55,7 @@ from cutty.templates.domain.bindings import Binding
     default=False,
     help="Abort the current update.",
 )
+@fatal
 def update(
     extra_context: dict[str, str],
     non_interactive: bool,

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -2,15 +2,40 @@
 from pathlib import Path
 from typing import Optional
 
-from cutty.services.update import update
+from cutty.projects.build import buildproject
+from cutty.projects.config import ProjectConfig
+from cutty.projects.config import readprojectconfigfile
+from cutty.projects.messages import updatecommitmessage
+from cutty.projects.repository import ProjectRepository
 
 
 def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     """Import changes from a template into a project."""
-    update(
-        projectdir,
-        extrabindings=(),
-        interactive=True,
-        revision=revision,
-        directory=None,
+    config1 = readprojectconfigfile(projectdir)
+
+    config2 = ProjectConfig(
+        config1.template,
+        config1.bindings,
+        revision,
+        config1.directory,
     )
+
+    repository = ProjectRepository(projectdir)
+
+    parent = buildproject(
+        repository,
+        config1,
+        interactive=True,
+        commitmessage=updatecommitmessage,
+    )
+
+    commit = buildproject(
+        repository,
+        config2,
+        interactive=True,
+        commitmessage=updatecommitmessage,
+        parent=parent,
+    )
+
+    if commit != parent:
+        repository.import_(commit)

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -41,7 +41,7 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     """Import changes from a template into a project."""
     config1 = replace(
         readprojectconfigfile(projectdir),
-        revision="HEAD^" if revision is None else f"{revision}^",
+        revision="HEAD^" if revision is None else f"{revision}^",  # FIXME: git-specific
     )
 
     config2 = ProjectConfig(

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -39,7 +39,10 @@ def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
 
 def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     """Import changes from a template into a project."""
-    config1 = replace(readprojectconfigfile(projectdir), revision="HEAD^")
+    config1 = replace(
+        readprojectconfigfile(projectdir),
+        revision="HEAD^" if revision is None else f"{revision}^",
+    )
 
     config2 = ProjectConfig(
         config1.template,

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -73,5 +73,7 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
         try:
             repository.import_(commit)
         except MergeConflictError:
-            resolveconflicts(projectdir, projectdir / "cutty.json", Side.THEIRS)
-            # TODO: reraise for remaining conflicts
+            try:
+                resolveconflicts(projectdir, projectdir / "cutty.json", Side.THEIRS)
+            except KeyError:
+                pass

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -72,8 +72,13 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     if commit != parent:
         try:
             repository.import_(commit)
-        except MergeConflictError:
+        except MergeConflictError as error:
             try:
                 resolveconflicts(projectdir, projectdir / "cutty.json", Side.THEIRS)
             except KeyError:
                 pass
+
+            repository.project._repository.index.read()
+            if repository.project._repository.index.conflicts:
+                # FIXME: remove cutty.json from error message
+                raise error

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -89,3 +89,5 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
                     paths.remove("cutty.json")
                 message = f"Merge conflicts: {', '.join(paths)}"
                 raise MergeConflictError(message)
+
+            repository.continue_()

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -80,5 +80,9 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
 
             repository.project._repository.index.read()
             if repository.project._repository.index.conflicts:
-                # FIXME: remove cutty.json from error message
-                raise error
+                message = str(error)
+                paths = message.removeprefix("Merge conflicts: ").split(", ")
+                if "cutty.json" in paths:
+                    paths.remove("cutty.json")
+                message = f"Merge conflicts: {', '.join(paths)}"
+                raise MergeConflictError(message)

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Optional
 
+from cutty.packages.adapters.providers.git import RevisionNotFoundError
 from cutty.projects.build import buildproject
 from cutty.projects.config import ProjectConfig
 from cutty.projects.config import readprojectconfigfile
@@ -23,12 +24,16 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
 
     repository = ProjectRepository(projectdir)
 
-    parent = buildproject(
-        repository,
-        config1,
-        interactive=True,
-        commitmessage=updatecommitmessage,
-    )
+    parent: Optional[str]
+    try:
+        parent = buildproject(
+            repository,
+            config1,
+            interactive=True,
+            commitmessage=updatecommitmessage,
+        )
+    except RevisionNotFoundError:
+        parent = None
 
     commit = buildproject(
         repository,

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -1,4 +1,5 @@
 """Import changes from templates into projects."""
+from dataclasses import replace
 from pathlib import Path
 from typing import Optional
 
@@ -11,7 +12,7 @@ from cutty.projects.repository import ProjectRepository
 
 def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     """Import changes from a template into a project."""
-    config1 = readprojectconfigfile(projectdir)
+    config1 = replace(readprojectconfigfile(projectdir), revision="HEAD^")
 
     config2 = ProjectConfig(
         config1.template,

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -1,0 +1,16 @@
+"""Import changes from templates into projects."""
+from pathlib import Path
+from typing import Optional
+
+from cutty.services.update import update
+
+
+def import_(projectdir: Path, *, revision: Optional[str]) -> None:
+    """Import changes from a template into a project."""
+    update(
+        projectdir,
+        extrabindings=(),
+        interactive=True,
+        revision=revision,
+        directory=None,
+    )

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -6,6 +6,7 @@ import pytest
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
 from tests.util.files import chdir
+from tests.util.git import updatefile
 
 
 def test_help(runcutty: RunCutty) -> None:
@@ -29,3 +30,19 @@ def test_noop(runcutty: RunCutty, project: Path) -> None:
         runcutty("import")
 
     assert head == Repository.open(project).head.commit
+
+
+@pytest.fixture
+def templateproject(template: Path) -> Path:
+    """Return the project directory in the template."""
+    return template / "{{ cookiecutter.project }}"
+
+
+def test_latest(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
+    """It applies the latest changeset by default."""
+    updatefile(templateproject / "marker")
+
+    with chdir(project):
+        runcutty("import")
+
+    assert "marker" in Repository.open(project).head.commit.tree

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -60,3 +60,17 @@ def test_revision(
         runcutty("import", f"--revision={revision}")
 
     assert "marker" in Repository.open(project).head.commit.tree
+
+
+def test_parent(
+    runcutty: RunCutty, template: Path, templateproject: Path, project: Path
+) -> None:
+    """It does not apply the parent commit."""
+    updatefile(templateproject / "extra")
+    updatefile(templateproject / "marker")
+
+    with chdir(project):
+        runcutty("import")
+
+    assert "marker" in Repository.open(project).head.commit.tree
+    assert "extra" not in Repository.open(project).head.commit.tree

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -87,6 +87,20 @@ def test_parent(
     assert "extra" not in tree(project)
 
 
+def test_child(
+    runcutty: RunCutty, template: Path, templateproject: Path, project: Path
+) -> None:
+    """It does not apply the child commit."""
+    updatefile(templateproject / "marker")
+    updatefile(templateproject / "extra")
+
+    with chdir(project):
+        runcutty("import", "--revision=HEAD^")
+
+    assert "marker" in tree(project)
+    assert "extra" not in tree(project)
+
+
 def test_conflict(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
     """It exits with non-zero status on merge conflicts."""
     updatefile(templateproject / "marker", "a")

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -1,7 +1,31 @@
 """Functional tests for `cutty import`."""
+from pathlib import Path
+
+import pytest
+
+from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
+from tests.util.files import chdir
 
 
 def test_help(runcutty: RunCutty) -> None:
     """It exits with a status code of zero."""
     runcutty("import", "--help")
+
+
+@pytest.fixture
+def project(runcutty: RunCutty, template: Path) -> Path:
+    """Fixture for a generated project."""
+    runcutty("create", "--non-interactive", str(template))
+
+    return Path("example")
+
+
+def test_noop(runcutty: RunCutty, project: Path) -> None:
+    """It doesn't do anything if nothing changed."""
+    head = Repository.open(project).head.commit
+
+    with chdir(project):
+        runcutty("import")
+
+    assert head == Repository.open(project).head.commit

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -29,7 +29,7 @@ def commit(repository: Path) -> pygit2.Commit:
 
 
 def test_noop(runcutty: RunCutty, project: Path) -> None:
-    """It doesn't do anything if nothing changed."""
+    """It doesn't do anything if the project is up-to-date."""
     head = commit(project)
 
     with chdir(project):

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -46,3 +46,17 @@ def test_latest(runcutty: RunCutty, templateproject: Path, project: Path) -> Non
         runcutty("import")
 
     assert "marker" in Repository.open(project).head.commit.tree
+
+
+def test_revision(
+    runcutty: RunCutty, template: Path, templateproject: Path, project: Path
+) -> None:
+    """It applies the indicated changeset."""
+    updatefile(templateproject / "marker")
+
+    revision = Repository.open(template).head.commit.id
+
+    with chdir(project):
+        runcutty("import", f"--revision={revision}")
+
+    assert "marker" in Repository.open(project).head.commit.tree

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -85,3 +85,13 @@ def test_parent(
 
     assert "marker" in tree(project)
     assert "extra" not in tree(project)
+
+
+def test_conflict(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
+    """It exits with non-zero status on merge conflicts."""
+    updatefile(templateproject / "marker", "a")
+    updatefile(project / "marker", "b")
+
+    with pytest.raises(Exception, match="conflict"):
+        with chdir(project):
+            runcutty("import")

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -59,6 +59,21 @@ def test_latest(runcutty: RunCutty, templateproject: Path, project: Path) -> Non
     assert "marker" in tree(project)
 
 
+def test_idempotent(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
+    """It doesn't do anything if the change was already imported."""
+    updatefile(templateproject / "marker")
+
+    with chdir(project):
+        runcutty("import")
+
+    head = commit(project)
+
+    with chdir(project):
+        runcutty("import")
+
+    assert head == commit(project)
+
+
 def test_revision(
     runcutty: RunCutty, template: Path, templateproject: Path, project: Path
 ) -> None:

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -95,3 +95,18 @@ def test_conflict(runcutty: RunCutty, templateproject: Path, project: Path) -> N
     with pytest.raises(Exception, match="conflict"):
         with chdir(project):
             runcutty("import")
+
+
+def test_conflict_message(
+    runcutty: RunCutty, templateproject: Path, project: Path
+) -> None:
+    """It does not report cutty.json on merge conflicts."""
+    updatefile(templateproject / "extra")
+    updatefile(templateproject / "marker", "a")
+    updatefile(project / "marker", "b")
+
+    with pytest.raises(Exception) as exceptioninfo:
+        with chdir(project):
+            runcutty("import")
+
+    assert "cutty.json" not in str(exceptioninfo.value)

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -1,0 +1,7 @@
+"""Functional tests for `cutty import`."""
+from tests.functional.conftest import RunCutty
+
+
+def test_help(runcutty: RunCutty) -> None:
+    """It exits with a status code of zero."""
+    runcutty("import", "--help")

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -23,14 +23,19 @@ def project(runcutty: RunCutty, template: Path) -> Path:
     return Path("example")
 
 
+def commit(repository: Path) -> pygit2.Commit:
+    """Return the commit referenced by HEAD."""
+    return Repository.open(repository).head.commit
+
+
 def test_noop(runcutty: RunCutty, project: Path) -> None:
     """It doesn't do anything if nothing changed."""
-    head = Repository.open(project).head.commit
+    head = commit(project)
 
     with chdir(project):
         runcutty("import")
 
-    assert head == Repository.open(project).head.commit
+    assert head == commit(project)
 
 
 @pytest.fixture
@@ -41,7 +46,7 @@ def templateproject(template: Path) -> Path:
 
 def tree(repository: Path) -> pygit2.Tree:
     """Return the tree referenced by HEAD."""
-    return Repository.open(repository).head.commit.tree
+    return commit(repository).tree
 
 
 def test_latest(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
@@ -60,7 +65,7 @@ def test_revision(
     """It applies the indicated changeset."""
     updatefile(templateproject / "marker")
 
-    revision = Repository.open(template).head.commit.id
+    revision = commit(template).id
 
     with chdir(project):
         runcutty("import", f"--revision={revision}")

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -1,6 +1,7 @@
 """Functional tests for `cutty import`."""
 from pathlib import Path
 
+import pygit2
 import pytest
 
 from cutty.util.git import Repository
@@ -38,6 +39,11 @@ def templateproject(template: Path) -> Path:
     return template / "{{ cookiecutter.project }}"
 
 
+def tree(repository: Path) -> pygit2.Tree:
+    """Return the tree referenced by HEAD."""
+    return Repository.open(repository).head.commit.tree
+
+
 def test_latest(runcutty: RunCutty, templateproject: Path, project: Path) -> None:
     """It applies the latest changeset by default."""
     updatefile(templateproject / "marker")
@@ -45,7 +51,7 @@ def test_latest(runcutty: RunCutty, templateproject: Path, project: Path) -> Non
     with chdir(project):
         runcutty("import")
 
-    assert "marker" in Repository.open(project).head.commit.tree
+    assert "marker" in tree(project)
 
 
 def test_revision(
@@ -59,7 +65,7 @@ def test_revision(
     with chdir(project):
         runcutty("import", f"--revision={revision}")
 
-    assert "marker" in Repository.open(project).head.commit.tree
+    assert "marker" in tree(project)
 
 
 def test_parent(
@@ -72,5 +78,5 @@ def test_parent(
     with chdir(project):
         runcutty("import")
 
-    assert "marker" in Repository.open(project).head.commit.tree
-    assert "extra" not in Repository.open(project).head.commit.tree
+    assert "marker" in tree(project)
+    assert "extra" not in tree(project)


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty import --help`
- ✨ [entrypoints] Add command `cutty import`
- 🔨 [entrypoints] Inline variable `registercommand`
- 🔨 [entrypoints] Inline function `click.Group.command`
- 🔨 [entrypoints] Move `click.command` and `fatal` to command definitions
- 🔨 [entrypoints] Slide statement into loop
- ✅ [functional] Add test for `cutty import` without changes
- ✅ [functional] Add test for `cutty import` with latest changeset
- ✨ [entrypoints] Implement `cutty import` using `services.update`
- ✅ [functional] Add test for `cutty import --revision=<revision>`
- ✨ [entrypoints] Add option `cutty import --revision=<revision>`
- ✅ [functional] Add test for `cutty import` not applying parent commit
- 🔨 [functional] Extract function `tree`
- 🔨 [functional] Extract function `commit`
- 🔨 [services] Extract function `import_` from import CLI
- 🔨 [services] Inline function `update` in `import_`
- ✨ [services] Do not apply preceding changesets with `cutty import`
- ✨ [services] Allow `cutty import` of the root commit
- ✨ [services] Resolve cutty.json conflicts when importing changesets
- ✅ [functional] Add test for `cutty import` on merge conflicts
- 🐛 [services] Fix crash when merge conflicts do not include cutty.json
- 🐛 [services] Do not swallow merge conflicts in `cutty import`
- ✅ [functional] Add test for merge conflict message on `cutty import`
- 🐛 [services] Do not report cutty.json in merge conflicts
- ✅ [functional] Add test for `cutty import` not applying child commit
- ✨ [services] Allow importing revisions with more than one ancestor
- 🐛 [services] Commit after conflict resolution
- 💡 [services] Add FIXME comment about git-ism
