### PR TITLE
✨ [packages] Resolve parent revisions in Mercurial provider

### DIFF
--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -48,7 +48,7 @@ def getparentrevision(
     if revision is None:
         revision = "."
 
-    return getrevision(path, f"p1({revision})")
+    return getrevision(path, f"p1({revision})") or None
 
 
 hgproviderfactory = RemoteProviderFactory(

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -55,12 +55,7 @@ def getparentrevision(
     if revision is None:
         revision = "."
 
-    result = hg(
-        "log",
-        f"--rev={revision}",
-        "--template={ifeq(latesttagdistance, 0, latesttag, short(node))}",
-        cwd=path,
-    )
+    result = hg("log", f"--rev={revision}", "--template={node}", cwd=path)
 
     parentrevision = result.stdout
 

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -41,6 +41,20 @@ def mount(path: pathlib.Path, revision: Optional[Revision]) -> Iterator[Filesyst
         yield DiskFilesystem(pathlib.Path(directory))
 
 
+def getparentrevision(
+    path: pathlib.Path, revision: Optional[Revision]
+) -> Optional[Revision]:
+    """Return the parent revision, if any."""
+    if revision is None:
+        revision = "."
+
+    return getrevision(path, f"p1({revision})")
+
+
 hgproviderfactory = RemoteProviderFactory(
-    "hg", fetch=[hgfetcher], getrevision=getrevision, mount=mount
+    "hg",
+    fetch=[hgfetcher],
+    getrevision=getrevision,
+    getparentrevision=getparentrevision,
+    mount=mount,
 )

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -52,9 +52,7 @@ def getparentrevision(
 
     result = hg("log", f"--rev=p1({revision})", "--template={node}", cwd=path)
 
-    parentrevision = result.stdout
-
-    return parentrevision or None
+    return result.stdout or None
 
 
 hgproviderfactory = RemoteProviderFactory(

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -48,11 +48,9 @@ def getparentrevision(
     if revision is None:
         revision = "."
 
-    revision = f"p1({revision})"
-
     hg = findhg()
 
-    result = hg("log", f"--rev={revision}", "--template={node}", cwd=path)
+    result = hg("log", f"--rev=p1({revision})", "--template={node}", cwd=path)
 
     parentrevision = result.stdout
 

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -48,7 +48,23 @@ def getparentrevision(
     if revision is None:
         revision = "."
 
-    return getrevision(path, f"p1({revision})") or None
+    revision = f"p1({revision})"
+
+    hg = findhg()
+
+    if revision is None:
+        revision = "."
+
+    result = hg(
+        "log",
+        f"--rev={revision}",
+        "--template={ifeq(latesttagdistance, 0, latesttag, short(node))}",
+        cwd=path,
+    )
+
+    parentrevision = result.stdout
+
+    return parentrevision or None
 
 
 hgproviderfactory = RemoteProviderFactory(

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -52,9 +52,6 @@ def getparentrevision(
 
     hg = findhg()
 
-    if revision is None:
-        revision = "."
-
     result = hg("log", f"--rev={revision}", "--template={node}", cwd=path)
 
     parentrevision = result.stdout

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -45,10 +45,10 @@ def getparentrevision(
     path: pathlib.Path, revision: Optional[Revision]
 ) -> Optional[Revision]:
     """Return the parent revision, if any."""
+    hg = findhg()
+
     if revision is None:
         revision = "."
-
-    hg = findhg()
 
     result = hg("log", f"--rev=p1({revision})", "--template={node}", cwd=path)
 

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -164,3 +164,15 @@ def test_revision_not_found(hgprovider: Provider, hgrepository: pathlib.Path) ->
         if repository := hgprovider.provide(hgrepository):
             with repository.get("invalid"):
                 pass
+
+
+def test_parent_revision_tip(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
+    """It returns the parent revision of the tip."""
+    repository = hgprovider.provide(hgrepository)
+
+    assert repository is not None
+
+    revision = repository.getparentrevision(None)
+
+    with repository.get(revision) as package:
+        assert "Lorem" == (package.tree / "marker").read_text()

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -176,3 +176,14 @@ def test_parent_revision_tip(hgprovider: Provider, hgrepository: pathlib.Path) -
 
     with repository.get(revision) as package:
         assert "Lorem" == (package.tree / "marker").read_text()
+
+
+def test_parent_revision_root(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
+    """It returns None for the parent revision of the root."""
+    repository = hgprovider.provide(hgrepository)
+
+    assert repository is not None
+
+    revision = repository.getparentrevision("v1.0")
+
+    assert revision is None

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -73,6 +73,11 @@ def is_mercurial_shorthash(revision: str) -> bool:
     return len(revision) == 12 and all(c in string.hexdigits for c in revision)
 
 
+def is_mercurial_hash(revision: str) -> bool:
+    """Return True if the text is a full changeset identification hash."""
+    return len(revision) == 40 and all(c in string.hexdigits for c in revision)
+
+
 def test_revision_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     """It retrieves the short hash as the package revision."""
     repository = hgprovider.provide(hgrepository)
@@ -187,3 +192,15 @@ def test_parent_revision_root(hgprovider: Provider, hgrepository: pathlib.Path) 
     revision = repository.getparentrevision("v1.0")
 
     assert revision is None
+
+
+def test_parent_revision_hash(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
+    """It returns the full revision identifier."""
+    repository = hgprovider.provide(hgrepository)
+
+    assert repository is not None
+
+    # Skip over the changeset adding the tag.
+    revision = repository.getparentrevision(repository.getparentrevision(None))
+
+    assert revision is not None and is_mercurial_hash(revision)


### PR DESCRIPTION
- 🔨 [packages] Add test for `mercurial.getparentrevision(None)`
- ✨ [packages] Implement `getparentrevision` for `hgproviderfactory`
- 🔨 [packages] Add test for `mercurial.getparentrevision(<root>)`
- ✨ [packages] Return `None` as parent revision of root commit
- ✅ [packages] Add test for `mercurial.getparentrevision` returning full hash
- 🔨 [packages] Inline function `getrevision` in `getparentrevision`
- ✨ [packages] Return the full hash from `mercurial.getparentrevision`
- 🔨 [packages] Remove dead code
- 🔨 [packages] Inline variable `revision`
- 🔨 [packages] Inline variable `parentrevision`
- 🔨 [packages] Slide statement
