### PR TITLE
🔨 [packages] Combine functions into class `GitPackageRepository`

### DIFF
--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -55,6 +55,8 @@ class GitPackageRepository(DefaultPackageRepository):
         """Initialize."""
         super().__init__(name, path)
 
+        self.repository = pygit2.Repository(path)
+
     @contextmanager
     def mount(self, revision: Optional[Revision]) -> Iterator[GitFilesystem]:
         """Return a filesystem tree for the given revision.
@@ -69,17 +71,15 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the commit identifier."""
-        repository = pygit2.Repository(self.path)
-        commit = _getcommit(repository, revision)
+        commit = _getcommit(self.repository, revision)
         return str(commit.id)
 
     def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the resolved revision."""
-        repository = pygit2.Repository(self.path)
-        commit = _getcommit(repository, revision)
+        commit = _getcommit(self.repository, revision)
 
         try:
-            revision = repository.describe(
+            revision = self.repository.describe(
                 commit,
                 describe_strategy=pygit2.GIT_DESCRIBE_TAGS,
                 max_candidates_tags=0,
@@ -95,8 +95,7 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
-        repository = pygit2.Repository(self.path)
-        commit = _getcommit(repository, revision)
+        commit = _getcommit(self.repository, revision)
 
         if parents := commit.parents:
             [parent] = parents
@@ -107,8 +106,7 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getmessage(self, revision: Optional[Revision]) -> Optional[str]:
         """Return the commit message."""
-        repository = pygit2.Repository(self.path)
-        commit = _getcommit(repository, revision)
+        commit = _getcommit(self.repository, revision)
         message: str = commit.message
 
         return message

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -122,7 +122,6 @@ class GitPackageRepository(DefaultPackageRepository):
             name,
             path,
             mount=mount,
-            getrevision=getrevision,
             getparentrevision=getparentrevision,
             getmessage=getmessage,
         )
@@ -130,6 +129,10 @@ class GitPackageRepository(DefaultPackageRepository):
     def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the commit identifier."""
         return getcommit(self.path, revision)
