### PR TITLE
✨ [packages] Preserve commit message in `cutty import`

### DIFF
--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -110,6 +110,22 @@ def getparentrevision(
     return None
 
 
+def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:
+    """Return the commit message."""
+    if revision is None:
+        revision = "HEAD"
+
+    repository = pygit2.Repository(path)
+
+    try:
+        commit = repository.revparse_single(revision).peel(pygit2.Commit)
+    except KeyError:  # pragma: no cover
+        raise RevisionNotFoundError(revision)
+
+    message: str = commit.message
+    return message
+
+
 localgitprovider = LocalProvider(
     "localgit",
     match=match,
@@ -117,6 +133,7 @@ localgitprovider = LocalProvider(
     getcommit=getcommit,
     getrevision=getrevision,
     getparentrevision=getparentrevision,
+    getmessage=getmessage,
 )
 
 gitproviderfactory = RemoteProviderFactory(
@@ -126,4 +143,5 @@ gitproviderfactory = RemoteProviderFactory(
     getcommit=getcommit,
     getrevision=getrevision,
     getparentrevision=getparentrevision,
+    getmessage=getmessage,
 )

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -66,11 +66,23 @@ def getparentrevision(
     return result.stdout or None
 
 
+def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:
+    """Return the commit message."""
+    hg = findhg()
+
+    if revision is None:
+        revision = "."
+
+    result = hg("log", f"--rev={revision}", "--template={desc}", cwd=path)
+    return result.stdout
+
+
 hgproviderfactory = RemoteProviderFactory(
     "hg",
     fetch=[hgfetcher],
     getcommit=getcommit,
     getrevision=getrevision,
     getparentrevision=getparentrevision,
+    getmessage=getmessage,
     mount=mount,
 )

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -18,10 +18,11 @@ class Package:
     tree: Path
     revision: Optional[Revision]
     commit: Optional[str] = None
+    message: Optional[str] = None
 
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""
         tree = self.tree.joinpath(*directory.parts)
         tree = Path(filesystem=PathFilesystem(tree))
 
-        return Package(directory.name, tree, self.revision, self.commit)
+        return Package(directory.name, tree, self.revision, self.commit, self.message)

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -18,6 +18,7 @@ from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.matchers import PathMatcher
 from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.repository import DefaultPackageRepository
+from cutty.packages.domain.repository import GetMessage
 from cutty.packages.domain.repository import GetRevision
 from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
@@ -48,6 +49,7 @@ class LocalProvider(Provider):
         getcommit: Optional[GetRevision] = None,
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
+        getmessage: Optional[GetMessage] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
@@ -57,6 +59,7 @@ class LocalProvider(Provider):
         self.getcommit = getcommit
         self.getrevision = getrevision
         self.getparentrevision = getparentrevision
+        self.getmessage = getmessage
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
@@ -69,6 +72,7 @@ class LocalProvider(Provider):
                     getcommit=self.getcommit,
                     getrevision=self.getrevision,
                     getparentrevision=self.getparentrevision,
+                    getmessage=self.getmessage,
                 )
 
         return None
@@ -95,6 +99,7 @@ class RemoteProvider(Provider):
         getcommit: Optional[GetRevision] = None,
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
+        getmessage: Optional[GetMessage] = None,
         store: Store,
     ) -> None:
         """Initialize."""
@@ -113,6 +118,7 @@ class RemoteProvider(Provider):
         self.getcommit = getcommit
         self.getrevision = getrevision
         self.getparentrevision = getparentrevision
+        self.getmessage = getmessage
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
@@ -134,6 +140,7 @@ class RemoteProvider(Provider):
                         getcommit=self.getcommit,
                         getrevision=self.getrevision,
                         getparentrevision=self.getparentrevision,
+                        getmessage=self.getmessage,
                     )
 
         return None
@@ -165,6 +172,7 @@ class RemoteProviderFactory(ProviderFactory):
         getcommit: Optional[GetRevision] = None,
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
+        getmessage: Optional[GetMessage] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
@@ -174,6 +182,7 @@ class RemoteProviderFactory(ProviderFactory):
         self.getcommit = getcommit
         self.getrevision = getrevision
         self.getparentrevision = getparentrevision
+        self.getmessage = getmessage
 
     def __call__(self, store: Store) -> Provider:
         """Create a provider."""
@@ -185,6 +194,7 @@ class RemoteProviderFactory(ProviderFactory):
             getcommit=self.getcommit,
             getrevision=self.getrevision,
             getparentrevision=self.getparentrevision,
+            getmessage=self.getmessage,
             store=store,
         )
 

