### PR TITLE
🔨 [packages] Replace callbacks with `PackageRepositoryLoader` class hierarchy

### DIFF
--- a/src/cutty/packages/adapters/providers/disk.py
+++ b/src/cutty/packages/adapters/providers/disk.py
@@ -1,5 +1,6 @@
 """Package provider for a local directory."""
 from cutty.filesystems.adapters.disk import DiskFilesystem
+from cutty.packages.domain.loader import MountedPackageRepositoryLoader
 from cutty.packages.domain.mounters import unversioned_mounter
 from cutty.packages.domain.providers import LocalProvider
 
@@ -7,5 +8,5 @@ from cutty.packages.domain.providers import LocalProvider
 diskprovider = LocalProvider(
     "local",
     match=lambda path: path.is_dir(),
-    mount=unversioned_mounter(DiskFilesystem),
+    loader=MountedPackageRepositoryLoader(unversioned_mounter(DiskFilesystem)),
 )

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -100,7 +100,7 @@ class GitPackageRepository(DefaultPackageRepository):
         return message
 
 
-class GitProvider(PackageRepositoryLoader):
+class GitRepositoryLoader(PackageRepositoryLoader):
     """Git repository provider."""
 
     def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
@@ -118,7 +118,9 @@ def match(path: pathlib.Path) -> bool:
     return path in (repositorypath, repositorypath.parent)
 
 
-localgitprovider = LocalProvider("localgit", match=match, provider=GitProvider())
+localgitprovider = LocalProvider(
+    "localgit", match=match, provider=GitRepositoryLoader()
+)
 gitproviderfactory = RemoteProviderFactory(
-    "git", fetch=[gitfetcher], provider=GitProvider()
+    "git", fetch=[gitfetcher], provider=GitRepositoryLoader()
 )

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -103,7 +103,7 @@ class GitPackageRepository(DefaultPackageRepository):
 class GitRepositoryLoader(PackageRepositoryLoader):
     """Git repository loader."""
 
-    def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
+    def load(self, name: str, path: pathlib.Path) -> PackageRepository:
         """Load a package repository."""
         return GitPackageRepository(name, path)
 

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -10,11 +10,11 @@ from cutty.compat.contextlib import contextmanager
 from cutty.errors import CuttyError
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.packages.adapters.fetchers.git import gitfetcher
+from cutty.packages.domain.loader import PackageRepositoryLoader
 from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
-from cutty.packages.domain.repository import PackageRepositoryLoader
 from cutty.packages.domain.revisions import Revision
 
 

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -101,7 +101,7 @@ class GitPackageRepository(DefaultPackageRepository):
 
 
 class GitRepositoryLoader(PackageRepositoryLoader):
-    """Git repository provider."""
+    """Git repository loader."""
 
     def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
         """Load a package repository."""

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -14,7 +14,7 @@ from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
-from cutty.packages.domain.repository import PackageRepositoryProvider
+from cutty.packages.domain.repository import PackageRepositoryLoader
 from cutty.packages.domain.revisions import Revision
 
 
@@ -100,7 +100,7 @@ class GitPackageRepository(DefaultPackageRepository):
         return message
 
 
-class GitProvider(PackageRepositoryProvider):
+class GitProvider(PackageRepositoryLoader):
     """Git repository provider."""
 
     def provide(self, name: str, path: pathlib.Path) -> PackageRepository:

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -118,9 +118,7 @@ def match(path: pathlib.Path) -> bool:
     return path in (repositorypath, repositorypath.parent)
 
 
-localgitprovider = LocalProvider(
-    "localgit", match=match, provider=GitRepositoryLoader()
-)
+localgitprovider = LocalProvider("localgit", match=match, loader=GitRepositoryLoader())
 gitproviderfactory = RemoteProviderFactory(
-    "git", fetch=[gitfetcher], provider=GitRepositoryLoader()
+    "git", fetch=[gitfetcher], loader=GitRepositoryLoader()
 )

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -64,7 +64,7 @@ class MercurialPackageRepository(DefaultPackageRepository):
 
 
 class MercurialRepositoryLoader(PackageRepositoryLoader):
-    """Mercurial repository provider."""
+    """Mercurial repository loader."""
 
     def provide(self, name: str, path: pathlib.Path) -> MercurialPackageRepository:
         """Load a package repository."""

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -66,7 +66,7 @@ class MercurialPackageRepository(DefaultPackageRepository):
 class MercurialRepositoryLoader(PackageRepositoryLoader):
     """Mercurial repository loader."""
 
-    def provide(self, name: str, path: pathlib.Path) -> MercurialPackageRepository:
+    def load(self, name: str, path: pathlib.Path) -> MercurialPackageRepository:
         """Load a package repository."""
         return MercurialPackageRepository(name, path)
 

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -72,5 +72,5 @@ class MercurialRepositoryLoader(PackageRepositoryLoader):
 
 
 hgproviderfactory = RemoteProviderFactory(
-    "hg", fetch=[hgfetcher], provider=MercurialRepositoryLoader()
+    "hg", fetch=[hgfetcher], loader=MercurialRepositoryLoader()
 )

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -63,7 +63,7 @@ class MercurialPackageRepository(DefaultPackageRepository):
         return self.getmetadata(revision, "desc")
 
 
-class MercurialProvider(PackageRepositoryLoader):
+class MercurialRepositoryLoader(PackageRepositoryLoader):
     """Mercurial repository provider."""
 
     def provide(self, name: str, path: pathlib.Path) -> MercurialPackageRepository:
