### PR TITLE
✨ [projects] Store full commit identifier in cutty.json

### DIFF
--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -45,6 +45,21 @@ def mount(path: pathlib.Path, revision: Optional[Revision]) -> Iterator[GitFiles
         yield GitFilesystem(path)
 
 
+def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
+    """Return the commit identifier."""
+    if revision is None:
+        revision = "HEAD"
+
+    repository = pygit2.Repository(path)
+
+    try:
+        commit = repository.revparse_single(revision).peel(pygit2.Commit)
+    except KeyError:
+        raise RevisionNotFoundError(revision)
+
+    return str(commit.id)
+
+
 def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
     """Return the package revision."""
     if revision is None:
@@ -54,7 +69,7 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
 
     try:
         commit = repository.revparse_single(revision).peel(pygit2.Commit)
-    except KeyError:
+    except KeyError:  # pragma: no cover
         raise RevisionNotFoundError(revision)
 
     try:
@@ -99,6 +114,7 @@ localgitprovider = LocalProvider(
     "localgit",
     match=match,
     mount=mount,
+    getcommit=getcommit,
     getrevision=getrevision,
     getparentrevision=getparentrevision,
 )
@@ -107,6 +123,7 @@ gitproviderfactory = RemoteProviderFactory(
     "git",
     fetch=[gitfetcher],
     mount=mount,
+    getcommit=getcommit,
     getrevision=getrevision,
     getparentrevision=getparentrevision,
 )

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -13,6 +13,17 @@ from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.revisions import Revision
 
 
+def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
+    """Return the commit identifier."""
+    hg = findhg()
+
+    if revision is None:
+        revision = "."
+
+    result = hg("log", f"--rev={revision}", "--template={node}", cwd=path)
+    return result.stdout
+
+
 def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
     """Return the package revision."""
     hg = findhg()
@@ -58,6 +69,7 @@ def getparentrevision(
 hgproviderfactory = RemoteProviderFactory(
     "hg",
     fetch=[hgfetcher],
+    getcommit=getcommit,
     getrevision=getrevision,
     getparentrevision=getparentrevision,
     mount=mount,

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -17,6 +17,7 @@ class Package:
     name: str
     tree: Path
     revision: Optional[Revision]
+    commit: Optional[str] = None
 
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -22,9 +22,6 @@ class Package:
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""
         tree = self.tree.joinpath(*directory.parts)
-        return Package(
-            directory.name,
-            Path(filesystem=PathFilesystem(tree)),
-            self.revision,
-            self.commit,
-        )
+        tree = Path(filesystem=PathFilesystem(tree))
+
+        return Package(directory.name, tree, self.revision, self.commit)

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -26,4 +26,5 @@ class Package:
             directory.name,
             Path(filesystem=PathFilesystem(tree)),
             self.revision,
+            self.commit,
         )

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -45,6 +45,7 @@ class LocalProvider(Provider):
         *,
         match: PathMatcher,
         mount: Mounter,
+        getcommit: Optional[GetRevision] = None,
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
     ) -> None:
@@ -53,6 +54,7 @@ class LocalProvider(Provider):
 
         self.match = match
         self.mount = mount
+        self.getcommit = getcommit
         self.getrevision = getrevision
         self.getparentrevision = getparentrevision
 
@@ -64,6 +66,7 @@ class LocalProvider(Provider):
                     location.name,
                     path,
                     mount=self.mount,
+                    getcommit=self.getcommit,
                     getrevision=self.getrevision,
                     getparentrevision=self.getparentrevision,
                 )
@@ -89,6 +92,7 @@ class RemoteProvider(Provider):
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
+        getcommit: Optional[GetRevision] = None,
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
         store: Store,
@@ -106,6 +110,7 @@ class RemoteProvider(Provider):
         self.fetch = tuple(fetch)
         self.store = store
         self.mount = mount
+        self.getcommit = getcommit
         self.getrevision = getrevision
         self.getparentrevision = getparentrevision
 
@@ -126,6 +131,7 @@ class RemoteProvider(Provider):
                         location.name,
                         path,
                         mount=self.mount,
