### PR TITLE
🔨 [tests] Move duplicated test utilities to `tests.util.variables`

### DIFF
--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -1,7 +1,5 @@
 """Functional tests for `cutty import`."""
-import json
 from pathlib import Path
-from typing import Any
 
 import pygit2
 import pytest
@@ -15,6 +13,7 @@ from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
 from tests.util.variables import projectvariable
+from tests.util.variables import updatetemplatevariable
 
 
 def test_help(runcutty: RunCutty) -> None:
@@ -192,14 +191,6 @@ def test_extra_context_old_variable(
         runcutty("import", "project=excellent")
 
     assert "excellent" == projectvariable(project, "project")
-
-
-def updatetemplatevariable(template: Path, name: str, value: Any) -> None:
-    """Add or update a template variable."""
-    path = template / "cookiecutter.json"
-    data = json.loads(path.read_text())
-    data[name] = value
-    updatefile(path, json.dumps(data))
 
 
 def test_extra_context_new_variable(

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -14,6 +14,7 @@ from tests.util.git import move_repository_files_to_subdirectory
 from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
+from tests.util.variables import projectvariable
 
 
 def test_help(runcutty: RunCutty) -> None:
@@ -179,12 +180,6 @@ def test_message(
         runcutty("import")
 
     assert commit(template).message == commit(project).message
-
-
-def projectvariable(project: Path, name: str) -> Any:
-    """Return the bound value of a project variable."""
-    config = readprojectconfigfile(project)
-    return next(binding.value for binding in config.bindings if binding.name == name)
 
 
 def test_extra_context_old_variable(

--- a/tests/functional/test_link.py
+++ b/tests/functional/test_link.py
@@ -7,10 +7,10 @@ from cutty.projects.config import readprojectconfigfile
 from cutty.util.git import Repository
 from tests.functional.conftest import RunCutty
 from tests.functional.conftest import RunCuttyError
-from tests.functional.test_update import projectvariable
 from tests.util.files import chdir
 from tests.util.git import move_repository_files_to_subdirectory
 from tests.util.git import updatefile
+from tests.util.variables import projectvariable
 
 
 def test_help(runcutty: RunCutty) -> None:

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -18,6 +18,7 @@ from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
 from tests.util.variables import projectvariable
+from tests.util.variables import updatetemplatevariable
 
 
 def test_help(runcutty: RunCutty) -> None:
@@ -40,14 +41,6 @@ def templatevariable(template: Path, name: str) -> Any:
     path = template / "cookiecutter.json"
     data = json.loads(path.read_text())
     return data[name]
-
-
-def updatetemplatevariable(template: Path, name: str, value: Any) -> None:
-    """Add or update a template variable."""
-    path = template / "cookiecutter.json"
-    data = json.loads(path.read_text())
-    data[name] = value
-    updatefile(path, json.dumps(data))
 
 
 @pytest.fixture

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -18,6 +18,7 @@ from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
 from tests.util.variables import projectvariable
+from tests.util.variables import templatevariable
 from tests.util.variables import updatetemplatevariable
 
 
@@ -34,13 +35,6 @@ def project(runcutty: RunCutty, template: Path) -> Path:
     runcutty("create", "--non-interactive", str(template), f"project={project.name}")
 
     return project
-
-
-def templatevariable(template: Path, name: str) -> Any:
-    """Return the value of a template variable."""
-    path = template / "cookiecutter.json"
-    data = json.loads(path.read_text())
-    return data[name]
 
 
 @pytest.fixture

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -17,6 +17,7 @@ from tests.util.git import removefile
 from tests.util.git import resolveconflicts
 from tests.util.git import Side
 from tests.util.git import updatefile
+from tests.util.variables import projectvariable
 
 
 def test_help(runcutty: RunCutty) -> None:
@@ -47,12 +48,6 @@ def updatetemplatevariable(template: Path, name: str, value: Any) -> None:
     data = json.loads(path.read_text())
     data[name] = value
     updatefile(path, json.dumps(data))
-
-
-def projectvariable(project: Path, name: str) -> Any:
-    """Return the bound value of a project variable."""
-    config = readprojectconfigfile(project)
-    return next(binding.value for binding in config.bindings if binding.name == name)
 
 
 @pytest.fixture

--- a/tests/util/variables.py
+++ b/tests/util/variables.py
@@ -1,11 +1,21 @@
 """Utilities for template variables."""
+import json
 from pathlib import Path
 from typing import Any
 
 from cutty.projects.config import readprojectconfigfile
+from tests.util.git import updatefile
 
 
 def projectvariable(project: Path, name: str) -> Any:
     """Return the bound value of a project variable."""
     config = readprojectconfigfile(project)
     return next(binding.value for binding in config.bindings if binding.name == name)
+
+
+def updatetemplatevariable(template: Path, name: str, value: Any) -> None:
+    """Add or update a template variable."""
+    path = template / "cookiecutter.json"
+    data = json.loads(path.read_text())
+    data[name] = value
+    updatefile(path, json.dumps(data))

--- a/tests/util/variables.py
+++ b/tests/util/variables.py
@@ -13,6 +13,13 @@ def projectvariable(project: Path, name: str) -> Any:
     return next(binding.value for binding in config.bindings if binding.name == name)
 
 
+def templatevariable(template: Path, name: str) -> Any:
+    """Return the value of a template variable."""
+    path = template / "cookiecutter.json"
+    data = json.loads(path.read_text())
+    return data[name]
+
+
 def updatetemplatevariable(template: Path, name: str, value: Any) -> None:
     """Add or update a template variable."""
     path = template / "cookiecutter.json"

--- a/tests/util/variables.py
+++ b/tests/util/variables.py
@@ -1,0 +1,11 @@
+"""Utilities for template variables."""
+from pathlib import Path
+from typing import Any
+
+from cutty.projects.config import readprojectconfigfile
+
+
+def projectvariable(project: Path, name: str) -> Any:
+    """Return the bound value of a project variable."""
+    config = readprojectconfigfile(project)
+    return next(binding.value for binding in config.bindings if binding.name == name)


### PR DESCRIPTION
- 🔨 [util] Move function `projectvariable` to `tests.util.variables`
- 🔨 [functional] Replace inline code with function call
- 🔨 [functional] Adapt import of function `projectvariable`
- 🔨 [util] Move function `updatetemplatevariable` to `tests.util.variables`
- 🔨 [functional] Replace inline code with function call
- 🔨 [util] Move function `templatevariable` to `tests.util.variables`