@@ -72,5 +72,5 @@ class MercurialProvider(PackageRepositoryLoader):
 
 
 hgproviderfactory = RemoteProviderFactory(
-    "hg", fetch=[hgfetcher], provider=MercurialProvider()
+    "hg", fetch=[hgfetcher], provider=MercurialRepositoryLoader()
 )

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -11,7 +11,7 @@ from cutty.packages.adapters.fetchers.mercurial import findhg
 from cutty.packages.adapters.fetchers.mercurial import hgfetcher
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.repository import DefaultPackageRepository
-from cutty.packages.domain.repository import PackageRepositoryProvider
+from cutty.packages.domain.repository import PackageRepositoryLoader
 from cutty.packages.domain.revisions import Revision
 
 
@@ -63,7 +63,7 @@ class MercurialPackageRepository(DefaultPackageRepository):
         return self.getmetadata(revision, "desc")
 
 
-class MercurialProvider(PackageRepositoryProvider):
+class MercurialProvider(PackageRepositoryLoader):
     """Mercurial repository provider."""
 
     def provide(self, name: str, path: pathlib.Path) -> MercurialPackageRepository:

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -9,9 +9,9 @@ from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.packages.adapters.fetchers.mercurial import findhg
 from cutty.packages.adapters.fetchers.mercurial import hgfetcher
+from cutty.packages.domain.loader import PackageRepositoryLoader
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.repository import DefaultPackageRepository
-from cutty.packages.domain.repository import PackageRepositoryLoader
 from cutty.packages.domain.revisions import Revision
 
 

--- a/src/cutty/packages/adapters/providers/zip.py
+++ b/src/cutty/packages/adapters/providers/zip.py
@@ -5,6 +5,7 @@ from cutty.filesystems.adapters.zip import ZipFilesystem
 from cutty.packages.adapters.fetchers.file import filefetcher
 from cutty.packages.adapters.fetchers.ftp import ftpfetcher
 from cutty.packages.adapters.fetchers.http import httpfetcher
+from cutty.packages.domain.loader import MountedPackageRepositoryLoader
 from cutty.packages.domain.mounters import unversioned_mounter
 from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import RemoteProviderFactory
@@ -16,10 +17,12 @@ def match(path: Path) -> bool:
 
 
 mount = unversioned_mounter(ZipFilesystem)
-localzipprovider = LocalProvider("localzip", match=match, mount=mount)
+localzipprovider = LocalProvider(
+    "localzip", match=match, loader=MountedPackageRepositoryLoader(mount)
+)
 zipproviderfactory = RemoteProviderFactory(
     "zip",
     match=lambda url: url.path.lower().endswith(".zip"),
     fetch=[httpfetcher, ftpfetcher, filefetcher],
-    mount=mount,
+    loader=MountedPackageRepositoryLoader(mount),
 )

--- a/src/cutty/packages/domain/loader.py
+++ b/src/cutty/packages/domain/loader.py
@@ -28,7 +28,7 @@ class DefaultPackageRepositoryLoader(PackageRepositoryLoader):
 
 
 class MountedPackageRepositoryLoader(PackageRepositoryLoader):
-    """Loader for repositories of mounted packages."""
+    """Repository loader with a custom mounter."""
 
     def __init__(self, mount: Mounter) -> None:
         """Initialize."""

--- a/src/cutty/packages/domain/loader.py
+++ b/src/cutty/packages/domain/loader.py
@@ -15,6 +15,14 @@ class PackageRepositoryLoader(abc.ABC):
         """Load a package repository from disk."""
 
 
+class DefaultPackageRepositoryLoader(PackageRepositoryLoader):
+    """Default implementation of a repository loader."""
+
+    def load(self, name: str, path: pathlib.Path) -> PackageRepository:
+        """Load a package repository from disk."""
+        return DefaultPackageRepository(name, path)
+
+
 class MountedPackageRepositoryLoader(PackageRepositoryLoader):
     """Loader for repositories of mounted packages."""
 

--- a/src/cutty/packages/domain/loader.py
+++ b/src/cutty/packages/domain/loader.py
@@ -1,0 +1,13 @@
+"""Loaders for package repositories."""
+import abc
+import pathlib
+
+from cutty.packages.domain.repository import PackageRepository
+
+
+class PackageRepositoryLoader(abc.ABC):
+    """Loader for package repositories."""
+
+    @abc.abstractmethod
+    def load(self, name: str, path: pathlib.Path) -> PackageRepository:
+        """Load a package repository from disk."""

--- a/src/cutty/packages/domain/loader.py
+++ b/src/cutty/packages/domain/loader.py
@@ -2,6 +2,8 @@
 import abc
 import pathlib
 
+from cutty.packages.domain.mounters import Mounter
+from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
 
 
@@ -11,3 +13,15 @@ class PackageRepositoryLoader(abc.ABC):
     @abc.abstractmethod
     def load(self, name: str, path: pathlib.Path) -> PackageRepository:
         """Load a package repository from disk."""
+
+
+class MountedPackageRepositoryLoader(PackageRepositoryLoader):
+    """Loader for repositories of mounted packages."""
+
+    def __init__(self, mount: Mounter) -> None:
+        """Initialize."""
+        self.mount = mount
+
+    def load(self, name: str, path: pathlib.Path) -> PackageRepository:
+        """Load a package repository from disk."""
+        return DefaultPackageRepository(name, path, mount=self.mount)

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -1,15 +1,10 @@
 """Package providers."""
 import abc
-import pathlib
 from collections.abc import Iterable
-from collections.abc import Iterator
 from typing import Optional
 
 from yarl import URL
 
-from cutty.compat.contextlib import contextmanager
-from cutty.filesystems.adapters.disk import DiskFilesystem
-from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.packages.domain.fetchers import Fetcher
 from cutty.packages.domain.loader import PackageRepositoryLoader
 from cutty.packages.domain.locations import asurl
