### PR TITLE
🔨 [projects] Move conflict resolution from `services.import_` to `ProjectRepository.import_`

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -111,11 +111,12 @@ class ProjectRepository:
             self.project.cherrypick(cherry)
         except MergeConflictError:
             try:
-                path = self.project.path / "cutty.json"
                 side = Side.THEIRS
 
                 repository = pygit2.Repository(self.project.path)
-                pathstr = str(path.relative_to(self.project.path))
+                pathstr = str(
+                    (self.project.path / "cutty.json").relative_to(self.project.path)
+                )
                 ancestor, ours, theirs = repository.index.conflicts[pathstr]
                 resolution = (ancestor, ours, theirs)[side.value]
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -118,8 +118,6 @@ class ProjectRepository:
             except KeyError:
                 pass
 
-            index.read()
-
             if index.conflicts:
                 raise MergeConflictError.fromindex(index)
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -106,12 +106,12 @@ class ProjectRepository:
             index = repository.index
 
             try:
-                _, _, theirs = repository.index.conflicts[PROJECT_CONFIG_FILE]
+                _, _, theirs = index.conflicts[PROJECT_CONFIG_FILE]
 
-                del repository.index.conflicts[PROJECT_CONFIG_FILE]
+                del index.conflicts[PROJECT_CONFIG_FILE]
 
-                repository.index.add(theirs)
-                repository.index.write()
+                index.add(theirs)
+                index.write()
                 repository.checkout(
                     strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[PROJECT_CONFIG_FILE]
                 )

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -103,9 +103,7 @@ class ProjectRepository:
         except MergeConflictError:
             try:
                 repository = pygit2.Repository(self.project.path)
-                pathstr = str(
-                    (self.project.path / "cutty.json").relative_to(self.project.path)
-                )
+                pathstr = "cutty.json"
                 ancestor, ours, theirs = repository.index.conflicts[pathstr]
 
                 del repository.index.conflicts[pathstr]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -103,7 +103,7 @@ class ProjectRepository:
             self.project.cherrypick(cherry)
         except MergeConflictError:
             try:
-                repository = pygit2.Repository(self.project.path)
+                repository = self.project._repository
                 _, _, theirs = repository.index.conflicts[PROJECT_CONFIG_FILE]
 
                 del repository.index.conflicts[PROJECT_CONFIG_FILE]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -11,6 +11,7 @@ import pygit2
 
 from cutty.compat.contextlib import contextmanager
 from cutty.errors import CuttyError
+from cutty.projects.config import PROJECT_CONFIG_FILE
 from cutty.util.git import MergeConflictError
 from cutty.util.git import Repository
 
@@ -103,7 +104,7 @@ class ProjectRepository:
         except MergeConflictError:
             try:
                 repository = pygit2.Repository(self.project.path)
-                pathstr = "cutty.json"
+                pathstr = PROJECT_CONFIG_FILE
                 ancestor, ours, theirs = repository.index.conflicts[pathstr]
 
                 del repository.index.conflicts[pathstr]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -116,7 +116,7 @@ class ProjectRepository:
             except KeyError:
                 pass
 
-            index = self.project._repository.index
+            index = repository.index
             index.read()
 
             if index.conflicts:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -118,16 +118,7 @@ class ProjectRepository:
             self._cherrypick(cherry)
             return
 
-        for path in paths:
-            (self.project.path / path).write_bytes((cherry.tree / path).data)
-            self.project._repository.index.add(path)
-
-        self.project.commit(
-            message=cherry.message,
-            author=cherry.author,
-            committer=self.project.default_signature,
-            stageallfiles=False,
-        )
+        self._cherrypickpaths(cherry, paths)
 
     def _cherrypick(self, cherry: pygit2.Commit) -> None:
         """Import changes to the project made by the given commit."""
@@ -148,6 +139,19 @@ class ProjectRepository:
                 raise MergeConflictError.fromindex(index)
 
             self.continue_()
