### PR TITLE
✨ [projects] Preserve author information when importing changes from git repositories

### DIFF
--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -99,6 +99,13 @@ class GitPackageRepository(DefaultPackageRepository):
 
         return message
 
+    def getauthor(self, revision: Optional[Revision]) -> Optional[str]:
+        """Return the commit author."""
+        commit = self._lookup(revision)
+        author: str = commit.author.name
+
+        return author
+
 
 class GitRepositoryLoader(PackageRepositoryLoader):
     """Git repository loader."""

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -106,6 +106,13 @@ class GitPackageRepository(DefaultPackageRepository):
 
         return author
 
+    def getauthoremail(self, revision: Optional[Revision]) -> Optional[str]:
+        """Return the commit author email."""
+        commit = self._lookup(revision)
+        email: str = commit.author.email
+
+        return email
+
 
 class GitRepositoryLoader(PackageRepositoryLoader):
     """Git repository loader."""

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -20,6 +20,7 @@ class Package:
     commit: Optional[str] = None
     message: Optional[str] = None
     author: Optional[str] = None
+    authoremail: Optional[str] = None
 
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""
@@ -27,5 +28,11 @@ class Package:
         tree = Path(filesystem=PathFilesystem(tree))
 
         return Package(
-            directory.name, tree, self.revision, self.commit, self.message, self.author
+            directory.name,
+            tree,
+            self.revision,
+            self.commit,
+            self.message,
+            self.author,
+            self.authoremail,
         )

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -19,10 +19,13 @@ class Package:
     revision: Optional[Revision]
     commit: Optional[str] = None
     message: Optional[str] = None
+    author: Optional[str] = None
 
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""
         tree = self.tree.joinpath(*directory.parts)
         tree = Path(filesystem=PathFilesystem(tree))
 
-        return Package(directory.name, tree, self.revision, self.commit, self.message)
+        return Package(
+            directory.name, tree, self.revision, self.commit, self.message, self.author
+        )

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -48,11 +48,14 @@ class DefaultPackageRepository(PackageRepository):
         resolved_revision = self.getrevision(revision)
         message = self.getmessage(revision)
         author = self.getauthor(revision)
+        authoremail = self.getauthoremail(revision)
 
         with self.mount(revision) as filesystem:
             tree = Path(filesystem=filesystem)
 
-            yield Package(self.name, tree, resolved_revision, commit, message, author)
+            yield Package(
+                self.name, tree, resolved_revision, commit, message, author, authoremail
+            )
 
     @contextmanager
     def mount(self, revision: Optional[Revision]) -> Iterator[Filesystem]:
@@ -77,4 +80,8 @@ class DefaultPackageRepository(PackageRepository):
 
     def getauthor(self, revision: Optional[Revision]) -> Optional[str]:
         """Return the commit author."""
+        return None
+
+    def getauthoremail(self, revision: Optional[Revision]) -> Optional[str]:
+        """Return the commit author email."""
         return None

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -47,11 +47,12 @@ class DefaultPackageRepository(PackageRepository):
         commit = self.getcommit(revision)
         resolved_revision = self.getrevision(revision)
         message = self.getmessage(revision)
+        author = self.getauthor(revision)
 
         with self.mount(revision) as filesystem:
             tree = Path(filesystem=filesystem)
 
-            yield Package(self.name, tree, resolved_revision, commit, message)
+            yield Package(self.name, tree, resolved_revision, commit, message, author)
 
     @contextmanager
     def mount(self, revision: Optional[Revision]) -> Iterator[Filesystem]:
@@ -72,4 +73,8 @@ class DefaultPackageRepository(PackageRepository):
 
     def getmessage(self, revision: Optional[Revision]) -> Optional[str]:
         """Return the commit message."""
