### PR TITLE
🔨 [packages] Rename attribute `Package.{path => tree}`

### DIFF
--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -18,6 +18,11 @@ class Package:
     path: Path
     revision: Optional[Revision]
 
+    @property
+    def tree(self) -> Path:
+        """."""
+        return self.path
+
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""
         path = self.path.joinpath(*directory.parts)

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -25,9 +25,9 @@ class Package:
 
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""
-        path = self.path.joinpath(*directory.parts)
+        tree = self.tree.joinpath(*directory.parts)
         return Package(
             directory.name,
-            Path(filesystem=PathFilesystem(path)),
+            Path(filesystem=PathFilesystem(tree)),
             self.revision,
         )

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -15,13 +15,8 @@ class Package:
     """A package."""
 
     name: str
-    path: Path
+    tree: Path
     revision: Optional[Revision]
-
-    @property
-    def tree(self) -> Path:
-        """."""
-        return self.path
 
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -50,4 +50,4 @@ class Template:
 
             metadata = cls.Metadata(template, directory, package.name, package.revision)
 
-            yield cls(metadata, package.path)
+            yield cls(metadata, package.tree)

--- a/tests/unit/packages/adapters/providers/test_disk.py
+++ b/tests/unit/packages/adapters/providers/test_disk.py
@@ -23,7 +23,7 @@ def test_happy(repositorypath: Path) -> None:
     assert repository is not None
 
     with repository.get() as package:
-        text = (package.path / "marker").read_text()
+        text = (package.tree / "marker").read_text()
         assert text == "Lorem"
 
 

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -46,7 +46,7 @@ def test_local_happy(url: URL, revision: Optional[str], expected: str) -> None:
     assert repository is not None
 
     with repository.get(revision) as package:
-        text = (package.path / "marker").read_text()
+        text = (package.tree / "marker").read_text()
         assert expected == text
 
 
@@ -112,7 +112,7 @@ def test_remote_happy(
     assert repository is not None
 
     with repository.get(revision) as package:
-        text = (package.path / "marker").read_text()
+        text = (package.tree / "marker").read_text()
         assert expected == text
 
 

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -64,7 +64,7 @@ def test_happy(
     assert repository is not None
 
     with repository.get(revision) as package:
-        text = (package.path / "marker").read_text()
+        text = (package.tree / "marker").read_text()
         assert expected == text
 
 

--- a/tests/unit/packages/adapters/providers/test_zip.py
+++ b/tests/unit/packages/adapters/providers/test_zip.py
@@ -32,7 +32,7 @@ def test_local_happy(url: URL) -> None:
     assert repository is not None
 
     with repository.get() as package:
-        text = (package.path / "marker").read_text()
+        text = (package.tree / "marker").read_text()
         assert "Lorem" == text
 
 
@@ -64,7 +64,7 @@ def test_remote_happy(zipprovider: Provider, url: URL) -> None:
     assert repository is not None
 
     with repository.get() as package:
-        text = (package.path / "marker").read_text()
+        text = (package.tree / "marker").read_text()
         assert "Lorem" == text
 
 

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -61,7 +61,7 @@ def test_localprovider_path(tmp_path: pathlib.Path, diskmounter: Mounter) -> Non
     assert repository is not None
 
     with repository.get() as package:
-        [entry] = package.path.iterdir()
+        [entry] = package.tree.iterdir()
         assert entry.name == "marker"
 
 
@@ -180,7 +180,7 @@ def test_remoteproviderfactory_mounter(
     assert repository is not None
 
     with repository.get(revision) as package:
-        assert (package.path / "marker").read_text() == "Lorem"
+        assert (package.tree / "marker").read_text() == "Lorem"
 
 
 def test_remoteproviderfactory_inexistent_path(

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -64,8 +64,8 @@ def test_provide_pass(providerstore: ProviderStore, providers: list[Provider]) -
 
     repository = registry.getrepository("")
     with repository.get() as package:
-        assert package.path.is_dir()
-        assert not (package.path / "marker").is_file()
+        assert package.tree.is_dir()
+        assert not (package.tree / "marker").is_file()
 
 
 def test_none(providerstore: ProviderStore, url: URL) -> None:
@@ -84,7 +84,7 @@ def test_with_url(
     repository = registry.getrepository(str(url))
 
     with repository.get() as package:
-        assert not list(package.path.iterdir())
+        assert not list(package.tree.iterdir())
 
 
 def test_with_path(
@@ -105,7 +105,7 @@ def test_with_path(
     repository = registry.getrepository(str(directory))
 
     with repository.get() as package:
-        [entry] = package.path.iterdir()
+        [entry] = package.tree.iterdir()
 
     assert entry.name == "marker"
 


### PR DESCRIPTION
- 🔨 [packages] Add property `Package.tree` delegating to `Package.path`
- 🔨 [packages] Replace uses of `Package.{path => tree}`
- 🔨 [packages] Rename attribute `Package.{path => tree}`
