### PR TITLE
🔨 [packages] Add `getparentrevision` callback for template providers

### DIFF
--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -73,7 +73,9 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
     return revision
 
 
-def getparentrevision(revision: Optional[Revision]) -> Optional[Revision]:
+def getparentrevision(
+    path: pathlib.Path, revision: Optional[Revision]
+) -> Optional[Revision]:
     """Return the parent revision, if any."""
     return "HEAD^" if revision is None else f"{revision}^"
 

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -81,8 +81,17 @@ def getparentrevision(
 
 
 localgitprovider = LocalProvider(
-    "localgit", match=match, mount=mount, getrevision=getrevision
+    "localgit",
+    match=match,
+    mount=mount,
+    getrevision=getrevision,
+    getparentrevision=getparentrevision,
 )
+
 gitproviderfactory = RemoteProviderFactory(
-    "git", fetch=[gitfetcher], mount=mount, getrevision=getrevision
+    "git",
+    fetch=[gitfetcher],
+    mount=mount,
+    getrevision=getrevision,
+    getparentrevision=getparentrevision,
 )

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -73,6 +73,11 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
     return revision
 
 
+def getparentrevision(revision: Optional[Revision]) -> Optional[Revision]:
+    """Return the parent revision, if any."""
+    return "HEAD^" if revision is None else f"{revision}^"
+
+
 localgitprovider = LocalProvider(
     "localgit", match=match, mount=mount, getrevision=getrevision
 )

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -90,6 +90,7 @@ class RemoteProvider(Provider):
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
         getrevision: Optional[GetRevision] = None,
+        getparentrevision: Optional[GetRevision] = None,
         store: Store,
     ) -> None:
         """Initialize."""
@@ -106,6 +107,7 @@ class RemoteProvider(Provider):
         self.store = store
         self.mount = mount
         self.getrevision = getrevision
+        self.getparentrevision = getparentrevision
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
@@ -125,6 +127,7 @@ class RemoteProvider(Provider):
                         path,
                         mount=self.mount,
                         getrevision=self.getrevision,
+                        getparentrevision=self.getparentrevision,
                     )
 
         return None

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -46,6 +46,7 @@ class LocalProvider(Provider):
         match: PathMatcher,
         mount: Mounter,
         getrevision: Optional[GetRevision] = None,
+        getparentrevision: Optional[GetRevision] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
@@ -53,13 +54,18 @@ class LocalProvider(Provider):
         self.match = match
         self.mount = mount
         self.getrevision = getrevision
+        self.getparentrevision = getparentrevision
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
         if path := pathfromlocation(location):
             if path.exists() and self.match(path):
                 return DefaultPackageRepository(
-                    location.name, path, mount=self.mount, getrevision=self.getrevision
+                    location.name,
+                    path,
+                    mount=self.mount,
+                    getrevision=self.getrevision,
+                    getparentrevision=self.getparentrevision,
                 )
 
         return None

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -157,6 +157,7 @@ class RemoteProviderFactory(ProviderFactory):
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
         getrevision: Optional[GetRevision] = None,
+        getparentrevision: Optional[GetRevision] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
@@ -164,6 +165,7 @@ class RemoteProviderFactory(ProviderFactory):
         self.fetch = tuple(fetch)
         self.mount = mount
         self.getrevision = getrevision
+        self.getparentrevision = getparentrevision
 
     def __call__(self, store: Store) -> Provider:
         """Create a provider."""
@@ -173,6 +175,7 @@ class RemoteProviderFactory(ProviderFactory):
             fetch=self.fetch,
             mount=self.mount,
             getrevision=self.getrevision,
+            getparentrevision=self.getparentrevision,
             store=store,
         )
 

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -20,6 +20,12 @@ class PackageRepository(abc.ABC):
     def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
         """Retrieve the package with the given revision."""
 