+
+    def _cherrypickpaths(self, cherry: pygit2.Commit, paths: Iterable[Path]) -> None:
+        """Import changes to the project made by the given commit."""
+        for path in paths:
+            (self.project.path / path).write_bytes((cherry.tree / path).data)
+            self.project._repository.index.add(path)
+
+        self.project.commit(
+            message=cherry.message,
+            author=cherry.author,
+            committer=self.project.default_signature,
+            stageallfiles=False,
+        )
 
     def continue_(self) -> None:
         """Continue an update after conflict resolution."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -111,14 +111,12 @@ class ProjectRepository:
             self.project.cherrypick(cherry)
         except MergeConflictError:
             try:
-                side = Side.THEIRS
-
                 repository = pygit2.Repository(self.project.path)
                 pathstr = str(
                     (self.project.path / "cutty.json").relative_to(self.project.path)
                 )
                 ancestor, ours, theirs = repository.index.conflicts[pathstr]
-                resolution = (ancestor, ours, theirs)[side.value]
+                resolution = (ancestor, ours, theirs)[Side.THEIRS.value]
 
                 del repository.index.conflicts[pathstr]
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -107,7 +107,9 @@ class ProjectRepository:
 
             try:
                 _, _, theirs = index.conflicts[PROJECT_CONFIG_FILE]
-
+            except KeyError:
+                pass
+            else:
                 del index.conflicts[PROJECT_CONFIG_FILE]
 
                 index.add(theirs)
@@ -115,8 +117,6 @@ class ProjectRepository:
                 repository.checkout(
                     strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[PROJECT_CONFIG_FILE]
                 )
-            except KeyError:
-                pass
 
             if index.conflicts:
                 raise MergeConflictError.fromindex(index)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -107,11 +107,10 @@ class ProjectRepository:
                     (self.project.path / "cutty.json").relative_to(self.project.path)
                 )
                 ancestor, ours, theirs = repository.index.conflicts[pathstr]
-                resolution = (ancestor, ours, theirs)[2]
 
                 del repository.index.conflicts[pathstr]
 
-                repository.index.add(resolution)
+                repository.index.add(theirs)
                 repository.index.write()
                 repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[pathstr])
             except KeyError:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -102,8 +102,10 @@ class ProjectRepository:
         try:
             self.project.cherrypick(cherry)
         except MergeConflictError:
+            repository = self.project._repository
+            index = repository.index
+
             try:
-                repository = self.project._repository
                 _, _, theirs = repository.index.conflicts[PROJECT_CONFIG_FILE]
 
                 del repository.index.conflicts[PROJECT_CONFIG_FILE]
@@ -116,7 +118,6 @@ class ProjectRepository:
             except KeyError:
                 pass
 
-            index = repository.index
             index.read()
 
             if index.conflicts:

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -114,11 +114,10 @@ class ProjectRepository:
         """Import changes to the project made by the given commit."""
         cherry = self.project._repository[commit]
 
-        if not paths:
+        if paths:
+            self._cherrypickpaths(cherry, paths)
+        else:
             self._cherrypick(cherry)
-            return
-
-        self._cherrypickpaths(cherry, paths)
 
     def _cherrypick(self, cherry: pygit2.Commit) -> None:
         """Import changes to the project made by the given commit."""

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -1,7 +1,6 @@
 """Project repositories."""
 from __future__ import annotations
 
-import enum
 from collections.abc import Iterable
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -17,14 +16,6 @@ from cutty.util.git import Repository
 
 
 UPDATE_BRANCH = "cutty/update"
-
-
-class Side(enum.Enum):
-    """The side of a conflict."""
-
-    ANCESTOR = 0
-    OURS = 1
-    THEIRS = 2
 
 
 class NoUpdateInProgressError(CuttyError):
@@ -116,7 +107,7 @@ class ProjectRepository:
                     (self.project.path / "cutty.json").relative_to(self.project.path)
                 )
                 ancestor, ours, theirs = repository.index.conflicts[pathstr]
-                resolution = (ancestor, ours, theirs)[Side.THEIRS.value]
+                resolution = (ancestor, ours, theirs)[2]
 
                 del repository.index.conflicts[pathstr]
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -101,14 +101,14 @@ class ProjectRepository:
         """Import changes to the project made by the given commit."""
         try:
             self.project.cherrypick(cherry)
-        except MergeConflictError as error:
+        except MergeConflictError:
             repository = self.project._repository
             index = repository.index
 
             try:
                 _, _, theirs = index.conflicts[PROJECT_CONFIG_FILE]
             except KeyError:
-                raise error from None
+                raise MergeConflictError.fromindex(index)
 
             del index.conflicts[PROJECT_CONFIG_FILE]
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -111,12 +111,11 @@ class ProjectRepository:
             self.project.cherrypick(cherry)
         except MergeConflictError:
             try:
-                repositorypath = self.project.path
                 path = self.project.path / "cutty.json"
                 side = Side.THEIRS
 
-                repository = pygit2.Repository(repositorypath)
-                pathstr = str(path.relative_to(repositorypath))
+                repository = pygit2.Repository(self.project.path)
+                pathstr = str(path.relative_to(self.project.path))
                 ancestor, ours, theirs = repository.index.conflicts[pathstr]
                 resolution = (ancestor, ours, theirs)[side.value]
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -101,22 +101,22 @@ class ProjectRepository:
         """Import changes to the project made by the given commit."""
         try:
             self.project.cherrypick(cherry)
-        except MergeConflictError:
+        except MergeConflictError as error:
             repository = self.project._repository
             index = repository.index
 
             try:
                 _, _, theirs = index.conflicts[PROJECT_CONFIG_FILE]
             except KeyError:
-                pass
-            else:
-                del index.conflicts[PROJECT_CONFIG_FILE]
+                raise error from None
 
-                index.add(theirs)
-                index.write()
-                repository.checkout(
-                    strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[PROJECT_CONFIG_FILE]
-                )
+            del index.conflicts[PROJECT_CONFIG_FILE]
+
+            index.add(theirs)
+            index.write()
+            repository.checkout(
+                strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[PROJECT_CONFIG_FILE]
+            )
 
             if index.conflicts:
                 raise MergeConflictError.fromindex(index)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -104,14 +104,15 @@ class ProjectRepository:
         except MergeConflictError:
             try:
                 repository = pygit2.Repository(self.project.path)
-                pathstr = PROJECT_CONFIG_FILE
-                ancestor, ours, theirs = repository.index.conflicts[pathstr]
+                ancestor, ours, theirs = repository.index.conflicts[PROJECT_CONFIG_FILE]
 
-                del repository.index.conflicts[pathstr]
+                del repository.index.conflicts[PROJECT_CONFIG_FILE]
 
                 repository.index.add(theirs)
                 repository.index.write()
-                repository.checkout(strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[pathstr])
+                repository.checkout(
+                    strategy=pygit2.GIT_CHECKOUT_FORCE, paths=[PROJECT_CONFIG_FILE]
+                )
             except KeyError:
                 pass
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -104,7 +104,7 @@ class ProjectRepository:
         except MergeConflictError:
             try:
                 repository = pygit2.Repository(self.project.path)
-                ancestor, ours, theirs = repository.index.conflicts[PROJECT_CONFIG_FILE]
+                _, _, theirs = repository.index.conflicts[PROJECT_CONFIG_FILE]
 
                 del repository.index.conflicts[PROJECT_CONFIG_FILE]
 

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -184,9 +184,9 @@ def test_existing_project_files(runcutty: RunCutty, template: Path) -> None:
 def test_conflict(runcutty: RunCutty, template: Path) -> None:
     """It produces conflict markers if files have conflicting changes."""
     project = Repository.init(Path("example"))
-    conflicting = project.path / "cutty.json"
+    conflicting = project.path / "README.md"
 
-    updatefile(conflicting, "null")
+    updatefile(conflicting, "teapot")
 
     with pytest.raises(Exception, match="conflict"):
         runcutty("create", str(template))

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -194,6 +194,18 @@ def test_conflict(runcutty: RunCutty, template: Path) -> None:
     assert ">>>>" in conflicting.read_text()
 
 
+def test_conflict_cutty_json(runcutty: RunCutty, template: Path) -> None:
+    """It resolves conflicts in cutty.json in favor of the new version."""
+    project = Repository.init(Path("example"))
+    conflicting = project.path / "cutty.json"
+
+    updatefile(conflicting, "null")
+
+    runcutty("create", str(template))
+
+    assert ">>>>" not in conflicting.read_text()
+
+
 def test_commit_hash(runcutty: RunCutty, template: Path) -> None:
     """It stores the commit hash."""
     runcutty("create", str(template))


### PR DESCRIPTION
- 🔨 [projects] Move conflict resolution from `services.import_` to `ProjectRepository.import_`
- ✅ [functional] Adapt test for `cutty create` with conflicts
- 🔨 [functional] Add test for `cutty create` with conflicts in cutty.json
- 🔨 [projects] Extract function `ProjectRepository._cherrypick`
- 🔨 [projects] Extract function `ProjectRepository._cherrypickpaths`
- 🔨 [projects] Replace guard clause with nested conditional
- 🔨 [projects] Inline function `resolveconflicts`
- 🔨 [projects] Inline variable `repositorypath`
- 🔨 [projects] Inline variable `path`
- 🔨 [projects] Inline variable `side`
- 🔨 [projects] Inline enum `Side`
- 🔨 [projects] Inline variable `resolution`
- 🔨 [projects] Simplify variable assignment for `pathstr`
- 🔨 [projects] Replace literal with constant `PROJECT_CONFIG_FILE`
- 🔨 [projects] Inline variable `pathstr`
- 🔨 [projects] Rename unused variables to `_`
- 🔨 [projects] Eliminate redundant copy of `pygit2.Repository`
- 🔨 [projects] Replace query with temp `repository`
- 🔨 [projects] Slide statements
- 🔨 [projects] Replace query with temp `index`
- 🔨 [projects] Remove redundant `index.read()`
- 🔨 [projects] Use try...else to reduce scope of try clause
- 🔨 [projects] Eliminate `else` clause by re-raising original exception
- 🔨 [projects] Raise new exception instead of current one
- 🔨 [projects] Extract function `ProjectRepository._resolveconflicts`
