### PR TITLE
✨ [entrypoints] Improve error message for merge conflicts

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -14,6 +14,7 @@ from cutty.projects.project import EmptyTemplateError
 from cutty.projects.repository import NoUpdateInProgressError
 from cutty.services.link import TemplateNotSpecifiedError
 from cutty.util.exceptionhandlers import exceptionhandler
+from cutty.util.git import MergeConflictError
 
 
 def _die(message: str) -> NoReturn:
@@ -91,6 +92,11 @@ def _noupdateinprogress(error: NoUpdateInProgressError) -> NoReturn:
     _die("no update in progress")
 
 
+@exceptionhandler
+def _mergeconflict(error: MergeConflictError) -> NoReturn:
+    _die(str(error))
+
+
 fatal = (
     _unknownlocation
     >> _unsupportedrevision
@@ -103,4 +109,5 @@ fatal = (
     >> _templatenotspecified
     >> _emptytemplate
     >> _noupdateinprogress
+    >> _mergeconflict
 )

--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -94,7 +94,7 @@ def _noupdateinprogress(error: NoUpdateInProgressError) -> NoReturn:
 
 @exceptionhandler
 def _mergeconflict(error: MergeConflictError) -> NoReturn:
-    _die(str(error))
+    _die(f"Merge conflicts: {', '.join(error.paths)}")
 
 
 fatal = (

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -85,8 +85,10 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
         except KeyError:
             pass
 
-        repository.project._repository.index.read()
-        if repository.project._repository.index.conflicts:
-            raise MergeConflictError.fromindex(repository.project._repository.index)
+        index = repository.project._repository.index
+        index.read()
+
+        if index.conflicts:
+            raise MergeConflictError.fromindex(index)
 
         repository.continue_()

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -79,7 +79,7 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
 
     try:
         repository.import_(commit)
-    except MergeConflictError as error:
+    except MergeConflictError:
         try:
             resolveconflicts(projectdir, projectdir / "cutty.json", Side.THEIRS)
         except KeyError:
@@ -87,11 +87,6 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
 
         repository.project._repository.index.read()
         if repository.project._repository.index.conflicts:
-            message = str(error)
-            paths = message.removeprefix("Merge conflicts: ").split(", ")
-            if "cutty.json" in paths:
-                paths.remove("cutty.json")
-            message = f"Merge conflicts: {', '.join(paths)}"
-            raise MergeConflictError(message)
+            raise MergeConflictError.fromindex(repository.project._repository.index)
 
         repository.continue_()

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -89,8 +89,11 @@ class Branch:
         self._branches[self._name] = commit
 
 
+@dataclass
 class MergeConflictError(Exception):
     """The merge resulted in conflicts."""
+
+    paths: set[str]
 
     @classmethod
     def fromindex(cls, index: pygit2.Index) -> MergeConflictError:
@@ -101,7 +104,7 @@ class MergeConflictError(Exception):
             for side in (ours, theirs)
             if side is not None
         }
-        return cls(f"Merge conflicts: {', '.join(paths)}")
+        return cls(paths)
 
 
 @dataclass

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -58,7 +58,7 @@ from cutty.util.git import MergeConflictError
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),
         TemplateNotSpecifiedError(),
         NoUpdateInProgressError(),
-        MergeConflictError(),
+        MergeConflictError({"README.md"}),
     ],
 )
 def test_errors(error: CuttyError) -> None:

--- a/tests/unit/entrypoints/cli/test_errors.py
+++ b/tests/unit/entrypoints/cli/test_errors.py
@@ -17,6 +17,7 @@ from cutty.packages.domain.mounters import UnsupportedRevisionError
 from cutty.packages.domain.registry import UnknownLocationError
 from cutty.projects.repository import NoUpdateInProgressError
 from cutty.services.link import TemplateNotSpecifiedError
+from cutty.util.git import MergeConflictError
 
 
 @pytest.mark.parametrize(
@@ -57,6 +58,7 @@ from cutty.services.link import TemplateNotSpecifiedError
         UnknownLocationError(pathlib.Path("/no/such/file/or/directory")),
         TemplateNotSpecifiedError(),
         NoUpdateInProgressError(),
+        MergeConflictError(),
     ],
 )
 def test_errors(error: CuttyError) -> None:


### PR DESCRIPTION
- 🔨 [util] Extract function `git.MergeConflictError.fromindex`
- 🔨 [services] Use `MergeConflictError.fromindex` in `import_`
- 🔨 [services] Extract variable `index`
- ✅ [entrypoints] Add test for `MergeConflictError` handler
- ✨ [entrypoints] Add handler for `MergeConflictError`
- 🔨 [entrypoints] Build error message for `MergeConflictError` in handler
