### PR TITLE
✨ [packages] Resolve parent revisions in git provider

### DIFF
--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -77,7 +77,22 @@ def getparentrevision(
     path: pathlib.Path, revision: Optional[Revision]
 ) -> Optional[Revision]:
     """Return the parent revision, if any."""
-    return "HEAD^" if revision is None else f"{revision}^"
+    if revision is None:
+        revision = "HEAD"
+
+    repository = pygit2.Repository(path)
+
+    try:
+        commit = repository.revparse_single(revision).peel(pygit2.Commit)
+    except KeyError:
+        raise RevisionNotFoundError(revision)
+
+    if parents := commit.parents:
+        [parent] = parents
+
+        return str(parent.id)
+
+    return None
 
 
 localgitprovider = LocalProvider(

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -1,10 +1,8 @@
 """Building projects in a repository."""
-import contextlib
 from collections.abc import Iterator
 from typing import Optional
 
 from cutty.compat.contextlib import contextmanager
-from cutty.packages.adapters.providers.git import RevisionNotFoundError
 from cutty.projects.config import ProjectConfig
 from cutty.projects.generate import generate
 from cutty.projects.messages import MessageBuilder
@@ -72,10 +70,9 @@ def buildparentproject(
     provider = TemplateProvider.create()
     templates = provider.provide(config.template, config.directory)
 
-    if parentrevision := templates.getparentrevision(revision):  # pragma: no branch
-        with contextlib.suppress(RevisionNotFoundError):
-            with templates.get(parentrevision) as template:
-                project = generate(template, config.bindings, interactive=interactive)
-                return commitproject(repository, project, commitmessage=commitmessage)
+    if parentrevision := templates.getparentrevision(revision):
+        with templates.get(parentrevision) as template:
+            project = generate(template, config.bindings, interactive=interactive)
+            return commitproject(repository, project, commitmessage=commitmessage)
 
     return None

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -154,3 +154,10 @@ def test_no_vcs(runcutty: RunCutty, template: Path, templateproject: Path) -> No
     with pytest.raises(Exception, match="not support"):
         with chdir(project):
             runcutty("import")
+
+
+def test_invalid_revision(runcutty: RunCutty, project: Path) -> None:
+    """It applies the latest changeset by default."""
+    with pytest.raises(Exception, match="revision not found"):
+        with chdir(project):
+            runcutty("import", "--revision=invalid")


### PR DESCRIPTION
- 🔨 [packages] Resolve parent revision in `git.getparentrevision`
- 🔨 [functional] Add test for `cutty import --revision` with invalid argument
- 🔨 [projects] Remove obsolete exception handling for `RevisionNotFoundError`