@@ -19,7 +14,6 @@ from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.matchers import PathMatcher
 from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
-from cutty.packages.domain.revisions import Revision
 from cutty.packages.domain.stores import Store
 
 
@@ -58,13 +52,6 @@ class LocalProvider(Provider):
                 return self.loader.load(location.name, path)
 
         return None
-
-
-@contextmanager
-def _defaultmount(
-    path: pathlib.Path, revision: Optional[Revision]
-) -> Iterator[Filesystem]:
-    yield DiskFilesystem(path)
 
 
 class RemoteProvider(Provider):
@@ -107,9 +94,7 @@ class RemoteProvider(Provider):
                     if self.loader is not None:
                         return self.loader.load(location.name, path)
 
-                    return DefaultPackageRepository(
-                        location.name, path, mount=_defaultmount
-                    )
+                    return DefaultPackageRepository(location.name, path)
 
         return None
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -142,14 +142,12 @@ class RemoteProviderFactory(ProviderFactory):
         *,
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
-        mount: Optional[Mounter] = None,
         loader: Optional[PackageRepositoryLoader] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
         self.match = match
         self.fetch = tuple(fetch)
-        self.mount = mount
         self.loader = loader
 
     def __call__(self, store: Store) -> Provider:
@@ -158,7 +156,6 @@ class RemoteProviderFactory(ProviderFactory):
             self.name,
             match=self.match,
             fetch=self.fetch,
-            mount=self.mount,
             loader=self.loader,
             store=store,
         )

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -37,10 +37,13 @@ class LocalProvider(Provider):
         /,
         *,
         match: PathMatcher,
-        loader: PackageRepositoryLoader,
+        loader: Optional[PackageRepositoryLoader] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
+
+        if loader is None:
+            loader = DefaultPackageRepositoryLoader()
 
         self.match = match
         self.loader = loader

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -17,7 +17,6 @@ from cutty.packages.domain.locations import Location
 from cutty.packages.domain.locations import pathfromlocation
 from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.matchers import PathMatcher
-from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
@@ -78,15 +77,11 @@ class RemoteProvider(Provider):
         *,
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
-        mount: Optional[Mounter] = None,
         loader: Optional[PackageRepositoryLoader] = None,
         store: Store,
     ) -> None:
         """Initialize."""
         super().__init__(name)
-
-        if mount is None:
-            mount = _defaultmount
 
         if match is None:
             match = lambda _: True  # noqa: E731
@@ -94,7 +89,6 @@ class RemoteProvider(Provider):
         self.match = match
         self.fetch = tuple(fetch)
         self.store = store
-        self.mount = mount
         self.loader = loader
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
@@ -114,7 +108,7 @@ class RemoteProvider(Provider):
                         return self.loader.load(location.name, path)
 
                     return DefaultPackageRepository(
-                        location.name, path, mount=self.mount
+                        location.name, path, mount=_defaultmount
                     )
 
         return None

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -6,13 +6,13 @@ from typing import Optional
 from yarl import URL
 
 from cutty.packages.domain.fetchers import Fetcher
+from cutty.packages.domain.loader import DefaultPackageRepositoryLoader
 from cutty.packages.domain.loader import PackageRepositoryLoader
 from cutty.packages.domain.locations import asurl
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.locations import pathfromlocation
 from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.matchers import PathMatcher
-from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.stores import Store
 
@@ -73,6 +73,9 @@ class RemoteProvider(Provider):
         if match is None:
             match = lambda _: True  # noqa: E731
 
+        if loader is None:
+            loader = DefaultPackageRepositoryLoader()
+
         self.match = match
         self.fetch = tuple(fetch)
         self.store = store
@@ -91,10 +94,7 @@ class RemoteProvider(Provider):
             for fetcher in self.fetch:
                 if fetcher.match(url):
                     path = fetcher.fetch(url, self.store)
-                    if self.loader is not None:
-                        return self.loader.load(location.name, path)
-
-                    return DefaultPackageRepository(location.name, path)
+                    return self.loader.load(location.name, path)
 
         return None
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -44,14 +44,12 @@ class LocalProvider(Provider):
         /,
         *,
         match: PathMatcher,
-        mount: Optional[Mounter] = None,
         loader: Optional[PackageRepositoryLoader] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
 
         self.match = match
-        self.mount = mount
         self.loader = loader
 
     def provide(self, location: Location) -> Optional[PackageRepository]:

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -36,11 +36,14 @@ class LocalProvider(Provider):
         name: str = "local",
         /,
         *,
-        match: PathMatcher,
+        match: Optional[PathMatcher] = None,
         loader: Optional[PackageRepositoryLoader] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
+
+        if match is None:
+            match = lambda _: True  # noqa: E731
 
         if loader is None:
             loader = DefaultPackageRepositoryLoader()

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -45,21 +45,21 @@ class LocalProvider(Provider):
         *,
         match: PathMatcher,
         mount: Optional[Mounter] = None,
-        provider: Optional[PackageRepositoryLoader] = None,
+        loader: Optional[PackageRepositoryLoader] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
 
         self.match = match
         self.mount = mount
-        self.provider = provider
+        self.loader = loader
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
         if path := pathfromlocation(location):
             if path.exists() and self.match(path):
-                if self.provider is not None:
-                    return self.provider.load(location.name, path)
+                if self.loader is not None:
+                    return self.loader.load(location.name, path)
 
                 assert self.mount is not None  # noqa: S101
 
