### PR TITLE
🔨 [projects] Minor refactorings in `TemplateProvider`

### DIFF
--- a/src/cutty/packages/adapters/storage.py
+++ b/src/cutty/packages/adapters/storage.py
@@ -14,8 +14,6 @@ from typing import Optional
 
 from yarl import URL
 
-from cutty.packages.adapters.registry import defaultproviderfactories
-from cutty.packages.domain.registry import ProviderRegistry
 from cutty.packages.domain.registry import ProviderStore
 from cutty.packages.domain.stores import Store
 
@@ -146,13 +144,3 @@ def getdefaultproviderstore(
         return store
 
     return providerstore
-
-
-def getdefaultpackageprovider(
-    path: pathlib.Path, *, timer: Timer = defaulttimer
-) -> ProviderRegistry:
-    """Return a package provider."""
-    return ProviderRegistry(
-        getdefaultproviderstore(path, timer=timer),
-        defaultproviderfactories,
-    )

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -11,7 +11,8 @@ import platformdirs
 from cutty.compat.contextlib import contextmanager
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.packages.adapters.storage import getdefaultpackageprovider
+from cutty.packages.adapters.registry import defaultproviderfactories
+from cutty.packages.adapters.storage import getdefaultproviderstore
 from cutty.packages.domain.registry import ProviderRegistry
 from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
@@ -27,7 +28,9 @@ class TemplateProvider:
     def create(cls) -> TemplateProvider:
         """Create the template provider."""
         cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
-        packageprovider = getdefaultpackageprovider(cachedir)
+        packageprovider = ProviderRegistry(
+            getdefaultproviderstore(cachedir), defaultproviderfactories
+        )
 
         return cls(packageprovider)
 

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -22,23 +22,23 @@ from cutty.packages.domain.revisions import Revision
 class TemplateProvider:
     """Provider of project templates."""
 
-    packageprovider: ProviderRegistry
+    registry: ProviderRegistry
 
     @classmethod
     def create(cls) -> TemplateProvider:
         """Create the template provider."""
         cachedir = pathlib.Path(platformdirs.user_cache_dir("cutty"))
-        packageprovider = ProviderRegistry(
+        registry = ProviderRegistry(
             getdefaultproviderstore(cachedir), defaultproviderfactories
         )
 
-        return cls(packageprovider)
+        return cls(registry)
 
     def provide(
         self, location: str, directory: Optional[pathlib.Path]
     ) -> TemplateRepository:
         """Load a template repository."""
-        repository = self.packageprovider.getrepository(location)
+        repository = self.registry.getrepository(location)
 
         return TemplateRepository(repository, location, directory)
 


### PR DESCRIPTION
- 🔨 [packages] Inline function `getdefaultpackageprovider`
- 🔨 [projects] Rename attribute `TemplateProvider.{packageprovider => registry}`