+        return None
+
+    def getauthor(self, revision: Optional[Revision]) -> Optional[str]:
+        """Return the commit author."""
         return None

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -41,7 +41,9 @@ def commitproject(
         storeproject(project, builder.path)
 
         return builder.commit(
-            commitmessage(project.template), author=project.template.author
+            commitmessage(project.template),
+            author=project.template.author,
+            authoremail=project.template.authoremail,
         )
 
 

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -40,7 +40,9 @@ def commitproject(
     with repository.build(parent=parent) as builder:
         storeproject(project, builder.path)
 
-        return builder.commit(commitmessage(project.template))
+        return builder.commit(
+            commitmessage(project.template), author=project.template.author
+        )
 
 
 def buildproject(

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -34,9 +34,15 @@ class ProjectBuilder:
         """Return the project directory."""
         return self._worktree.path
 
-    def commit(self, message: str) -> str:
+    def commit(self, message: str, author: Optional[str] = None) -> str:
         """Commit the project."""
-        self._worktree.commit(message=message)
+        signature = self._worktree.default_signature
+        if author is not None:
+            signature = pygit2.Signature(
+                author, signature.email, signature.time, signature.offset
+            )
+
+        self._worktree.commit(message=message, author=signature)
         return str(self._worktree.head.commit.id)
 
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -34,12 +34,21 @@ class ProjectBuilder:
         """Return the project directory."""
         return self._worktree.path
 
-    def commit(self, message: str, author: Optional[str] = None) -> str:
+    def commit(
+        self,
+        message: str,
+        author: Optional[str] = None,
+        authoremail: Optional[str] = None,
+    ) -> str:
         """Commit the project."""
         signature = self._worktree.default_signature
         if author is not None:
             signature = pygit2.Signature(
                 author, signature.email, signature.time, signature.offset
+            )
+        if authoremail is not None:
+            signature = pygit2.Signature(
+                signature.name, authoremail, signature.time, signature.offset
             )
 
         self._worktree.commit(message=message, author=signature)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -90,6 +90,7 @@ class Template:
         commit: Optional[str] = None
         message: Optional[str] = None
         author: Optional[str] = None
+        authoremail: Optional[str] = None
 
     metadata: Metadata
     root: Path

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -65,6 +65,7 @@ class TemplateRepository:
                 package.revision,
                 package.commit,
                 package.message,
+                package.author,
             )
 
             yield Template(metadata, package.tree)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -66,6 +66,7 @@ class TemplateRepository:
                 package.commit,
                 package.message,
                 package.author,
+                package.authoremail,
             )
 
             yield Template(metadata, package.tree)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -88,6 +88,7 @@ class Template:
         revision: Optional[Revision]
         commit: Optional[str] = None
         message: Optional[str] = None
+        author: Optional[str] = None
 
     metadata: Metadata
     root: Path

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -181,6 +181,27 @@ def test_message(
     assert commit(template).message == commit(project).message
 
 
+def test_author(
+    runcutty: RunCutty, template: Path, templateproject: Path, project: Path
+) -> None:
+    """It preserves author info from the imported changeset."""
+    repository = Repository.open(template)
+
+    path = templateproject / "marker"
+    path.touch()
+
+    expected = pygit2.Signature("The Author", "the.author@example.com")
+    repository.commit(message=f"Add {path.name}", author=expected)
+
+    with chdir(project):
+        runcutty("import")
+
+    author = commit(project).author
+
+    assert expected.name == author.name
+    assert expected.email == author.email
+
+
 def test_extra_context_old_variable(
     runcutty: RunCutty, templateproject: Path, project: Path
 ) -> None:

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -90,6 +90,16 @@ def test_local_revision_commit(url: URL) -> None:
         )
 
 
+def test_local_author(url: URL) -> None:
+    """It retrieves the author name."""
+    repository = localgitprovider.provide(url)
+
+    assert repository is not None
+
+    with repository.get() as package:
+        assert package.author is not None
+
+
 @pytest.fixture
 def gitprovider(store: Store) -> Provider:
     """Fixture for a git provider."""

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -91,13 +91,14 @@ def test_local_revision_commit(url: URL) -> None:
 
 
 def test_local_author(url: URL) -> None:
-    """It retrieves the author name."""
+    """It retrieves the author name and email."""
     repository = localgitprovider.provide(url)
 
     assert repository is not None
 
     with repository.get() as package:
         assert package.author is not None
+        assert package.authoremail is not None
 
 
 @pytest.fixture


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty import` preserving author and date
- ✅ [packages] Add test for `Package.author` retrieved by git provider
- 🔨 [packages] Add optional attribute `Package.author`
- 🔨 [packages] Add function `DefaultPackageRepository.getauthor`
- ✨ [packages] Retrieve author name in `GitPackageRepository`
- 🔨 [projects] Add optional attribute `Template.Metadata.author`
- 🔨 [projects] Initialize `Template.Metadata.author` from `Package.author`
- 🔨 [projects] Add optional parameter `author` to `ProjectBuilder.commit`
- ✨ [projects] Preserve commit author when importing template changes
- ✅ [packages] Add test for git provider retrieving author email
- 🔨 [packages] Add optional attribute `Package.authoremail`
- 🔨 [packages] Add function `DefaultPackageRepository.getauthoremail`
- ✨ [packages] Add function `GitPackageRepository.getauthoremail`
- 🔨 [projects] Add optional attribute `Template.Metadata.authoremail`
- 🔨 [projects] Initialize `Template.Metadata.authoremail` from `Package.authoremail`
- ✨ [projects] Add optional parameter `authoremail` to `ProjectBuilder.commit`
- ✨ [projects] Preserve author email when importing template changes