@@ -86,7 +86,7 @@ class RemoteProvider(Provider):
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
-        provider: Optional[PackageRepositoryLoader] = None,
+        loader: Optional[PackageRepositoryLoader] = None,
         store: Store,
     ) -> None:
         """Initialize."""
@@ -102,7 +102,7 @@ class RemoteProvider(Provider):
         self.fetch = tuple(fetch)
         self.store = store
         self.mount = mount
-        self.provider = provider
+        self.loader = loader
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
         """Retrieve the package repository at the given location."""
@@ -117,8 +117,8 @@ class RemoteProvider(Provider):
             for fetcher in self.fetch:
                 if fetcher.match(url):
                     path = fetcher.fetch(url, self.store)
-                    if self.provider is not None:
-                        return self.provider.load(location.name, path)
+                    if self.loader is not None:
+                        return self.loader.load(location.name, path)
 
                     return DefaultPackageRepository(
                         location.name, path, mount=self.mount
@@ -150,14 +150,14 @@ class RemoteProviderFactory(ProviderFactory):
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
-        provider: Optional[PackageRepositoryLoader] = None,
+        loader: Optional[PackageRepositoryLoader] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
         self.match = match
         self.fetch = tuple(fetch)
         self.mount = mount
-        self.provider = provider
+        self.loader = loader
 
     def __call__(self, store: Store) -> Provider:
         """Create a provider."""
@@ -166,7 +166,7 @@ class RemoteProviderFactory(ProviderFactory):
             match=self.match,
             fetch=self.fetch,
             mount=self.mount,
-            provider=self.provider,
+            loader=self.loader,
             store=store,
         )
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -59,7 +59,7 @@ class LocalProvider(Provider):
         if path := pathfromlocation(location):
             if path.exists() and self.match(path):
                 if self.provider is not None:
-                    return self.provider.provide(location.name, path)
+                    return self.provider.load(location.name, path)
 
                 assert self.mount is not None  # noqa: S101
 
@@ -118,7 +118,7 @@ class RemoteProvider(Provider):
                 if fetcher.match(url):
                     path = fetcher.fetch(url, self.store)
                     if self.provider is not None:
-                        return self.provider.provide(location.name, path)
+                        return self.provider.load(location.name, path)
 
                     return DefaultPackageRepository(
                         location.name, path, mount=self.mount

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -19,7 +19,7 @@ from cutty.packages.domain.matchers import PathMatcher
 from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
-from cutty.packages.domain.repository import PackageRepositoryProvider
+from cutty.packages.domain.repository import PackageRepositoryLoader
 from cutty.packages.domain.revisions import Revision
 from cutty.packages.domain.stores import Store
 
@@ -45,7 +45,7 @@ class LocalProvider(Provider):
         *,
         match: PathMatcher,
         mount: Optional[Mounter] = None,
-        provider: Optional[PackageRepositoryProvider] = None,
+        provider: Optional[PackageRepositoryLoader] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)
@@ -86,7 +86,7 @@ class RemoteProvider(Provider):
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
-        provider: Optional[PackageRepositoryProvider] = None,
+        provider: Optional[PackageRepositoryLoader] = None,
         store: Store,
     ) -> None:
         """Initialize."""
@@ -150,7 +150,7 @@ class RemoteProviderFactory(ProviderFactory):
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
-        provider: Optional[PackageRepositoryProvider] = None,
+        provider: Optional[PackageRepositoryLoader] = None,
     ) -> None:
         """Initialize."""
         super().__init__(name)

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -44,7 +44,7 @@ class LocalProvider(Provider):
         /,
         *,
         match: PathMatcher,
-        loader: Optional[PackageRepositoryLoader] = None,
+        loader: PackageRepositoryLoader,
     ) -> None:
         """Initialize."""
         super().__init__(name)
@@ -56,8 +56,6 @@ class LocalProvider(Provider):
         """Retrieve the package repository at the given location."""
         if path := pathfromlocation(location):
             if path.exists() and self.match(path):
-                assert self.loader is not None  # noqa: S101
-
                 return self.loader.load(location.name, path)
 
         return None

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -18,7 +18,6 @@ from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.matchers import PathMatcher
 from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.repository import DefaultPackageRepository
-from cutty.packages.domain.repository import GetRevision
 from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.repository import PackageRepositoryProvider
 from cutty.packages.domain.revisions import Revision
@@ -46,7 +45,6 @@ class LocalProvider(Provider):
         *,
         match: PathMatcher,
         mount: Optional[Mounter] = None,
-        getrevision: Optional[GetRevision] = None,
         provider: Optional[PackageRepositoryProvider] = None,
     ) -> None:
         """Initialize."""
@@ -54,7 +52,6 @@ class LocalProvider(Provider):
 
         self.match = match
         self.mount = mount
-        self.getrevision = getrevision
         self.provider = provider
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
@@ -66,9 +63,7 @@ class LocalProvider(Provider):
 
                 assert self.mount is not None  # noqa: S101
 
-                return DefaultPackageRepository(
-                    location.name, path, mount=self.mount, getrevision=self.getrevision
-                )
+                return DefaultPackageRepository(location.name, path, mount=self.mount)
 
         return None
 
@@ -91,7 +86,6 @@ class RemoteProvider(Provider):
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
-        getrevision: Optional[GetRevision] = None,
         provider: Optional[PackageRepositoryProvider] = None,
         store: Store,
     ) -> None:
@@ -108,7 +102,6 @@ class RemoteProvider(Provider):
         self.fetch = tuple(fetch)
         self.store = store
         self.mount = mount
-        self.getrevision = getrevision
         self.provider = provider
 
     def provide(self, location: Location) -> Optional[PackageRepository]:
