### PR TITLE
🔨 [packages] Remove duplication in git and Mercurial providers

### DIFF
--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -67,10 +67,10 @@ def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revi
 
 def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
     """Return the package revision."""
+    repository = pygit2.Repository(path)
+
     if revision is None:
         revision = "HEAD"
-
-    repository = pygit2.Repository(path)
 
     try:
         commit = repository.revparse_single(revision).peel(pygit2.Commit)

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -104,16 +104,9 @@ def getparentrevision(
 def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:
     """Return the commit message."""
     repository = pygit2.Repository(path)
-
-    if revision is None:
-        revision = "HEAD"
-
-    try:
-        commit = repository.revparse_single(revision).peel(pygit2.Commit)
-    except KeyError:  # pragma: no cover
-        raise RevisionNotFoundError(revision)
-
+    commit = _getcommit(repository, revision)
     message: str = commit.message
+
     return message
 
 

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -45,10 +45,10 @@ def mount(path: pathlib.Path, revision: Optional[Revision]) -> Iterator[GitFiles
         yield GitFilesystem(path)
 
 
-def _getcommit(path: pathlib.Path, revision: Optional[Revision]) -> pygit2.Commit:
+def _getcommit(
+    repository: pygit2.Repository, revision: Optional[Revision]
+) -> pygit2.Commit:
     """Return the commit object."""
-    repository = pygit2.Repository(path)
-
     if revision is None:
         revision = "HEAD"
 
@@ -60,7 +60,8 @@ def _getcommit(path: pathlib.Path, revision: Optional[Revision]) -> pygit2.Commi
 
 def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
     """Return the commit identifier."""
-    commit = _getcommit(path, revision)
+    repository = pygit2.Repository(path)
+    commit = _getcommit(repository, revision)
     return str(commit.id)
 
 

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -103,10 +103,10 @@ def getparentrevision(
 
 def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:
     """Return the commit message."""
+    repository = pygit2.Repository(path)
+
     if revision is None:
         revision = "HEAD"
-
-    repository = pygit2.Repository(path)
 
     try:
         commit = repository.revparse_single(revision).peel(pygit2.Commit)

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -90,10 +90,10 @@ def getparentrevision(
     path: pathlib.Path, revision: Optional[Revision]
 ) -> Optional[Revision]:
     """Return the parent revision, if any."""
+    repository = pygit2.Repository(path)
+
     if revision is None:
         revision = "HEAD"
-
-    repository = pygit2.Repository(path)
 
     try:
         commit = repository.revparse_single(revision).peel(pygit2.Commit)

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -47,10 +47,10 @@ def mount(path: pathlib.Path, revision: Optional[Revision]) -> Iterator[GitFiles
 
 def _getcommit(path: pathlib.Path, revision: Optional[Revision]) -> pygit2.Commit:
     """Return the commit object."""
+    repository = pygit2.Repository(path)
+
     if revision is None:
         revision = "HEAD"
-
-    repository = pygit2.Repository(path)
 
     try:
         return repository.revparse_single(revision).peel(pygit2.Commit)

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -45,18 +45,22 @@ def mount(path: pathlib.Path, revision: Optional[Revision]) -> Iterator[GitFiles
         yield GitFilesystem(path)
 
 
-def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
-    """Return the commit identifier."""
+def _getcommit(path: pathlib.Path, revision: Optional[Revision]) -> pygit2.Commit:
+    """Return the commit object."""
     if revision is None:
         revision = "HEAD"
 
     repository = pygit2.Repository(path)
 
     try:
-        commit = repository.revparse_single(revision).peel(pygit2.Commit)
+        return repository.revparse_single(revision).peel(pygit2.Commit)
     except KeyError:
         raise RevisionNotFoundError(revision)
 
+
+def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
+    """Return the commit identifier."""
+    commit = _getcommit(path, revision)
     return str(commit.id)
 
 

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -91,14 +91,7 @@ def getparentrevision(
 ) -> Optional[Revision]:
     """Return the parent revision, if any."""
     repository = pygit2.Repository(path)
-
-    if revision is None:
-        revision = "HEAD"
-
-    try:
-        commit = repository.revparse_single(revision).peel(pygit2.Commit)
-    except KeyError:
-        raise RevisionNotFoundError(revision)
+    commit = _getcommit(repository, revision)
 
     if parents := commit.parents:
         [parent] = parents

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -68,14 +68,7 @@ def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revi
 def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
     """Return the package revision."""
     repository = pygit2.Repository(path)
-
-    if revision is None:
-        revision = "HEAD"
-
-    try:
-        commit = repository.revparse_single(revision).peel(pygit2.Commit)
-    except KeyError:  # pragma: no cover
-        raise RevisionNotFoundError(revision)
+    commit = _getcommit(repository, revision)
 
     try:
         revision = repository.describe(

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -38,18 +38,6 @@ def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Re
     )
 
 
-@contextmanager
-def mount(path: pathlib.Path, revision: Optional[Revision]) -> Iterator[Filesystem]:
-    """Mount an archive of the revision as a disk filesystem."""
-    hg = findhg()
-
-    with tempfile.TemporaryDirectory() as directory:
-        options = ["--rev", revision] if revision is not None else []
-        hg("archive", *options, directory, cwd=path)
-
-        yield DiskFilesystem(pathlib.Path(directory))
-
-
 def getparentrevision(
     path: pathlib.Path, revision: Optional[Revision]
 ) -> Optional[Revision]:
@@ -63,6 +51,18 @@ def getparentrevision(
 def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:
     """Return the commit message."""
     return getmetadata(path, revision, "desc")
+
+
+@contextmanager
+def mount(path: pathlib.Path, revision: Optional[Revision]) -> Iterator[Filesystem]:
+    """Mount an archive of the revision as a disk filesystem."""
+    hg = findhg()
+
+    with tempfile.TemporaryDirectory() as directory:
+        options = ["--rev", revision] if revision is not None else []
+        hg("archive", *options, directory, cwd=path)
+
+        yield DiskFilesystem(pathlib.Path(directory))
 
 
 hgproviderfactory = RemoteProviderFactory(

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -45,7 +45,7 @@ def getparentrevision(
     if revision is None:
         revision = "."
 
-    return getmetadata(path, f"--rev=p1({revision})", "node") or None
+    return getmetadata(path, f"p1({revision})", "node") or None
 
 
 def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -62,13 +62,7 @@ def getparentrevision(
 
 def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:
     """Return the commit message."""
-    hg = findhg()
-
-    if revision is None:
-        revision = "."
-
-    result = hg("log", f"--rev={revision}", "--template={desc}", cwd=path)
-    return result.stdout
+    return getmetadata(path, revision, "desc")
 
 
 hgproviderfactory = RemoteProviderFactory(

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -54,14 +54,10 @@ def getparentrevision(
     path: pathlib.Path, revision: Optional[Revision]
 ) -> Optional[Revision]:
     """Return the parent revision, if any."""
-    hg = findhg()
-
     if revision is None:
         revision = "."
 
-    result = hg("log", f"--rev=p1({revision})", "--template={node}", cwd=path)
-
-    return result.stdout or None
+    return getmetadata(path, f"--rev=p1({revision})", "node") or None
 
 
 def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -13,15 +13,22 @@ from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.revisions import Revision
 
 
-def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
-    """Return the commit identifier."""
+def getmetadata(
+    path: pathlib.Path, revision: Optional[Revision], template: str
+) -> Optional[str]:
+    """Return commit metadata."""
     hg = findhg()
 
     if revision is None:
         revision = "."
 
-    result = hg("log", f"--rev={revision}", "--template={node}", cwd=path)
+    result = hg("log", f"--rev={revision}", f"--template={{{template}}}", cwd=path)
     return result.stdout
+
+
+def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
+    """Return the commit identifier."""
+    return getmetadata(path, revision, "node")
 
 
 def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -33,18 +33,9 @@ def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revi
 
 def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
     """Return the package revision."""
-    hg = findhg()
-
-    if revision is None:
-        revision = "."
-
-    result = hg(
-        "log",
-        f"--rev={revision}",
-        "--template={ifeq(latesttagdistance, 0, latesttag, short(node))}",
-        cwd=path,
+    return getmetadata(
+        path, revision, "ifeq(latesttagdistance, 0, latesttag, short(node))"
     )
-    return result.stdout
 
 
 @contextmanager


### PR DESCRIPTION
- 🔨 [packages] Extract function `_getcommit` from `git.getcommit`
- 🔨 [packages] Slide statement
- 🔨 [packages] Move statement to caller
- 🔨 [packages] Slide statement
- 🔨 [packages] Replace inline code with function call
- 🔨 [packages] Slide statement
- 🔨 [packages] Replace inline code with function call
- 🔨 [packages] Slide statement
- 🔨 [packages] Replace inline code with function call
- 🔨 [packages] Extract function `getmetadata` from `mercurial.getcommit`
- 🔨 [packages] Replace inline code with function call
- 🔨 [packages] Replace inline code with function call
- 🔨 [packages] Replace inline code with function call
- 🔨 [packages] Slide statements