+    def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
+        """Return the parent revision, if any."""
+        from cutty.packages.adapters.providers.git import getparentrevision
+
+        return getparentrevision(revision)
+
 
 GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]
 

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -59,9 +59,9 @@ class DefaultPackageRepository(PackageRepository):
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
-        if self._getparentrevision is None:
+        if self._getparentrevision is None:  # pragma: no cover
             from cutty.packages.adapters.providers.git import getparentrevision
 
             return getparentrevision(self.path, revision)
-        else:  # pragma: no cover
-            return self._getparentrevision(self.path, revision)
+
+        return self._getparentrevision(self.path, revision)

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -59,4 +59,4 @@ class DefaultPackageRepository(PackageRepository):
         """Return the parent revision, if any."""
         from cutty.packages.adapters.providers.git import getparentrevision
 
-        return getparentrevision(revision)
+        return getparentrevision(self.path, revision)

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -37,12 +37,14 @@ class DefaultPackageRepository(PackageRepository):
         *,
         mount: Mounter,
         getrevision: Optional[GetRevision],
+        getparentrevision: Optional[GetRevision] = None,
     ) -> None:
         """Initialize."""
         self.name = name
         self.path = path
         self.mount = mount
         self.getrevision = getrevision
+        self._getparentrevision = getparentrevision
 
     @contextmanager
     def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
@@ -57,6 +59,9 @@ class DefaultPackageRepository(PackageRepository):
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
-        from cutty.packages.adapters.providers.git import getparentrevision
+        if self._getparentrevision is None:
+            from cutty.packages.adapters.providers.git import getparentrevision
 
-        return getparentrevision(self.path, revision)
+            return getparentrevision(self.path, revision)
+        else:  # pragma: no cover
+            return self._getparentrevision(self.path, revision)

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -22,9 +22,6 @@ class PackageRepository(abc.ABC):
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
-        from cutty.packages.adapters.providers.git import getparentrevision
-
-        return getparentrevision(revision)
 
 
 GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]
@@ -57,3 +54,9 @@ class DefaultPackageRepository(PackageRepository):
 
         with self.mount(self.path, revision) as filesystem:
             yield Package(self.name, Path(filesystem=filesystem), resolved_revision)
+
+    def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
+        """Return the parent revision, if any."""
+        from cutty.packages.adapters.providers.git import getparentrevision
+
+        return getparentrevision(revision)

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -1,8 +1,12 @@
 """Building projects in a repository."""
+import contextlib
 from collections.abc import Iterator
+from dataclasses import replace
 from typing import Optional
 
 from cutty.compat.contextlib import contextmanager
+from cutty.packages.adapters.providers.git import getparentrevision
+from cutty.packages.adapters.providers.git import RevisionNotFoundError
 from cutty.projects.config import ProjectConfig
 from cutty.projects.generate import generate
 from cutty.projects.messages import MessageBuilder