@@ -128,10 +121,7 @@ class RemoteProvider(Provider):
                         return self.provider.provide(location.name, path)
 
                     return DefaultPackageRepository(
-                        location.name,
-                        path,
-                        mount=self.mount,
-                        getrevision=self.getrevision,
+                        location.name, path, mount=self.mount
                     )
 
         return None
@@ -160,7 +150,6 @@ class RemoteProviderFactory(ProviderFactory):
         match: Optional[Matcher] = None,
         fetch: Iterable[Fetcher],
         mount: Optional[Mounter] = None,
-        getrevision: Optional[GetRevision] = None,
         provider: Optional[PackageRepositoryProvider] = None,
     ) -> None:
         """Initialize."""
@@ -168,7 +157,6 @@ class RemoteProviderFactory(ProviderFactory):
         self.match = match
         self.fetch = tuple(fetch)
         self.mount = mount
-        self.getrevision = getrevision
         self.provider = provider
 
     def __call__(self, store: Store) -> Provider:
@@ -178,7 +166,6 @@ class RemoteProviderFactory(ProviderFactory):
             match=self.match,
             fetch=self.fetch,
             mount=self.mount,
-            getrevision=self.getrevision,
             provider=self.provider,
             store=store,
         )

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -11,6 +11,7 @@ from cutty.compat.contextlib import contextmanager
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.packages.domain.fetchers import Fetcher
+from cutty.packages.domain.loader import PackageRepositoryLoader
 from cutty.packages.domain.locations import asurl
 from cutty.packages.domain.locations import Location
 from cutty.packages.domain.locations import pathfromlocation
@@ -19,7 +20,6 @@ from cutty.packages.domain.matchers import PathMatcher
 from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
-from cutty.packages.domain.repository import PackageRepositoryLoader
 from cutty.packages.domain.revisions import Revision
 from cutty.packages.domain.stores import Store
 

--- a/src/cutty/packages/domain/providers.py
+++ b/src/cutty/packages/domain/providers.py
@@ -58,12 +58,9 @@ class LocalProvider(Provider):
         """Retrieve the package repository at the given location."""
         if path := pathfromlocation(location):
             if path.exists() and self.match(path):
-                if self.loader is not None:
-                    return self.loader.load(location.name, path)
+                assert self.loader is not None  # noqa: S101
 
-                assert self.mount is not None  # noqa: S101
-
-                return DefaultPackageRepository(location.name, path, mount=self.mount)
+                return self.loader.load(location.name, path)
 
         return None
 

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -34,7 +34,7 @@ class PackageRepository(abc.ABC):
         """Return the parent revision, if any."""
 
 
-class PackageRepositoryProvider(abc.ABC):
+class PackageRepositoryLoader(abc.ABC):
     """A provider of package repositories."""
 
     @abc.abstractmethod

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -38,7 +38,7 @@ class PackageRepositoryLoader(abc.ABC):
     """Loader for package repositories."""
 
     @abc.abstractmethod
-    def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
+    def load(self, name: str, path: pathlib.Path) -> PackageRepository:
         """Load a package repository from disk."""
 
 

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -1,7 +1,6 @@
 """Package repositories."""
 import abc
 import pathlib
-from collections.abc import Callable
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -43,25 +42,16 @@ class PackageRepositoryProvider(abc.ABC):
         """Load a package repository."""
 
 
-GetRevision = Callable[[pathlib.Path, Optional[Revision]], Optional[Revision]]
-
-
 class DefaultPackageRepository(PackageRepository):
     """Default implementation of a package repository."""
 
     def __init__(
-        self,
-        name: str,
-        path: pathlib.Path,
-        *,
-        mount: Optional[Mounter] = None,
-        getrevision: Optional[GetRevision] = None,
+        self, name: str, path: pathlib.Path, *, mount: Optional[Mounter] = None
     ) -> None:
         """Initialize."""
         self.name = name
         self.path = path
         self._mount = mount
-        self._getrevision = getrevision
 
     @contextmanager
     def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