+
+    def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
+        """Return the resolved revision."""
+        return getrevision(self.path, revision)
 
 
 class GitProvider(PackageRepositoryProvider):

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -63,21 +63,6 @@ def _getcommit(
         raise RevisionNotFoundError(revision)
 
 
-def getparentrevision(
-    path: pathlib.Path, revision: Optional[Revision]
-) -> Optional[Revision]:
-    """Return the parent revision, if any."""
-    repository = pygit2.Repository(path)
-    commit = _getcommit(repository, revision)
-
-    if parents := commit.parents:
-        [parent] = parents
-
-        return str(parent.id)
-
-    return None
-
-
 def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:
     """Return the commit message."""
     repository = pygit2.Repository(path)
@@ -126,7 +111,15 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
-        return getparentrevision(self.path, revision)
+        repository = pygit2.Repository(self.path)
+        commit = _getcommit(repository, revision)
+
+        if parents := commit.parents:
+            [parent] = parents
+
+            return str(parent.id)
+
+        return None
 
     def getmessage(self, revision: Optional[Revision]) -> Optional[str]:
         """Return the commit message."""

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -1,6 +1,7 @@
 """Providers for git repositories."""
 import pathlib
 from collections.abc import Iterator
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Optional
 
@@ -9,6 +10,7 @@ import pygit2
 from cutty.compat.contextlib import contextmanager
 from cutty.errors import CuttyError
 from cutty.filesystems.adapters.git import GitFilesystem
+from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.packages.adapters.fetchers.git import gitfetcher
 from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import RemoteProviderFactory
@@ -118,7 +120,11 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def __init__(self, name: str, path: pathlib.Path) -> None:
         """Initialize."""
-        super().__init__(name, path, mount=mount)
+        super().__init__(name, path)
+
+    def mount(self, revision: Optional[Revision]) -> AbstractContextManager[Filesystem]:
+        """Mount the package filesystem."""
+        return mount(self.path, revision)
 
     def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the commit identifier."""

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -122,11 +122,14 @@ class GitPackageRepository(DefaultPackageRepository):
             name,
             path,
             mount=mount,
-            getcommit=getcommit,
             getrevision=getrevision,
             getparentrevision=getparentrevision,
             getmessage=getmessage,
         )
+
+    def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
+        """Return the commit identifier."""
+        return getcommit(self.path, revision)
 
 
 class GitProvider(PackageRepositoryProvider):

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -113,12 +113,16 @@ def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str
     return message
 
 
+class GitPackageRepository(DefaultPackageRepository):
+    """Git package repository."""
+
+
 class GitProvider(PackageRepositoryProvider):
     """Git repository provider."""
 
     def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
         """Load a package repository."""
-        return DefaultPackageRepository(
+        return GitPackageRepository(
             name,
             path,
             mount=mount,

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -130,13 +130,6 @@ class GitProvider(PackageRepositoryProvider):
 
 
 localgitprovider = LocalProvider("localgit", match=match, provider=GitProvider())
-
 gitproviderfactory = RemoteProviderFactory(
-    "git",
-    fetch=[gitfetcher],
-    mount=mount,
-    getcommit=getcommit,
-    getrevision=getrevision,
-    getparentrevision=getparentrevision,
-    getmessage=getmessage,
+    "git", fetch=[gitfetcher], provider=GitProvider()
 )

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -46,7 +46,7 @@ class GitPackageRepository(DefaultPackageRepository):
         else:
             yield GitFilesystem(self.path)
 
-    def _getcommit(self, revision: Optional[Revision]) -> pygit2.Commit:
+    def _lookup(self, revision: Optional[Revision]) -> pygit2.Commit:
         """Return the commit object."""
         if revision is None:
             revision = "HEAD"
@@ -58,13 +58,13 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the commit identifier."""
-        commit = self._getcommit(revision)
+        commit = self._lookup(revision)
 
         return str(commit.id)
 
     def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the resolved revision."""
-        commit = self._getcommit(revision)
+        commit = self._lookup(revision)
 
         try:
             revision = self.repository.describe(
@@ -83,7 +83,7 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
-        commit = self._getcommit(revision)
+        commit = self._lookup(revision)
 
         if parents := commit.parents:
             [parent] = parents
@@ -94,7 +94,7 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getmessage(self, revision: Optional[Revision]) -> Optional[str]:
         """Return the commit message."""
-        commit = self._getcommit(revision)
+        commit = self._lookup(revision)
         message: str = commit.message
 
         return message

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -63,13 +63,6 @@ def _getcommit(
         raise RevisionNotFoundError(revision)
 
 
-def getcommit(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
-    """Return the commit identifier."""
-    repository = pygit2.Repository(path)
-    commit = _getcommit(repository, revision)
-    return str(commit.id)
-
-
 def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
     """Return the package revision."""
     repository = pygit2.Repository(path)
@@ -128,7 +121,9 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the commit identifier."""
-        return getcommit(self.path, revision)
+        repository = pygit2.Repository(self.path)
+        commit = _getcommit(repository, revision)
+        return str(commit.id)
 
     def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the resolved revision."""

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -116,13 +116,9 @@ def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str
 class GitPackageRepository(DefaultPackageRepository):
     """Git package repository."""
 
-
-class GitProvider(PackageRepositoryProvider):
-    """Git repository provider."""
-
-    def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
-        """Load a package repository."""
-        return GitPackageRepository(
+    def __init__(self, name: str, path: pathlib.Path) -> None:
+        """Initialize."""
+        super().__init__(
             name,
             path,
             mount=mount,
@@ -131,6 +127,14 @@ class GitProvider(PackageRepositoryProvider):
             getparentrevision=getparentrevision,
             getmessage=getmessage,
         )
+
+
+class GitProvider(PackageRepositoryProvider):
+    """Git repository provider."""
+
+    def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
+        """Load a package repository."""
+        return GitPackageRepository(name, path)
 
 
 localgitprovider = LocalProvider("localgit", match=match, provider=GitProvider())

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -63,15 +63,6 @@ def _getcommit(
         raise RevisionNotFoundError(revision)
 
 
-def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str]:
-    """Return the commit message."""
-    repository = pygit2.Repository(path)
-    commit = _getcommit(repository, revision)
-    message: str = commit.message
-
-    return message
-
-
 class GitPackageRepository(DefaultPackageRepository):
     """Git package repository."""
 
@@ -123,7 +114,11 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getmessage(self, revision: Optional[Revision]) -> Optional[str]:
         """Return the commit message."""
-        return getmessage(self.path, revision)
+        repository = pygit2.Repository(self.path)
+        commit = _getcommit(repository, revision)
+        message: str = commit.message
+
+        return message
 
 
 class GitProvider(PackageRepositoryProvider):

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -122,7 +122,6 @@ class GitPackageRepository(DefaultPackageRepository):
             name,
             path,
             mount=mount,
-            getparentrevision=getparentrevision,
             getmessage=getmessage,
         )
 
@@ -133,6 +132,10 @@ class GitPackageRepository(DefaultPackageRepository):
     def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the resolved revision."""
         return getrevision(self.path, revision)
+
+    def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
+        """Return the parent revision, if any."""
+        return getparentrevision(self.path, revision)
 
 
 class GitProvider(PackageRepositoryProvider):

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -118,12 +118,7 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def __init__(self, name: str, path: pathlib.Path) -> None:
         """Initialize."""
-        super().__init__(
-            name,
-            path,
-            mount=mount,
-            getmessage=getmessage,
-        )
+        super().__init__(name, path, mount=mount)
 
     def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the commit identifier."""
@@ -136,6 +131,10 @@ class GitPackageRepository(DefaultPackageRepository):
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
         return getparentrevision(self.path, revision)
+
+    def getmessage(self, revision: Optional[Revision]) -> Optional[str]:
+        """Return the commit message."""
+        return getmessage(self.path, revision)
 
 
 class GitProvider(PackageRepositoryProvider):

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -63,27 +63,6 @@ def _getcommit(
         raise RevisionNotFoundError(revision)
 
 
-def getrevision(path: pathlib.Path, revision: Optional[Revision]) -> Optional[Revision]:
-    """Return the package revision."""
-    repository = pygit2.Repository(path)
-    commit = _getcommit(repository, revision)
-
-    try:
-        revision = repository.describe(
-            commit,
-            describe_strategy=pygit2.GIT_DESCRIBE_TAGS,
-            max_candidates_tags=0,
-            show_commit_oid_as_fallback=True,
-        )
-    except KeyError:
-        # Emulate `show_commit_oid_as_fallback` when no tag matches exactly,
-        # which results in GIT_ENOTFOUND ("cannot describe - no tag exactly
-        # matches '...'").
-        revision = commit.short_id
-
-    return revision
-
-
 def getparentrevision(
     path: pathlib.Path, revision: Optional[Revision]
 ) -> Optional[Revision]:
@@ -127,7 +106,23 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the resolved revision."""
-        return getrevision(self.path, revision)
+        repository = pygit2.Repository(self.path)
+        commit = _getcommit(repository, revision)
+
+        try:
+            revision = repository.describe(
+                commit,
+                describe_strategy=pygit2.GIT_DESCRIBE_TAGS,
+                max_candidates_tags=0,
+                show_commit_oid_as_fallback=True,
+            )
+        except KeyError:
+            # Emulate `show_commit_oid_as_fallback` when no tag matches exactly,
+            # which results in GIT_ENOTFOUND ("cannot describe - no tag exactly
+            # matches '...'").
+            revision = commit.short_id
+
+        return revision
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -12,6 +12,9 @@ from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.packages.adapters.fetchers.git import gitfetcher
 from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import RemoteProviderFactory
+from cutty.packages.domain.repository import DefaultPackageRepository
+from cutty.packages.domain.repository import PackageRepository
+from cutty.packages.domain.repository import PackageRepositoryProvider
 from cutty.packages.domain.revisions import Revision
 
 
@@ -108,6 +111,22 @@ def getmessage(path: pathlib.Path, revision: Optional[Revision]) -> Optional[str
     message: str = commit.message
 
     return message
+
+
+class GitProvider(PackageRepositoryProvider):
+    """Git repository provider."""
+
+    def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
+        """Load a package repository."""
+        return DefaultPackageRepository(
+            name,
+            path,
+            mount=mount,
+            getcommit=getcommit,
+            getrevision=getrevision,
+            getparentrevision=getparentrevision,
+            getmessage=getmessage,
+        )
 
 
 localgitprovider = LocalProvider(

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -129,15 +129,7 @@ class GitProvider(PackageRepositoryProvider):
         )
 
 
-localgitprovider = LocalProvider(
-    "localgit",
-    match=match,
-    mount=mount,
-    getcommit=getcommit,
-    getrevision=getrevision,
-    getparentrevision=getparentrevision,
-    getmessage=getmessage,
-)
+localgitprovider = LocalProvider("localgit", match=match, provider=GitProvider())
 
 gitproviderfactory = RemoteProviderFactory(
     "git",

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -18,16 +18,6 @@ from cutty.packages.domain.repository import PackageRepositoryProvider
 from cutty.packages.domain.revisions import Revision
 
 
-def match(path: pathlib.Path) -> bool:
-    """Return True if the path is a git repository."""
-    repository = pygit2.discover_repository(path)
-    if repository is None:
-        return False
-
-    repositorypath = pathlib.Path(repository)
-    return path in (repositorypath, repositorypath.parent)
-
-
 @dataclass
 class RevisionNotFoundError(CuttyError):
     """The specified revision does not exist in the repository."""
@@ -116,6 +106,16 @@ class GitProvider(PackageRepositoryProvider):
     def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
         """Load a package repository."""
         return GitPackageRepository(name, path)
+
+
+def match(path: pathlib.Path) -> bool:
+    """Return True if the path is a git repository."""
+    repository = pygit2.discover_repository(path)
+    if repository is None:
+        return False
+
+    repositorypath = pathlib.Path(repository)
+    return path in (repositorypath, repositorypath.parent)
 
 
 localgitprovider = LocalProvider("localgit", match=match, provider=GitProvider())

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -46,7 +46,7 @@ class LocalProvider(Provider):
         /,
         *,
         match: PathMatcher,
-        mount: Mounter,
+        mount: Optional[Mounter] = None,
         getcommit: Optional[GetRevision] = None,
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
@@ -70,6 +70,8 @@ class LocalProvider(Provider):
             if path.exists() and self.match(path):
                 if self.provider is not None:
                     return self.provider.provide(location.name, path)
+
+                assert self.mount is not None  # noqa: S101
 
                 return DefaultPackageRepository(
                     location.name,

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -186,6 +186,7 @@ class RemoteProviderFactory(ProviderFactory):
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
         getmessage: Optional[GetMessage] = None,
+        provider: Optional[PackageRepositoryProvider] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
@@ -196,6 +197,7 @@ class RemoteProviderFactory(ProviderFactory):
         self.getrevision = getrevision
         self.getparentrevision = getparentrevision
         self.getmessage = getmessage
+        self.provider = provider
 
     def __call__(self, store: Store) -> Provider:
         """Create a provider."""
@@ -208,6 +210,7 @@ class RemoteProviderFactory(ProviderFactory):
             getrevision=self.getrevision,
             getparentrevision=self.getparentrevision,
             getmessage=self.getmessage,
+            provider=self.provider,
             store=store,
         )
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -108,6 +108,7 @@ class RemoteProvider(Provider):
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
         getmessage: Optional[GetMessage] = None,
+        provider: Optional[PackageRepositoryProvider] = None,
         store: Store,
     ) -> None:
         """Initialize."""
@@ -127,6 +128,7 @@ class RemoteProvider(Provider):
         self.getrevision = getrevision
         self.getparentrevision = getparentrevision
         self.getmessage = getmessage
+        self.provider = provider
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
@@ -141,6 +143,9 @@ class RemoteProvider(Provider):
             for fetcher in self.fetch:
                 if fetcher.match(url):
                     path = fetcher.fetch(url, self.store)
+                    if self.provider is not None:
+                        return self.provider.provide(location.name, path)
+
                     return DefaultPackageRepository(
                         location.name,
                         path,

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -21,6 +21,7 @@ from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import GetMessage
 from cutty.packages.domain.repository import GetRevision
 from cutty.packages.domain.repository import PackageRepository
+from cutty.packages.domain.repository import PackageRepositoryProvider
 from cutty.packages.domain.revisions import Revision
 from cutty.packages.domain.stores import Store
 
@@ -50,6 +51,7 @@ class LocalProvider(Provider):
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
         getmessage: Optional[GetMessage] = None,
+        provider: Optional[PackageRepositoryProvider] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
@@ -60,11 +62,15 @@ class LocalProvider(Provider):
         self.getrevision = getrevision
         self.getparentrevision = getparentrevision
         self.getmessage = getmessage
+        self.provider = provider
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
         if path := pathfromlocation(location):
             if path.exists() and self.match(path):
+                if self.provider is not None:
+                    return self.provider.provide(location.name, path)
+
                 return DefaultPackageRepository(
                     location.name,
                     path,

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -62,7 +62,7 @@ class DefaultPackageRepository(PackageRepository):
         """Initialize."""
         self.name = name
         self.path = path
-        self.mount = mount
+        self._mount = mount
         self._getcommit = getcommit
         self._getrevision = getrevision
         self._getparentrevision = getparentrevision
@@ -75,7 +75,7 @@ class DefaultPackageRepository(PackageRepository):
         resolved_revision = self.getrevision(revision)
         message = self.getmessage(revision)
 
-        with self.mount(self.path, revision) as filesystem:
+        with self._mount(self.path, revision) as filesystem:
             tree = Path(filesystem=filesystem)
 
             yield Package(self.name, tree, resolved_revision, commit, message)

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -55,7 +55,7 @@ class DefaultPackageRepository(PackageRepository):
         *,
         mount: Mounter,
         getcommit: Optional[GetRevision] = None,
-        getrevision: Optional[GetRevision],
+        getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
         getmessage: Optional[GetMessage] = None,
     ) -> None:

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -55,7 +55,7 @@ class DefaultPackageRepository(PackageRepository):
         name: str,
         path: pathlib.Path,
         *,
-        mount: Mounter,
+        mount: Optional[Mounter] = None,
         getcommit: Optional[GetRevision] = None,
         getrevision: Optional[GetRevision] = None,
         getparentrevision: Optional[GetRevision] = None,
@@ -84,6 +84,8 @@ class DefaultPackageRepository(PackageRepository):
 
     def mount(self, revision: Optional[Revision]) -> AbstractContextManager[Filesystem]:
         """Mount the package filesystem."""
+        assert self._mount is not None  # noqa: S101
+
         return self._mount(self.path, revision)
 
     def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -33,6 +33,14 @@ class PackageRepository(abc.ABC):
         """Return the parent revision, if any."""
 
 
+class PackageRepositoryProvider(abc.ABC):
+    """A provider of package repositories."""
+
+    @abc.abstractmethod
+    def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
+        """Load a package repository."""
+
+
 GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]
 GetMessage = Callable[[pathlib.Path, Optional[Revision]], Optional[str]]
 


### PR DESCRIPTION
- 🔨 [packages] Add class `PackageRepositoryProvider`
- 🔨 [packages] Add optional parameter `provider` to `LocalProvider`
- 🔨 [packages] Add class `GitProvider` implementing `PackageRepositoryProvider`
- 🔨 [packages] Do not require `mount` parameter for `LocalProvider`
- 🔨 [packages] Use `GitProvider` for `localgitprovider`
- 🔨 [packages] Add optional parameter `provider` to `RemoteProvider`
- 🔨 [packages] Add optional parameter `provider` to `RemoteProviderFactory`
- 🔨 [packages] Use `GitProvider` in `gitproviderfactory`
- 🔨 [packages] Add class `GitPackageRepository`
- 🔨 [packages] Extract function `GitPackageRepository.__init__`
- 🔨 [packages] Extract function `GitPackageRepository.getcommit`
- 🔨 [packages] Do not require parameter `getrevision` for `DefaultPackageRepository`
- 🔨 [packages] Extract function `GitPackageRepository.getrevision`
- 🔨 [packages] Extract function `GitPackageRepository.getparentrevision`
- 🔨 [packages] Extract function `GitPackageRepository.getmessage`
- 🔨 [packages] Rename attribute `DefaultPackageRepository.{ => _}mount`
- 🔨 [packages] Extract function `DefaultPackageRepository.mount`
- 🔨 [packages] Do not require parameter `mount` for `DefaultPackageRepository`
- 🔨 [packages] Extract function `GitProvider.mount`
- 🔨 [packages] Inline function `git.getcommit`
- 🔨 [packages] Inline function `git.getrevision`
- 🔨 [packages] Inline function `git.getparentrevision`
- 🔨 [packages] Inline function `git.getmessage`
- 🔨 [packages] Inline function `git.mount`
- 🔨 [packages] Extract attribute `GitPackageRepository.repository`
- 🔨 [packages] Move function `git._getcommit` into `GitPackageRepository`
- 🔨 [packages] Slide function `git.match`
- 🔨 [packages] Rename function `GitPackageRepository._{getcommit => lookup}`
