### PR TITLE
🔨 [projects] Extract classes `TemplateRepository` and `TemplateProvider`

### DIFF
--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -17,9 +17,9 @@ def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Iterator[Project]:
     """Create the project."""
-    templates = TemplateRepository.load(config.template)
+    templates = TemplateRepository.load(config.template, config.directory)
 
-    with templates.get(config.revision, config.directory) as template:
+    with templates.get(config.revision) as template:
         yield generate(
             template,
             config.bindings,

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -17,7 +17,8 @@ def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Iterator[Project]:
     """Create the project."""
-    templates = TemplateProvider().provide(config.template, config.directory)
+    provider = TemplateProvider.create()
+    templates = provider.provide(config.template, config.directory)
 
     with templates.get(config.revision) as template:
         yield generate(

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -9,7 +9,7 @@ from cutty.projects.messages import MessageBuilder
 from cutty.projects.project import Project
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
-from cutty.projects.template import TemplateRepository
+from cutty.projects.template import TemplateProvider
 
 
 @contextmanager
@@ -17,7 +17,7 @@ def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Iterator[Project]:
     """Create the project."""
-    templates = TemplateRepository.load(config.template, config.directory)
+    templates = TemplateProvider().provide(config.template, config.directory)
 
     with templates.get(config.revision) as template:
         yield generate(

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -17,7 +17,7 @@ def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Iterator[Project]:
     """Create the project."""
-    with TemplateRepository().load(
+    with TemplateRepository().get(
         config.template, config.revision, config.directory
     ) as template:
         yield generate(

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -17,9 +17,9 @@ def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Iterator[Project]:
     """Create the project."""
-    with TemplateRepository().get(
-        config.template, config.revision, config.directory
-    ) as template:
+    templates = TemplateRepository.load(config.template)
+
+    with templates.get(config.template, config.revision, config.directory) as template:
         yield generate(
             template,
             config.bindings,

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -9,7 +9,7 @@ from cutty.projects.messages import MessageBuilder
 from cutty.projects.project import Project
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
-from cutty.projects.template import Template
+from cutty.projects.template import TemplateRepository
 
 
 @contextmanager
@@ -17,7 +17,9 @@ def createproject(
     config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
 ) -> Iterator[Project]:
     """Create the project."""
-    with Template.load(config.template, config.revision, config.directory) as template:
+    with TemplateRepository().load(
+        config.template, config.revision, config.directory
+    ) as template:
         yield generate(
             template,
             config.bindings,

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -19,7 +19,7 @@ def createproject(
     """Create the project."""
     templates = TemplateRepository.load(config.template)
 
-    with templates.get(config.template, config.revision, config.directory) as template:
+    with templates.get(config.revision, config.directory) as template:
         yield generate(
             template,
             config.bindings,

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -12,11 +12,24 @@ from cutty.compat.contextlib import contextmanager
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.packages.adapters.storage import getdefaultpackageprovider
+from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
 
 
+@dataclass
 class TemplateRepository:
     """Repository of project templates."""
+
+    repository: PackageRepository
+
+    @classmethod
+    def load(cls, template: str) -> TemplateRepository:
+        """Load a template repository."""
+        cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
+        packageprovider = getdefaultpackageprovider(cachedir)
+        repository = packageprovider.getrepository(template)
+
+        return cls(repository)
 
     @contextmanager
     def get(
@@ -26,11 +39,7 @@ class TemplateRepository:
         directory: Optional[pathlib.Path],
     ) -> Iterator[Template]:
         """Load a project template."""
-        cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
-        packageprovider = getdefaultpackageprovider(cachedir)
-        repository = packageprovider.getrepository(template)
-
-        with repository.get(revision) as package:
+        with self.repository.get(revision) as package:
             if directory is not None:
                 package = package.descend(PurePath(*directory.parts))
 

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -16,6 +16,20 @@ from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
 
 
+class TemplateProvider:
+    """Provider of project templates."""
+
+    def provide(
+        self, location: str, directory: Optional[pathlib.Path]
+    ) -> TemplateRepository:
+        """Load a template repository."""
+        cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
+        packageprovider = getdefaultpackageprovider(cachedir)
+        repository = packageprovider.getrepository(location)
+
+        return TemplateRepository(repository, location, directory)
+
+
 @dataclass
 class TemplateRepository:
     """Repository of project templates."""
@@ -29,11 +43,7 @@ class TemplateRepository:
         cls, location: str, directory: Optional[pathlib.Path]
     ) -> TemplateRepository:
         """Load a template repository."""
-        cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
-        packageprovider = getdefaultpackageprovider(cachedir)
-        repository = packageprovider.getrepository(location)
-
-        return cls(repository, location, directory)
+        return TemplateProvider().provide(location, directory)
 
     @contextmanager
     def get(self, revision: Optional[str]) -> Iterator[Template]:

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -19,7 +19,7 @@ class TemplateRepository:
     """Repository of project templates."""
 
     @contextmanager
-    def load(
+    def get(
         self,
         template: str,
         revision: Optional[str],

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -24,13 +24,13 @@ class TemplateRepository:
     location: str
 
     @classmethod
-    def load(cls, template: str) -> TemplateRepository:
+    def load(cls, location: str) -> TemplateRepository:
         """Load a template repository."""
         cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
         packageprovider = getdefaultpackageprovider(cachedir)
-        repository = packageprovider.getrepository(template)
+        repository = packageprovider.getrepository(location)
 
-        return cls(repository, template)
+        return cls(repository, location)
 
     @contextmanager
     def get(

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -12,20 +12,30 @@ from cutty.compat.contextlib import contextmanager
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.packages.adapters.storage import getdefaultpackageprovider
+from cutty.packages.domain.registry import ProviderRegistry
 from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
 
 
+@dataclass
 class TemplateProvider:
     """Provider of project templates."""
+
+    packageprovider: ProviderRegistry
+
+    @classmethod
+    def create(cls) -> TemplateProvider:
+        """Create the template provider."""
+        cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
+        packageprovider = getdefaultpackageprovider(cachedir)
+
+        return cls(packageprovider)
 
     def provide(
         self, location: str, directory: Optional[pathlib.Path]
     ) -> TemplateRepository:
         """Load a template repository."""
-        cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
-        packageprovider = getdefaultpackageprovider(cachedir)
-        repository = packageprovider.getrepository(location)
+        repository = self.packageprovider.getrepository(location)
 
         return TemplateRepository(repository, location, directory)
 

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import pathlib
 from collections.abc import Iterator
-from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Optional
 
@@ -57,13 +56,3 @@ class Template:
 
     metadata: Metadata
     root: Path
-
-    @classmethod
-    def load(
-        cls,
-        template: str,
-        revision: Optional[str],
-        directory: Optional[pathlib.Path],
-    ) -> AbstractContextManager[Template]:
-        """Load a project template."""
-        return TemplateRepository().load(template, revision, directory)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -38,13 +38,6 @@ class TemplateRepository:
     location: str
     directory: Optional[pathlib.Path]
 
-    @classmethod
-    def load(
-        cls, location: str, directory: Optional[pathlib.Path]
-    ) -> TemplateRepository:
-        """Load a template repository."""
-        return TemplateProvider().provide(location, directory)
-
     @contextmanager
     def get(self, revision: Optional[str]) -> Iterator[Template]:
         """Load a project template."""

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -21,6 +21,7 @@ class TemplateRepository:
     """Repository of project templates."""
 
     repository: PackageRepository
+    location: str
 
     @classmethod
     def load(cls, template: str) -> TemplateRepository:
@@ -29,14 +30,11 @@ class TemplateRepository:
         packageprovider = getdefaultpackageprovider(cachedir)
         repository = packageprovider.getrepository(template)
 
-        return cls(repository)
+        return cls(repository, template)
 
     @contextmanager
     def get(
-        self,
-        template: str,
-        revision: Optional[str],
-        directory: Optional[pathlib.Path],
+        self, revision: Optional[str], directory: Optional[pathlib.Path]
     ) -> Iterator[Template]:
         """Load a project template."""
         with self.repository.get(revision) as package:
@@ -44,7 +42,7 @@ class TemplateRepository:
                 package = package.descend(PurePath(*directory.parts))
 
             metadata = Template.Metadata(
-                template, directory, package.name, package.revision
+                self.location, directory, package.name, package.revision
             )
 
             yield Template(metadata, package.tree)


### PR DESCRIPTION
- 🔨 [projects] Extract class `TemplateRepository`
- 🔨 [projects] Inline function `Template.load`
- 🔨 [projects] Rename function `TemplateRepository.{load => get}`
- 🔨 [projects] Extract function `TemplateRepository.load`
- 🔨 [projects] Replace parameter `template` with instance variable `TemplateRepository.location`
- 🔨 [projects] Rename parameter `template` to `location` in `TemplateRepository`
- 🔨 [projects] Replace parameter `directory` with instance variable in `TemplateRepository`
- 🔨 [projects] Extract class `TemplateProvider`
- 🔨 [projects] Inline function `TemplateRepository.load`
- 🔨 [projects] Extract factory method `TemplateProvider.create`