@@ -87,10 +77,7 @@ class DefaultPackageRepository(PackageRepository):
 
     def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the resolved revision."""
-        if self._getrevision is None:
-            return revision
-
-        return self._getrevision(self.path, revision)
+        return revision
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -34,14 +34,6 @@ class PackageRepository(abc.ABC):
         """Return the parent revision, if any."""
 
 
-class PackageRepositoryLoader(abc.ABC):
-    """Loader for package repositories."""
-
-    @abc.abstractmethod
-    def load(self, name: str, path: pathlib.Path) -> PackageRepository:
-        """Load a package repository from disk."""
-
-
 class DefaultPackageRepository(PackageRepository):
     """Default implementation of a package repository."""
 

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -11,7 +11,6 @@ from cutty.errors import CuttyError
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.filesystems.domain.path import Path
-from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.package import Package
 from cutty.packages.domain.revisions import Revision
 
@@ -45,13 +44,11 @@ def _defaultmount(
 class DefaultPackageRepository(PackageRepository):
     """Default implementation of a package repository."""
 
-    def __init__(
-        self, name: str, path: pathlib.Path, *, mount: Mounter = _defaultmount
-    ) -> None:
+    def __init__(self, name: str, path: pathlib.Path) -> None:
         """Initialize."""
         self.name = name
         self.path = path
-        self._mount = mount
+        self._mount = _defaultmount
 
     @contextmanager
     def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -35,11 +35,11 @@ class PackageRepository(abc.ABC):
 
 
 class PackageRepositoryLoader(abc.ABC):
-    """A provider of package repositories."""
+    """Loader for package repositories."""
 
     @abc.abstractmethod
     def provide(self, name: str, path: pathlib.Path) -> PackageRepository:
-        """Load a package repository."""
+        """Load a package repository from disk."""
 
 
 class DefaultPackageRepository(PackageRepository):

--- a/tests/fixtures/packages/domain/mounters.py
+++ b/tests/fixtures/packages/domain/mounters.py
@@ -8,17 +8,9 @@ import pytest
 
 from cutty.compat.contextlib import contextmanager
 from cutty.filesystems.adapters.dict import DictFilesystem
-from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.packages.domain.mounters import Mounter
-from cutty.packages.domain.mounters import unversioned_mounter
 from cutty.packages.domain.revisions import Revision
-
-
-@pytest.fixture
-def diskmounter() -> Mounter:
-    """Fixture with an unversioned disk filesystem mounter."""
-    return unversioned_mounter(DiskFilesystem)
 
 
 @pytest.fixture

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -5,12 +5,14 @@ import pathlib
 import pytest
 from yarl import URL
 
+from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.packages.domain.fetchers import Fetcher
 from cutty.packages.domain.loader import MountedPackageRepositoryLoader
 from cutty.packages.domain.loader import PackageRepositoryLoader
 from cutty.packages.domain.locations import asurl
 from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.mounters import Mounter
+from cutty.packages.domain.mounters import unversioned_mounter
 from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.stores import Store
@@ -24,9 +26,9 @@ pytest_plugins = [
 
 
 @pytest.fixture
-def loader(diskmounter: Mounter) -> PackageRepositoryLoader:
+def loader() -> PackageRepositoryLoader:
     """Fixture for a repository loader."""
-    return MountedPackageRepositoryLoader(diskmounter)
+    return MountedPackageRepositoryLoader(unversioned_mounter(DiskFilesystem))
 
 
 def test_localprovider_not_local(url: URL, loader: PackageRepositoryLoader) -> None:

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -7,6 +7,7 @@ from yarl import URL
 
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.packages.domain.fetchers import Fetcher
+from cutty.packages.domain.loader import DefaultPackageRepositoryLoader
 from cutty.packages.domain.loader import MountedPackageRepositoryLoader
 from cutty.packages.domain.loader import PackageRepositoryLoader
 from cutty.packages.domain.locations import asurl
@@ -28,7 +29,7 @@ pytest_plugins = [
 @pytest.fixture
 def loader() -> PackageRepositoryLoader:
     """Fixture for a repository loader."""
-    return MountedPackageRepositoryLoader(unversioned_mounter(DiskFilesystem))
+    return DefaultPackageRepositoryLoader()
 
 
 def test_localprovider_not_local(url: URL, loader: PackageRepositoryLoader) -> None:

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -64,16 +64,13 @@ def test_localprovider_path(tmp_path: pathlib.Path) -> None:
         assert entry.name == "marker"
 
 
-def test_localprovider_revision(
-    tmp_path: pathlib.Path,
-) -> None:
+def test_localprovider_revision(tmp_path: pathlib.Path) -> None:
     """It raises an exception if the mounter does not support revisions."""
     loader = MountedPackageRepositoryLoader(unversioned_mounter(DiskFilesystem))
-    url = asurl(tmp_path)
     provider = LocalProvider(match=lambda path: True, loader=loader)
 
     with pytest.raises(Exception):
-        if repository := provider.provide(url):
+        if repository := provider.provide(tmp_path):
             with repository.get("v1.0.0"):
                 pass
 

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -76,9 +76,10 @@ def test_localprovider_path(
 
 
 def test_localprovider_revision(
-    tmp_path: pathlib.Path, loader: PackageRepositoryLoader
+    tmp_path: pathlib.Path,
 ) -> None:
     """It raises an exception if the mounter does not support revisions."""
+    loader = MountedPackageRepositoryLoader(unversioned_mounter(DiskFilesystem))
     url = asurl(tmp_path)
     provider = LocalProvider(match=lambda path: True, loader=loader)
 

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -7,9 +7,7 @@ from yarl import URL
 
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.packages.domain.fetchers import Fetcher
-from cutty.packages.domain.loader import DefaultPackageRepositoryLoader
 from cutty.packages.domain.loader import MountedPackageRepositoryLoader
-from cutty.packages.domain.loader import PackageRepositoryLoader
 from cutty.packages.domain.locations import asurl
 from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.mounters import Mounter
@@ -26,47 +24,37 @@ pytest_plugins = [
 ]
 
 
-@pytest.fixture
-def loader() -> PackageRepositoryLoader:
-    """Fixture for a repository loader."""
-    return DefaultPackageRepositoryLoader()
-
-
-def test_localprovider_not_local(url: URL, loader: PackageRepositoryLoader) -> None:
+def test_localprovider_not_local(url: URL) -> None:
     """It returns None if the location is not local."""
-    provider = LocalProvider(match=lambda path: True, loader=loader)
+    provider = LocalProvider(match=lambda path: True)
 
     assert provider.provide(url) is None
 
 
-def test_localprovider_not_matching(
-    tmp_path: pathlib.Path, loader: PackageRepositoryLoader
-) -> None:
+def test_localprovider_not_matching(tmp_path: pathlib.Path) -> None:
     """It returns None if the provider does not match."""
     url = asurl(tmp_path)
-    provider = LocalProvider(match=lambda path: False, loader=loader)
+    provider = LocalProvider(match=lambda path: False)
 
     assert provider.provide(url) is None
 
 
-def test_localprovider_inexistent_path(loader: PackageRepositoryLoader) -> None:
+def test_localprovider_inexistent_path() -> None:
     """It returns None if the location is an inexistent path."""
-    provider = LocalProvider(match=lambda path: True, loader=loader)
+    provider = LocalProvider(match=lambda path: True)
     path = pathlib.Path("/no/such/file/or/directory")
 
     assert provider.provide(path) is None
 
 
-def test_localprovider_path(
-    tmp_path: pathlib.Path, loader: PackageRepositoryLoader
-) -> None:
+def test_localprovider_path(tmp_path: pathlib.Path) -> None:
     """It returns the package repository."""
     path = tmp_path / "repository"
     path.mkdir()
     (path / "marker").touch()
 
     url = asurl(path)
-    provider = LocalProvider(match=lambda path: True, loader=loader)
+    provider = LocalProvider(match=lambda path: True)
     repository = provider.provide(url)
 
     assert repository is not None

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -26,7 +26,7 @@ pytest_plugins = [
 
 def test_localprovider_not_local(url: URL) -> None:
     """It returns None if the location is not local."""
-    provider = LocalProvider(match=lambda path: True)
+    provider = LocalProvider()
 
     assert provider.provide(url) is None
 
@@ -41,7 +41,7 @@ def test_localprovider_not_matching(tmp_path: pathlib.Path) -> None:
 
 def test_localprovider_inexistent_path() -> None:
     """It returns None if the location is an inexistent path."""
-    provider = LocalProvider(match=lambda path: True)
+    provider = LocalProvider()
     path = pathlib.Path("/no/such/file/or/directory")
 
     assert provider.provide(path) is None
@@ -54,7 +54,7 @@ def test_localprovider_path(tmp_path: pathlib.Path) -> None:
     (path / "marker").touch()
 
     url = asurl(path)
-    provider = LocalProvider(match=lambda path: True)
+    provider = LocalProvider()
     repository = provider.provide(url)
 
     assert repository is not None
@@ -67,7 +67,7 @@ def test_localprovider_path(tmp_path: pathlib.Path) -> None:
 def test_localprovider_revision(tmp_path: pathlib.Path) -> None:
     """It raises an exception if the mounter does not support revisions."""
     loader = MountedPackageRepositoryLoader(unversioned_mounter(DiskFilesystem))
-    provider = LocalProvider(match=lambda path: True, loader=loader)
+    provider = LocalProvider(loader=loader)
 
     with pytest.raises(Exception):
         if repository := provider.provide(tmp_path):

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -7,6 +7,7 @@ from yarl import URL
 
 from cutty.packages.domain.fetchers import Fetcher
 from cutty.packages.domain.loader import MountedPackageRepositoryLoader
+from cutty.packages.domain.loader import PackageRepositoryLoader
 from cutty.packages.domain.locations import asurl
 from cutty.packages.domain.matchers import Matcher
 from cutty.packages.domain.mounters import Mounter
@@ -22,47 +23,47 @@ pytest_plugins = [
 ]
 
 
-def test_localprovider_not_local(url: URL, diskmounter: Mounter) -> None:
+@pytest.fixture
+def loader(diskmounter: Mounter) -> PackageRepositoryLoader:
+    """Fixture for a repository loader."""
+    return MountedPackageRepositoryLoader(diskmounter)
+
+
+def test_localprovider_not_local(url: URL, loader: PackageRepositoryLoader) -> None:
     """It returns None if the location is not local."""
-    provider = LocalProvider(
-        match=lambda path: True, loader=MountedPackageRepositoryLoader(diskmounter)
-    )
+    provider = LocalProvider(match=lambda path: True, loader=loader)
 
     assert provider.provide(url) is None
 
 
 def test_localprovider_not_matching(
-    tmp_path: pathlib.Path, diskmounter: Mounter
+    tmp_path: pathlib.Path, loader: PackageRepositoryLoader
 ) -> None:
     """It returns None if the provider does not match."""
     url = asurl(tmp_path)
-    provider = LocalProvider(
-        match=lambda path: False, loader=MountedPackageRepositoryLoader(diskmounter)
-    )
+    provider = LocalProvider(match=lambda path: False, loader=loader)
 
     assert provider.provide(url) is None
 
 
-def test_localprovider_inexistent_path(diskmounter: Mounter) -> None:
+def test_localprovider_inexistent_path(loader: PackageRepositoryLoader) -> None:
     """It returns None if the location is an inexistent path."""
-    provider = LocalProvider(
-        match=lambda path: True, loader=MountedPackageRepositoryLoader(diskmounter)
-    )
+    provider = LocalProvider(match=lambda path: True, loader=loader)
     path = pathlib.Path("/no/such/file/or/directory")
 
     assert provider.provide(path) is None
 
 
-def test_localprovider_path(tmp_path: pathlib.Path, diskmounter: Mounter) -> None:
+def test_localprovider_path(
+    tmp_path: pathlib.Path, loader: PackageRepositoryLoader
+) -> None:
     """It returns the package repository."""
     path = tmp_path / "repository"
     path.mkdir()
     (path / "marker").touch()
 
     url = asurl(path)
-    provider = LocalProvider(
-        match=lambda path: True, loader=MountedPackageRepositoryLoader(diskmounter)
-    )
+    provider = LocalProvider(match=lambda path: True, loader=loader)
     repository = provider.provide(url)
 
     assert repository is not None
@@ -72,12 +73,12 @@ def test_localprovider_path(tmp_path: pathlib.Path, diskmounter: Mounter) -> Non
         assert entry.name == "marker"
 
 
-def test_localprovider_revision(tmp_path: pathlib.Path, diskmounter: Mounter) -> None:
+def test_localprovider_revision(
+    tmp_path: pathlib.Path, loader: PackageRepositoryLoader
+) -> None:
     """It raises an exception if the mounter does not support revisions."""
     url = asurl(tmp_path)
-    provider = LocalProvider(
-        match=lambda path: True, loader=MountedPackageRepositoryLoader(diskmounter)
-    )
+    provider = LocalProvider(match=lambda path: True, loader=loader)
 
     with pytest.raises(Exception):
         if repository := provider.provide(url):

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -7,6 +7,7 @@ from yarl import URL
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.packages.domain.fetchers import Fetcher
+from cutty.packages.domain.loader import MountedPackageRepositoryLoader
 from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.package import Package
 from cutty.packages.domain.providers import ConstProviderFactory
@@ -98,7 +99,11 @@ def test_with_path(
     (directory / "marker").touch()
 
     providerfactory = ConstProviderFactory(
-        LocalProvider("default", match=lambda path: True, mount=diskmounter)
+        LocalProvider(
+            "default",
+            match=lambda path: True,
+            loader=MountedPackageRepositoryLoader(diskmounter),
+        )
     )
 
     registry = ProviderRegistry(providerstore, [providerfactory])

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -7,8 +7,6 @@ from yarl import URL
 from cutty.filesystems.adapters.dict import DictFilesystem
 from cutty.filesystems.domain.path import Path
 from cutty.packages.domain.fetchers import Fetcher
-from cutty.packages.domain.loader import MountedPackageRepositoryLoader
-from cutty.packages.domain.mounters import Mounter
 from cutty.packages.domain.package import Package
 from cutty.packages.domain.providers import ConstProviderFactory
 from cutty.packages.domain.providers import LocalProvider
@@ -91,7 +89,6 @@ def test_with_url(
 def test_with_path(
     tmp_path: pathlib.Path,
     providerstore: ProviderStore,
-    diskmounter: Mounter,
 ) -> None:
     """It returns a provider that allows traversing repositories."""
     directory = tmp_path / "repository"
@@ -99,11 +96,7 @@ def test_with_path(
     (directory / "marker").touch()
 
     providerfactory = ConstProviderFactory(
-        LocalProvider(
-            "default",
-            match=lambda path: True,
-            loader=MountedPackageRepositoryLoader(diskmounter),
-        )
+        LocalProvider("default", match=lambda path: True)
     )
 
     registry = ProviderRegistry(providerstore, [providerfactory])

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -95,9 +95,7 @@ def test_with_path(
     directory.mkdir()
     (directory / "marker").touch()
 
-    providerfactory = ConstProviderFactory(
-        LocalProvider("default", match=lambda path: True)
-    )
+    providerfactory = ConstProviderFactory(LocalProvider("default"))
 
     registry = ProviderRegistry(providerstore, [providerfactory])
     repository = registry.getrepository(str(directory))


### PR DESCRIPTION
- 🔥 [packages] Remove tests for `getrevision` callback
- 🔨 [packages] Remove `getrevision` callback
- 🔨 [packages] Rename class `PackageRepository{Provider => Loader}`
- 💡 [packages] Improve docstrings for `PackageRepositoryLoader`
- 🔨 [packages] Rename class `Git{Provider => RepositoryLoader}`
- 🔨 [packages] Rename class `Mercurial{Provider => RepositoryLoader}`
- 💡 [packages] Adapt docstrings for `{Mercurial,Git}RepositoryLoader`
- 🔨 [packages] Rename function `PackageRepositoryLoader.{provide => load}`
- 🔨 [packages] Rename parameter `{provider => loader}` in `*Provider`
- 🔨 [packages] Move class `PackageRepositoryLoader` to `loader` module
- 🔨 [packages] Add class `MountedPackageRepositoryLoader`
- 🔨 [packages] Use `MountedPackageRepositoryLoader` for zip providers
- 🔨 [packages] Use `MountedPackageRepositoryLoader` for disk provider
- 🔨 [packages] Use `MountedPackageRepositoryLoader` in provider tests
- 🔨 [packages] Use `MountedPackageRepositoryLoader` in registry tests
- 🔨 [packages] Remove dead code in `LocalProvider`
- 🔨 [packages] Remove attribute `LocalProvider.mount`
- 🔨 [packages] Require parameter `loader` in `LocalProvider`
- 🔨 [packages] Remove parameter `mount` from `RemoteProviderFactory`
- 🔨 [packages] Remove parameter `mount` from `RemoteProvider`
- 🔨 [packages] Move default mounter from `RemoteProvider` to `DefaultPackageRepository`
- 🔨 [packages] Extract class `DefaultPackageRepositoryLoader`
- 🔨 [packages] Extract nested class `_Repository` in `MountedPackageRepositoryLoader.load`
- 🔨 [packages] Remove parameter `mount` from `DefaultPackageRepository`
- 🔨 [packages] Inline attribute `DefaultPackageRepository._mount`
- 🔨 [packages] Extract fixture `loader` from `test_providers`
- 💡 [packages] Improve docstring of `MountedPackageRepositoryLoader`
- 🔨 [packages] Inline fixture `diskmounter` into fixture `loader`
- 🔨 [packages] Inline fixture `loader` into `test_localprovider_revision`
- 🔨 [packages] Use `DefaultPackageRepositoryLoader` in `loader` fixture
- 🔨 [packages] Do not require `loader` parameter for `LocalProvider`
- 🔨 [packages] Omit `loader` for `LocalProvider` in `test_providers`
- 🔨 [packages] Remove redundant `asurl` in `test_localprovider_revision`
- 🔨 [packages] Omit `loader` for `LocalProvider` in `test_registry`
- 🔨 [packages] Remove fixture `diskmounter`
- 🔨 [packages] Do not require `match` parameter for `LocalProvider`
- 🔨 [packages] Omit `match` for `LocalProvider` in tests