+                        getcommit=self.getcommit,
                         getrevision=self.getrevision,
                         getparentrevision=self.getparentrevision,
                     )
@@ -156,6 +162,7 @@ class RemoteProviderFactory(ProviderFactory):
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
+        getcommit: Optional[GetRevision] = None,
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
     ) -> None:
@@ -164,6 +171,7 @@ class RemoteProviderFactory(ProviderFactory):
         self.match = match
         self.fetch = tuple(fetch)
         self.mount = mount
+        self.getcommit = getcommit
         self.getrevision = getrevision
         self.getparentrevision = getparentrevision
 
@@ -174,6 +182,7 @@ class RemoteProviderFactory(ProviderFactory):
             match=self.match,
             fetch=self.fetch,
             mount=self.mount,
+            getcommit=self.getcommit,
             getrevision=self.getrevision,
             getparentrevision=self.getparentrevision,
             store=store,

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -52,14 +52,14 @@ class DefaultPackageRepository(PackageRepository):
         self.name = name
         self.path = path
         self.mount = mount
-        self.getrevision = getrevision
+        self._getrevision = getrevision
         self._getparentrevision = getparentrevision
 
     @contextmanager
     def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
         """Retrieve the package with the given revision."""
-        if self.getrevision is not None:
-            resolved_revision = self.getrevision(self.path, revision)
+        if self._getrevision is not None:
+            resolved_revision = self._getrevision(self.path, revision)
         else:
             resolved_revision = revision
 

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -65,10 +65,10 @@ class DefaultPackageRepository(PackageRepository):
 
     def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the resolved revision."""
-        if self._getrevision is not None:
-            return self._getrevision(self.path, revision)
-        else:
+        if self._getrevision is None:
             return revision
+
+        return self._getrevision(self.path, revision)
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -45,6 +45,7 @@ class DefaultPackageRepository(PackageRepository):
         path: pathlib.Path,
         *,
         mount: Mounter,
+        getcommit: Optional[GetRevision] = None,
         getrevision: Optional[GetRevision],
         getparentrevision: Optional[GetRevision] = None,
     ) -> None:
@@ -52,6 +53,7 @@ class DefaultPackageRepository(PackageRepository):
         self.name = name
         self.path = path
         self.mount = mount
+        self._getcommit = getcommit
         self._getrevision = getrevision
         self._getparentrevision = getparentrevision
 
@@ -62,6 +64,13 @@ class DefaultPackageRepository(PackageRepository):
 
         with self.mount(self.path, revision) as filesystem:
             yield Package(self.name, Path(filesystem=filesystem), resolved_revision)
+
+    def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
+        """Return the commit identifier."""
+        if self._getcommit is None:
+            return None
+
+        return self._getcommit(self.path, revision)
 
     def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the resolved revision."""

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -60,10 +60,13 @@ class DefaultPackageRepository(PackageRepository):
     @contextmanager
     def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
         """Retrieve the package with the given revision."""
+        commit = self.getcommit(revision)
         resolved_revision = self.getrevision(revision)
 
         with self.mount(self.path, revision) as filesystem:
-            yield Package(self.name, Path(filesystem=filesystem), resolved_revision)
+            yield Package(
+                self.name, Path(filesystem=filesystem), resolved_revision, commit
+            )
 
     def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the commit identifier."""

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -58,13 +58,17 @@ class DefaultPackageRepository(PackageRepository):
     @contextmanager
     def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
         """Retrieve the package with the given revision."""
-        if self._getrevision is not None:
-            resolved_revision = self._getrevision(self.path, revision)
-        else:
-            resolved_revision = revision
+        resolved_revision = self.getrevision(revision)
 
         with self.mount(self.path, revision) as filesystem:
             yield Package(self.name, Path(filesystem=filesystem), resolved_revision)
+
+    def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
+        """Return the resolved revision."""
+        if self._getrevision is not None:
+            return self._getrevision(self.path, revision)
+        else:
+            return revision
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -64,9 +64,9 @@ class DefaultPackageRepository(PackageRepository):
         resolved_revision = self.getrevision(revision)
 
         with self.mount(self.path, revision) as filesystem:
-            yield Package(
-                self.name, Path(filesystem=filesystem), resolved_revision, commit
-            )
+            tree = Path(filesystem=filesystem)
+
+            yield Package(self.name, tree, resolved_revision, commit)
 
     def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the commit identifier."""