@@ -56,3 +60,23 @@ def buildproject(
         return commitproject(
             repository, project, parent=parent, commitmessage=commitmessage
         )
+
+
+def buildparentproject(
+    repository: ProjectRepository,
+    config: ProjectConfig,
+    *,
+    revision: Optional[str],
+    interactive: bool,
+    commitmessage: MessageBuilder,
+) -> Optional[str]:
+    """Build the project for the parent revision."""
+    config = replace(config, revision=getparentrevision(revision))
+
+    if config.revision is not None:  # pragma: no branch
+        with contextlib.suppress(RevisionNotFoundError):
+            return buildproject(
+                repository, config, interactive=interactive, commitmessage=commitmessage
+            )
+
+    return None

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -75,8 +75,7 @@ def buildparentproject(
 
     if config.revision is not None:  # pragma: no branch
         with contextlib.suppress(RevisionNotFoundError):
-            return buildproject(
-                repository, config, interactive=interactive, commitmessage=commitmessage
-            )
+            with createproject(config, interactive=interactive) as project:
+                return commitproject(repository, project, commitmessage=commitmessage)
 
     return None

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -74,10 +74,11 @@ def buildparentproject(
     provider = TemplateProvider.create()
     templates = provider.provide(config.template, config.directory)
     config = replace(config, revision=getparentrevision(revision))
+    parentrevision = config.revision
 
-    if config.revision is not None:  # pragma: no branch
+    if parentrevision is not None:  # pragma: no branch
         with contextlib.suppress(RevisionNotFoundError):
-            with templates.get(config.revision) as template:
+            with templates.get(parentrevision) as template:
                 project = generate(template, config.bindings, interactive=interactive)
                 return commitproject(repository, project, commitmessage=commitmessage)
 

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -71,13 +71,12 @@ def buildparentproject(
     commitmessage: MessageBuilder,
 ) -> Optional[str]:
     """Build the project for the parent revision."""
+    provider = TemplateProvider.create()
+    templates = provider.provide(config.template, config.directory)
     config = replace(config, revision=getparentrevision(revision))
 
     if config.revision is not None:  # pragma: no branch
         with contextlib.suppress(RevisionNotFoundError):
-            provider = TemplateProvider.create()
-            templates = provider.provide(config.template, config.directory)
-
             with templates.get(config.revision) as template:
                 project = generate(template, config.bindings, interactive=interactive)
                 return commitproject(repository, project, commitmessage=commitmessage)

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -75,7 +75,11 @@ def buildparentproject(
 
     if config.revision is not None:  # pragma: no branch
         with contextlib.suppress(RevisionNotFoundError):
-            with createproject(config, interactive=interactive) as project:
+            provider = TemplateProvider.create()
+            templates = provider.provide(config.template, config.directory)
+
+            with templates.get(config.revision) as template:
+                project = generate(template, config.bindings, interactive=interactive)
                 return commitproject(repository, project, commitmessage=commitmessage)
 
     return None

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -1,7 +1,6 @@
 """Building projects in a repository."""
 import contextlib
 from collections.abc import Iterator
-from dataclasses import replace
 from typing import Optional
 
 from cutty.compat.contextlib import contextmanager
@@ -73,8 +72,7 @@ def buildparentproject(
     """Build the project for the parent revision."""
     provider = TemplateProvider.create()
     templates = provider.provide(config.template, config.directory)
-    config = replace(config, revision=getparentrevision(revision))
-    parentrevision = config.revision
+    parentrevision = getparentrevision(revision)
 
     if parentrevision is not None:  # pragma: no branch
         with contextlib.suppress(RevisionNotFoundError):

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -4,7 +4,6 @@ from collections.abc import Iterator
 from typing import Optional
 
 from cutty.compat.contextlib import contextmanager
-from cutty.packages.adapters.providers.git import getparentrevision
 from cutty.packages.adapters.providers.git import RevisionNotFoundError
 from cutty.projects.config import ProjectConfig
 from cutty.projects.generate import generate
@@ -73,7 +72,7 @@ def buildparentproject(
     provider = TemplateProvider.create()
     templates = provider.provide(config.template, config.directory)
 
-    if parentrevision := getparentrevision(revision):  # pragma: no branch
+    if parentrevision := templates.getparentrevision(revision):  # pragma: no branch
         with contextlib.suppress(RevisionNotFoundError):
             with templates.get(parentrevision) as template:
                 project = generate(template, config.bindings, interactive=interactive)

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -72,9 +72,8 @@ def buildparentproject(
     """Build the project for the parent revision."""
     provider = TemplateProvider.create()
     templates = provider.provide(config.template, config.directory)
-    parentrevision = getparentrevision(revision)
 
-    if parentrevision is not None:  # pragma: no branch
+    if parentrevision := getparentrevision(revision):  # pragma: no branch
         with contextlib.suppress(RevisionNotFoundError):
             with templates.get(parentrevision) as template:
                 project = generate(template, config.bindings, interactive=interactive)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -11,6 +11,7 @@ import platformdirs
 from cutty.compat.contextlib import contextmanager
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
+from cutty.packages.adapters.providers.git import getparentrevision
 from cutty.packages.adapters.storage import getdefaultpackageprovider
 from cutty.packages.domain.registry import ProviderRegistry
 from cutty.packages.domain.repository import PackageRepository
@@ -60,6 +61,10 @@ class TemplateRepository:
             )
 
             yield Template(metadata, package.tree)
+
+    def getparentrevision(self, revision: Optional[str]) -> Optional[str]:
+        """Return the parent revision, if any."""
+        return getparentrevision(revision)
 
 
 @dataclass

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -11,7 +11,6 @@ import platformdirs
 from cutty.compat.contextlib import contextmanager
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.packages.adapters.providers.git import getparentrevision
 from cutty.packages.adapters.storage import getdefaultpackageprovider
 from cutty.packages.domain.registry import ProviderRegistry
 from cutty.packages.domain.repository import PackageRepository
@@ -64,7 +63,7 @@ class TemplateRepository:
 
     def getparentrevision(self, revision: Optional[str]) -> Optional[str]:
         """Return the parent revision, if any."""
-        return getparentrevision(revision)
+        return self.repository.getparentrevision(revision)
 
 
 @dataclass

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -1,14 +1,11 @@
 """Import changes from templates into projects."""
-import contextlib
 import enum
-from dataclasses import replace
 from pathlib import Path
 from typing import Optional
 
 import pygit2
 
-from cutty.packages.adapters.providers.git import getparentrevision
-from cutty.packages.adapters.providers.git import RevisionNotFoundError
+from cutty.projects.build import buildparentproject
 from cutty.projects.build import buildproject
 from cutty.projects.config import ProjectConfig
 from cutty.projects.config import readprojectconfigfile
@@ -52,17 +49,13 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
 
     repository = ProjectRepository(projectdir)
 
-    config1 = replace(config1, revision=getparentrevision(revision))
-
-    parent: Optional[str] = None
-    if config1.revision is not None:  # pragma: no branch
-        with contextlib.suppress(RevisionNotFoundError):
-            parent = buildproject(
-                repository,
-                config1,
-                interactive=True,
-                commitmessage=updatecommitmessage,
-            )
+    parent = buildparentproject(
+        repository,
+        config1,
+        revision=revision,
+        interactive=True,
+        commitmessage=updatecommitmessage,
+    )
 
     commit = buildproject(
         repository,

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -1,4 +1,5 @@
 """Import changes from templates into projects."""
+import contextlib
 import enum
 from dataclasses import replace
 from pathlib import Path
@@ -57,15 +58,13 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     repository = ProjectRepository(projectdir)
 
     parent: Optional[str] = None
-    try:
+    with contextlib.suppress(RevisionNotFoundError):
         parent = buildproject(
             repository,
             config1,
             interactive=True,
             commitmessage=updatecommitmessage,
         )
-    except RevisionNotFoundError:
-        pass
 
     commit = buildproject(
         repository,

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -42,7 +42,6 @@ def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
 def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     """Import changes from a template into a project."""
     config1 = readprojectconfigfile(projectdir)
-    config1 = replace(config1, revision=getparentrevision(revision))
 
     config2 = ProjectConfig(
         config1.template,
@@ -52,6 +51,8 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     )
 
     repository = ProjectRepository(projectdir)
+
+    config1 = replace(config1, revision=getparentrevision(revision))
 
     parent: Optional[str] = None
     if config1.revision is not None:  # pragma: no branch

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import pygit2
 
+from cutty.packages.adapters.providers.git import getparentrevision
 from cutty.packages.adapters.providers.git import RevisionNotFoundError
 from cutty.projects.build import buildproject
 from cutty.projects.config import ProjectConfig
@@ -36,11 +37,6 @@ def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
     repository.index.add(resolution)
     repository.index.write()
     repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[pathstr])
-
-
-def getparentrevision(revision: Optional[str]) -> Optional[str]:
-    """Return the parent revision, if any."""
-    return "HEAD^" if revision is None else f"{revision}^"
 
 
 def import_(projectdir: Path, *, revision: Optional[str]) -> None:

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -37,13 +37,15 @@ def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
     repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[pathstr])
 
 
+def getparentrevision(revision: Optional[str]) -> Optional[str]:
+    """Return the parent revision, if any."""
+    return "HEAD^" if revision is None else f"{revision}^"
+
+
 def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     """Import changes from a template into a project."""
     config1 = readprojectconfigfile(projectdir)
-    config1 = replace(
-        config1,
-        revision="HEAD^" if revision is None else f"{revision}^",  # FIXME: git-specific
-    )
+    config1 = replace(config1, revision=getparentrevision(revision))
 
     config2 = ProjectConfig(
         config1.template,

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -56,7 +56,7 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
 
     repository = ProjectRepository(projectdir)
 
-    parent: Optional[str]
+    parent: Optional[str] = None
     try:
         parent = buildproject(
             repository,
@@ -65,7 +65,7 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
             commitmessage=updatecommitmessage,
         )
     except RevisionNotFoundError:
-        parent = None
+        pass
 
     commit = buildproject(
         repository,

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -39,8 +39,9 @@ def resolveconflicts(repositorypath: Path, path: Path, side: Side) -> None:
 
 def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     """Import changes from a template into a project."""
+    config1 = readprojectconfigfile(projectdir)
     config1 = replace(
-        readprojectconfigfile(projectdir),
+        config1,
         revision="HEAD^" if revision is None else f"{revision}^",  # FIXME: git-specific
     )
 

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -58,13 +58,14 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
     repository = ProjectRepository(projectdir)
 
     parent: Optional[str] = None
-    with contextlib.suppress(RevisionNotFoundError):
-        parent = buildproject(
-            repository,
-            config1,
-            interactive=True,
-            commitmessage=updatecommitmessage,
-        )
+    if config1.revision is not None:  # pragma: no branch
+        with contextlib.suppress(RevisionNotFoundError):
+            parent = buildproject(
+                repository,
+                config1,
+                interactive=True,
+                commitmessage=updatecommitmessage,
+            )
 
     commit = buildproject(
         repository,


### PR DESCRIPTION
- 🔨 [services] Extract variable `config1`
- 🔨 [services] Extract function `getparentrevision`
- 🔨 [services] Slide assignment of `parent`
- 🔨 [services] Replace try...except with `contextlib.suppress`
- 🔨 [services] Do not build bogus parent if there is no parent revision
- 🔨 [packages] Move function `getparentrevision` to `providers.git`
- 🔨 [services] Slide assignment of `config1`
- 🔨 [services] Extract function `buildparentproject`
- 🔨 [projects] Inline function `buildproject` in `buildparentproject`
- 🔨 [projects] Inline function `createproject` in `buildparentproject`
- 🔨 [projects] Slide assignment of `templates`
- 🔨 [projects] Extract variable `parentrevision`
- 🔨 [projects] Inline variable `config`
- 🔨 [projects] Replace assignment and condition with walrus operator
- 🔨 [projects] Extract function `TemplateRepository.getparentrevision`
- 🔨 [packages] Extract function `PackageRepository.getparentrevision`
- 🔨 [packages] Push down function `getparentrevision` to `DefaultPackageRepository`
- 🔨 [packages] Add parameter `path` to `getparentrevision`
- 🔨 [packages] Add optional parameter `getparentrevision` for `DefaultPackageRepository`
- 🔨 [packages] Add optional parameter `getparentrevision` to `LocalProvider`
- 🔨 [packages] Add optional parameter `getparentrevision` to `RemoteProvider`
- 🔨 [packages] Add optional parameter `getparentrevision` to `RemoteProviderFactory`
- 🔨 [packages] Pass `getparentrevision` to git providers