--- a/src/cutty/projects/messages.py
+++ b/src/cutty/projects/messages.py
@@ -29,3 +29,11 @@ def linkcommitmessage(template: Template.Metadata) -> str:
         return f"Link to {template.name} {template.revision}"
     else:
         return f"Link to {template.name}"
+
+
+def importcommitmessage(template: Template.Metadata) -> str:
+    """Build the commit message for importing a template commit."""
+    if template.message:
+        return template.message
+    else:
+        return updatecommitmessage(template)

--- a/src/cutty/projects/messages.py
+++ b/src/cutty/projects/messages.py
@@ -35,5 +35,5 @@ def importcommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for importing a template commit."""
     if template.message:
         return template.message
-    else:
+    else:  # pragma: no cover
         return updatecommitmessage(template)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -61,6 +61,7 @@ class TemplateRepository:
                 package.name,
                 package.revision,
                 package.commit,
+                package.message,
             )
 
             yield Template(metadata, package.tree)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -83,6 +83,7 @@ class Template:
         name: str
         revision: Optional[Revision]
         commit: Optional[str] = None
+        message: Optional[str] = None
 
     metadata: Metadata
     root: Path

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -6,7 +6,7 @@ from cutty.projects.build import buildparentproject
 from cutty.projects.build import buildproject
 from cutty.projects.config import ProjectConfig
 from cutty.projects.config import readprojectconfigfile
-from cutty.projects.messages import updatecommitmessage
+from cutty.projects.messages import importcommitmessage
 from cutty.projects.repository import ProjectRepository
 
 
@@ -28,14 +28,14 @@ def import_(projectdir: Path, *, revision: Optional[str]) -> None:
         config1,
         revision=revision,
         interactive=True,
-        commitmessage=updatecommitmessage,
+        commitmessage=importcommitmessage,
     )
 
     commit = buildproject(
         repository,
         config2,
         interactive=True,
-        commitmessage=updatecommitmessage,
+        commitmessage=importcommitmessage,
         parent=parent,
     )
 

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -161,3 +161,15 @@ def test_invalid_revision(runcutty: RunCutty, project: Path) -> None:
     with pytest.raises(Exception, match="revision not found"):
         with chdir(project):
             runcutty("import", "--revision=invalid")
+
+
+def test_message(
+    runcutty: RunCutty, template: Path, templateproject: Path, project: Path
+) -> None:
+    """It uses the commit message from the imported changeset."""
+    updatefile(templateproject / "marker")
+
+    with chdir(project):
+        runcutty("import")
+
+    assert commit(template).message == commit(project).message

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -214,3 +214,13 @@ def test_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
 
     with repository.get(None) as package:
         assert package.commit is not None and is_mercurial_hash(package.commit)
+
+
+def test_message(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
+    """It returns the commit message."""
+    repository = hgprovider.provide(hgrepository)
+
+    assert repository is not None
+
+    with repository.get(None) as package:
+        assert package.message is not None


### PR DESCRIPTION
- 🔨 [projects] Add optional attribute `Template.Metadata.message`
- 🔨 [projects] Add function `importcommitmessage`
- 🔨 [services] Replace `{update => import}commitmessage` in `import_`
- ✅ [functional] Add test for `cutty import` preserving commit message
- 🔨 [packages] Add optional attribute `Package.message`
- 🔨 [projects] Initialize `Template.Metadata.message` from `Package.message`
- 🔨 [packages] Add callback `getmessage` to `DefaultPackageRepository`
- 🔨 [packages] Add callback `getmessage` to `{Local,Remote}Provider`
- ✨ [packages] Implement `getmessage` hook in git provider
- ✅ [packages] Add test for `getmessage` hook in Mercurial provider
- ✨ [packages] Implement `getmessage` hook in Mercurial provider