--- a/src/cutty/projects/generator.py
+++ b/src/cutty/projects/generator.py
@@ -54,11 +54,16 @@ class ProjectGenerator:
 
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
+        revision = (
+            project.template.commit
+            if project.template.commit is not None
+            else project.template.revision
+        )
         projectconfig = ProjectConfig(
             project.template.location,
             bindings,
             directory=project.template.directory,
-            revision=project.template.revision,
+            revision=revision,
         )
         projectconfigfile = createprojectconfigfile(
             PurePath(project.name), projectconfig

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -56,7 +56,11 @@ class TemplateRepository:
                 package = package.descend(PurePath(*self.directory.parts))
 
             metadata = Template.Metadata(
-                self.location, self.directory, package.name, package.revision
+                self.location,
+                self.directory,
+                package.name,
+                package.revision,
+                package.commit,
             )
 
             yield Template(metadata, package.tree)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -78,6 +78,7 @@ class Template:
         directory: Optional[pathlib.Path]
         name: str
         revision: Optional[Revision]
+        commit: Optional[str] = None
 
     metadata: Metadata
     root: Path

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -1,9 +1,11 @@
 """Functional tests for the create CLI."""
+import string
 from pathlib import Path
 
 import pytest
 
 from cutty.projects.config import PROJECT_CONFIG_FILE
+from cutty.projects.config import readprojectconfigfile
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
 from tests.functional.conftest import RunCuttyError
@@ -190,3 +192,16 @@ def test_conflict(runcutty: RunCutty, template: Path) -> None:
         runcutty("create", str(template))
 
     assert ">>>>" in conflicting.read_text()
+
+
+def test_commit_hash(runcutty: RunCutty, template: Path) -> None:
+    """It stores the commit hash."""
+    runcutty("create", str(template))
+
+    revision = readprojectconfigfile(Path("example")).revision
+
+    assert (
+        revision is not None
+        and len(revision) == 40
+        and all(c in string.hexdigits for c in revision)
+    )

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -204,3 +204,13 @@ def test_parent_revision_hash(hgprovider: Provider, hgrepository: pathlib.Path) 
     revision = repository.getparentrevision(repository.getparentrevision(None))
 
     assert revision is not None and is_mercurial_hash(revision)
+
+
+def test_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
+    """It returns the full revision identifier."""
+    repository = hgprovider.provide(hgrepository)
+
+    assert repository is not None
+
+    with repository.get(None) as package:
+        assert package.commit is not None and is_mercurial_hash(package.commit)


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty create` storing full commit hash
- 🔨 [projects] Add optional attribute `Template.Metadata.commit`
- 🔨 [projects] Store `Template.Metadata.commit` in cutty.json if set
- 🔨 [packages] Add optional attribute `Package.commit`
- 🔨 [projects] Initialize `Template.Metadata.commit` from `Package.commit`
- 🔨 [packages] Extract variable `tree`
- 🔨 [packages] Rename attribute `DefaultPackageRepository.{ => _}getrevision`
- 🔨 [packages] Extract function `DefaultPackageRepository.getrevision`
- 🔨 [packages] Replace nested `if` statement with guard clause
- 🔨 [packages] Add `getcommit` hook to `DefaultPackageRepository`
- 🔨 [packages] Use `getcommit` hook to initialize `Package.commit`
- 🔨 [packages] Extract variable `tree`
- 🔨 [packages] Add `getcommit` hook to `{Local,Remote}Provider{,Factory}`
- 🔨 [packages] Add `getcommit` hook for git providers
- ✅ [packages] Add test for `getcommit` hook of Mercurial provider
- 🔨 [packages] Implement `getcommit` hook for Mercurial provider
