### PR TITLE
🐛 [projects] Fix unwarranted staging on import and conflict resolution

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -149,6 +149,7 @@ class ProjectRepository:
             message=commit.message,
             author=commit.author,
             committer=self.project.default_signature,
+            stageallfiles=False,
         )
 
     def abort(self) -> None:

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -271,3 +271,20 @@ def test_abort(runcutty: RunCutty, templateproject: Path, project: Path) -> None
     runcutty("import", f"--cwd={project}", "--abort")
 
     assert (project / "LICENSE").read_text() == "a"
+
+
+def test_untracked_files(
+    runcutty: RunCutty, template: Path, templateproject: Path, project: Path
+) -> None:
+    """It does not commit untracked files."""
+    untracked = project / "untracked-file"
+    untracked.touch()
+
+    # Update twice to produce a conflict in cutty.json.
+    updatefile(templateproject / "LICENSE")
+    updatefile(templateproject / "COPYING")
+
+    with chdir(project):
+        runcutty("import")
+
+    assert untracked.name not in tree(project)

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -84,6 +84,19 @@ def test_continue_state_cleanup(repository: Repository, path: Path) -> None:
     assert repository.cherrypickhead is None
 
 
+def test_continue_untracked(repository: Repository, path: Path) -> None:
+    """It does not commit untracked files."""
+    createconflict(repository, path, ours="a", theirs="b")
+    resolveconflicts(repository.path, path, Side.THEIRS)
+
+    untracked = repository.path / "untracked"
+    untracked.touch()
+
+    continue_(repository.path)
+
+    assert untracked.name not in repository.head.commit.tree
+
+
 def test_abort(repository: Repository, path: Path) -> None:
     """It uses our version."""
     createconflict(repository, path, ours="a", theirs="b")


### PR DESCRIPTION
`ProjectRepository.continue_` erroneously staged all files in the working directory before committing. It now only commits files that have been staged previously.

This bug was triggered on multiple code paths:

- With `cutty update --continue`.
- With `cutty import --continue`.
- With `cutty import` when the imported revision is not preceded by the revision recorded in cutty.json. In this situation, cutty resolves a spurious conflict in cutty.json and uses `continue_` to commit the result.