### PR TITLE
✨ [packages] Bail out on `cutty import` if template has no version history

### DIFF
--- a/src/cutty/entrypoints/cli/errors.py
+++ b/src/cutty/entrypoints/cli/errors.py
@@ -10,6 +10,7 @@ from cutty.packages.adapters.fetchers.mercurial import HgNotFoundError
 from cutty.packages.adapters.providers.git import RevisionNotFoundError
 from cutty.packages.domain.mounters import UnsupportedRevisionError
 from cutty.packages.domain.registry import UnknownLocationError
+from cutty.packages.domain.repository import ParentRevisionNotImplementedError
 from cutty.projects.project import EmptyTemplateError
 from cutty.projects.repository import NoUpdateInProgressError
 from cutty.services.link import TemplateNotSpecifiedError
@@ -97,6 +98,11 @@ def _mergeconflict(error: MergeConflictError) -> NoReturn:
     _die(f"Merge conflicts: {', '.join(error.paths)}")
 
 
+@exceptionhandler
+def _parentrevisionnotsupported(error: ParentRevisionNotImplementedError) -> NoReturn:
+    _die(f"repository {error.name} does not support retrieving the parent revision")
+
+
 fatal = (
     _unknownlocation
     >> _unsupportedrevision
@@ -110,4 +116,5 @@ fatal = (
     >> _emptytemplate
     >> _noupdateinprogress
     >> _mergeconflict
+    >> _parentrevisionnotsupported
 )

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -59,9 +59,10 @@ class DefaultPackageRepository(PackageRepository):
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
-        if self._getparentrevision is None:  # pragma: no cover
-            from cutty.packages.adapters.providers.git import getparentrevision
-
-            return getparentrevision(self.path, revision)
+        if self._getparentrevision is None:
+            raise NotImplementedError(
+                f"repository {self.name} does not support retrieving the parent "
+                "revision"
+            )
 
         return self._getparentrevision(self.path, revision)

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -3,13 +3,22 @@ import abc
 import pathlib
 from collections.abc import Callable
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Optional
 
 from cutty.compat.contextlib import contextmanager
+from cutty.errors import CuttyError
 from cutty.filesystems.domain.path import Path
 from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.package import Package
 from cutty.packages.domain.revisions import Revision
+
+
+@dataclass
+class ParentRevisionNotImplementedError(CuttyError):
+    """The repository does not support `getparentrevision`."""
+
+    name: str
 
 
 class PackageRepository(abc.ABC):
@@ -60,9 +69,6 @@ class DefaultPackageRepository(PackageRepository):
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
         if self._getparentrevision is None:
-            raise NotImplementedError(
-                f"repository {self.name} does not support retrieving the parent "
-                "revision"
-            )
+            raise ParentRevisionNotImplementedError(self.name)
 
         return self._getparentrevision(self.path, revision)

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -139,3 +139,18 @@ def test_conflict_message(
             runcutty("import")
 
     assert "cutty.json" not in str(exceptioninfo.value)
+
+
+def test_no_vcs(runcutty: RunCutty, template: Path, templateproject: Path) -> None:
+    """It returns with non-zero status if the template has no version history."""
+    location = "local+{}".format(template.as_uri())
+
+    runcutty("create", "--non-interactive", location)
+
+    project = Path("example")
+
+    updatefile(templateproject / "marker")
+
+    with pytest.raises(Exception, match="not support"):
+        with chdir(project):
+            runcutty("import")


### PR DESCRIPTION
- 🔨 [functional] Add test for `cutty import` without template version history
- 🔨 [packages] Bail out if repository does not support `getparentrevision`
- 🚸 [entrypoints] Improve error message when template has no version history
