### PR TITLE
🔨 [packages] Consolidate repository hooks into `lookup` function returning `Commit` instance

### DIFF
--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -52,12 +52,13 @@ class GitPackageRepository(DefaultPackageRepository):
         commit = self._lookup(revision)
 
         resolved_revision = self.getrevision(revision)
-        message = self.getmessage(revision)
-        author = self.getauthor(revision)
-        authoremail = self.getauthoremail(revision)
 
         return Commit.create(
-            resolved_revision, str(commit.id), message, author, authoremail
+            resolved_revision,
+            str(commit.id),
+            commit.message,
+            commit.author.name,
+            commit.author.email,
         )
 
     def _lookup(self, revision: Optional[Revision]) -> pygit2.Commit:
@@ -99,27 +100,6 @@ class GitPackageRepository(DefaultPackageRepository):
             return str(parent.id)
 
         return None
-
-    def getmessage(self, revision: Optional[Revision]) -> Optional[str]:
-        """Return the commit message."""
-        commit = self._lookup(revision)
-        message: str = commit.message
-
-        return message
-
-    def getauthor(self, revision: Optional[Revision]) -> Optional[str]:
-        """Return the commit author."""
-        commit = self._lookup(revision)
-        author: str = commit.author.name
-
-        return author
-
-    def getauthoremail(self, revision: Optional[Revision]) -> Optional[str]:
-        """Return the commit author email."""
-        commit = self._lookup(revision)
-        email: str = commit.author.email
-
-        return email
 
 
 class GitRepositoryLoader(PackageRepositoryLoader):

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -11,6 +11,7 @@ from cutty.errors import CuttyError
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.packages.adapters.fetchers.git import gitfetcher
 from cutty.packages.domain.loader import PackageRepositoryLoader
+from cutty.packages.domain.package import Author
 from cutty.packages.domain.package import Commit
 from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import RemoteProviderFactory
@@ -50,14 +51,9 @@ class GitPackageRepository(DefaultPackageRepository):
     def lookup(self, revision: Optional[Revision]) -> Optional[Commit]:
         """Look up the commit metadata for the given revision."""
         commit = self._lookup(revision)
+        author = Author(commit.author.name, commit.author.email)
 
-        return Commit.create(
-            self.describe(commit),
-            str(commit.id),
-            commit.message,
-            commit.author.name,
-            commit.author.email,
-        )
+        return Commit(str(commit.id), self.describe(commit), commit.message, author)
 
     def _lookup(self, revision: Optional[Revision]) -> pygit2.Commit:
         """Return the commit object."""

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -49,13 +49,16 @@ class GitPackageRepository(DefaultPackageRepository):
 
     def lookup(self, revision: Optional[Revision]) -> Optional[Commit]:
         """Look up the commit metadata for the given revision."""
-        commit = self.getcommit(revision)
+        commit = self._lookup(revision)
+
         resolved_revision = self.getrevision(revision)
         message = self.getmessage(revision)
         author = self.getauthor(revision)
         authoremail = self.getauthoremail(revision)
 
-        return Commit.create(resolved_revision, commit, message, author, authoremail)
+        return Commit.create(
+            resolved_revision, str(commit.id), message, author, authoremail
+        )
 
     def _lookup(self, revision: Optional[Revision]) -> pygit2.Commit:
         """Return the commit object."""
@@ -66,12 +69,6 @@ class GitPackageRepository(DefaultPackageRepository):
             return self.repository.revparse_single(revision).peel(pygit2.Commit)
         except KeyError:
             raise RevisionNotFoundError(revision)
-
-    def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
-        """Return the commit identifier."""
-        commit = self._lookup(revision)
-
-        return str(commit.id)
 
     def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the resolved revision."""

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -51,10 +51,8 @@ class GitPackageRepository(DefaultPackageRepository):
         """Look up the commit metadata for the given revision."""
         commit = self._lookup(revision)
 
-        resolved_revision = self.getrevision(revision)
-
         return Commit.create(
-            resolved_revision,
+            self.describe(commit),
             str(commit.id),
             commit.message,
             commit.author.name,
@@ -71,9 +69,9 @@ class GitPackageRepository(DefaultPackageRepository):
         except KeyError:
             raise RevisionNotFoundError(revision)
 
-    def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
+    def describe(self, commit: pygit2.Commit) -> str:
         """Return the resolved revision."""
-        commit = self._lookup(revision)
+        revision: str
 
         try:
             revision = self.repository.describe(

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -11,6 +11,7 @@ from cutty.errors import CuttyError
 from cutty.filesystems.adapters.git import GitFilesystem
 from cutty.packages.adapters.fetchers.git import gitfetcher
 from cutty.packages.domain.loader import PackageRepositoryLoader
+from cutty.packages.domain.package import Commit
 from cutty.packages.domain.providers import LocalProvider
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.repository import DefaultPackageRepository
@@ -45,6 +46,16 @@ class GitPackageRepository(DefaultPackageRepository):
             yield GitFilesystem(self.path, revision)
         else:
             yield GitFilesystem(self.path)
+
+    def lookup(self, revision: Optional[Revision]) -> Optional[Commit]:
+        """Look up the commit metadata for the given revision."""
+        commit = self.getcommit(revision)
+        resolved_revision = self.getrevision(revision)
+        message = self.getmessage(revision)
+        author = self.getauthor(revision)
+        authoremail = self.getauthoremail(revision)
+
+        return Commit.create(resolved_revision, commit, message, author, authoremail)
 
     def _lookup(self, revision: Optional[Revision]) -> pygit2.Commit:
         """Return the commit object."""

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -32,11 +32,13 @@ class MercurialPackageRepository(DefaultPackageRepository):
 
     def lookup(self, revision: Optional[Revision]) -> Optional[Commit]:
         """Look up the commit metadata for the given revision."""
-        commit = self.getcommit(revision)
-        resolved_revision = self.getrevision(revision)
-        message = self.getmessage(revision)
-        author = self.getauthor(revision)
-        authoremail = self.getauthoremail(revision)
+        commit = self.getmetadata(revision, "node")
+        resolved_revision = self.getmetadata(
+            revision, "ifeq(latesttagdistance, 0, latesttag, short(node))"
+        )
+        message = self.getmetadata(revision, "desc")
+        author = self.getmetadata(revision, "author|person")
+        authoremail = self.getmetadata(revision, "author|email")
 
         return Commit.create(resolved_revision, commit, message, author, authoremail)
 
@@ -52,34 +54,12 @@ class MercurialPackageRepository(DefaultPackageRepository):
         )
         return result.stdout
 
-    def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
-        """Return the commit identifier."""
-        return self.getmetadata(revision, "node")
-
-    def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
-        """Return the package revision."""
-        return self.getmetadata(
-            revision, "ifeq(latesttagdistance, 0, latesttag, short(node))"
-        )
-
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
         if revision is None:
             revision = "."
 
         return self.getmetadata(f"p1({revision})", "node") or None
-
-    def getmessage(self, revision: Optional[Revision]) -> Optional[str]:
-        """Return the commit message."""
-        return self.getmetadata(revision, "desc")
-
-    def getauthor(self, revision: Optional[Revision]) -> Optional[str]:
-        """Return the name of the commit author."""
-        return self.getmetadata(revision, "author|person")
-
-    def getauthoremail(self, revision: Optional[Revision]) -> Optional[str]:
-        """Return the E-mail address of the commit author."""
-        return self.getmetadata(revision, "author|email")
 
 
 class MercurialRepositoryLoader(PackageRepositoryLoader):

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -10,6 +10,7 @@ from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.packages.adapters.fetchers.mercurial import findhg
 from cutty.packages.adapters.fetchers.mercurial import hgfetcher
 from cutty.packages.domain.loader import PackageRepositoryLoader
+from cutty.packages.domain.package import Commit
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.revisions import Revision
@@ -28,6 +29,16 @@ class MercurialPackageRepository(DefaultPackageRepository):
             hg("archive", *options, directory, cwd=self.path)
 
             yield DiskFilesystem(pathlib.Path(directory))
+
+    def lookup(self, revision: Optional[Revision]) -> Optional[Commit]:
+        """Look up the commit metadata for the given revision."""
+        commit = self.getcommit(revision)
+        resolved_revision = self.getrevision(revision)
+        message = self.getmessage(revision)
+        author = self.getauthor(revision)
+        authoremail = self.getauthoremail(revision)
+
+        return Commit.create(resolved_revision, commit, message, author, authoremail)
 
     def getmetadata(self, revision: Optional[Revision], template: str) -> Optional[str]:
         """Return commit metadata."""

--- a/src/cutty/packages/adapters/providers/mercurial.py
+++ b/src/cutty/packages/adapters/providers/mercurial.py
@@ -12,6 +12,7 @@ from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.packages.adapters.fetchers.mercurial import findhg
 from cutty.packages.adapters.fetchers.mercurial import hgfetcher
 from cutty.packages.domain.loader import PackageRepositoryLoader
+from cutty.packages.domain.package import Author
 from cutty.packages.domain.package import Commit
 from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.repository import DefaultPackageRepository
@@ -54,8 +55,11 @@ class MercurialPackageRepository(DefaultPackageRepository):
         text = self.getmetadata(revision, template)
         data = json.loads(text)
 
-        return Commit.create(
-            data["revision"], data["id"], data["message"], data["name"], data["email"]
+        return Commit(
+            data["id"],
+            data["revision"],
+            data["message"],
+            Author(data["name"], data["email"]),
         )
 
     def getmetadata(self, revision: Optional[Revision], template: str) -> str:

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -54,11 +54,11 @@ class Package:
 
     name: str
     tree: Path
-    commit2: Optional[Commit] = None
+    commit: Optional[Commit] = None
 
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""
         tree = self.tree.joinpath(*directory.parts)
         tree = Path(filesystem=PathFilesystem(tree))
 
-        return Package(directory.name, tree, self.commit2)
+        return Package(directory.name, tree, self.commit)

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -16,7 +16,7 @@ class Package:
 
     name: str
     tree: Path
-    revision: Optional[Revision]
+    revision: Optional[Revision] = None
     commit: Optional[str] = None
     message: Optional[str] = None
     author: Optional[str] = None

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -11,6 +11,24 @@ from cutty.packages.domain.revisions import Revision
 
 
 @dataclass
+class Author:
+    """The commit author."""
+
+    name: str
+    email: str
+
+
+@dataclass
+class Commit:
+    """A commit in a versioned repository."""
+
+    id: str
+    revision: str
+    message: str
+    author: Author
+
+
+@dataclass
 class Package:
     """A package."""
 
@@ -21,6 +39,24 @@ class Package:
     message: Optional[str] = None
     author: Optional[str] = None
     authoremail: Optional[str] = None
+
+    @property
+    def commit2(self) -> Optional[Commit]:
+        """Return the commit metadata."""
+        if self.commit is None:
+            return None
+
+        assert self.revision is not None  # noqa: S101
+        assert self.message is not None  # noqa: S101
+        assert self.author is not None  # noqa: S101
+        assert self.authoremail is not None  # noqa: S101
+
+        return Commit(
+            self.commit,
+            self.revision,
+            self.message,
+            Author(self.author, self.authoremail),
+        )
 
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -54,30 +54,11 @@ class Package:
 
     name: str
     tree: Path
-    _revision: Optional[Revision] = None
-    _commit: Optional[str] = None
-    _message: Optional[str] = None
-    _author: Optional[str] = None
-    _authoremail: Optional[str] = None
-
-    @property
-    def commit2(self) -> Optional[Commit]:
-        """Return the commit metadata."""
-        return Commit.create(
-            self._revision, self._commit, self._message, self._author, self._authoremail
-        )
+    commit2: Optional[Commit] = None
 
     def descend(self, directory: PurePath) -> Package:
         """Return the subpackage located in the given directory."""
         tree = self.tree.joinpath(*directory.parts)
         tree = Path(filesystem=PathFilesystem(tree))
 
-        return Package(
-            directory.name,
-            tree,
-            self._revision,
-            self._commit,
-            self._message,
-            self._author,
-            self._authoremail,
-        )
+        return Package(directory.name, tree, self.commit2)

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -27,6 +27,26 @@ class Commit:
     message: str
     author: Author
 
+    @classmethod
+    def create(
+        cls,
+        _revision: Optional[Revision] = None,
+        _commit: Optional[str] = None,
+        _message: Optional[str] = None,
+        _author: Optional[str] = None,
+        _authoremail: Optional[str] = None,
+    ) -> Optional[Commit]:
+        """Create a commit instance."""
+        if _commit is None:
+            return None
+
+        assert _revision is not None  # noqa: S101
+        assert _message is not None  # noqa: S101
+        assert _author is not None  # noqa: S101
+        assert _authoremail is not None  # noqa: S101
+
+        return cls(_commit, _revision, _message, Author(_author, _authoremail))
+
 
 @dataclass
 class Package:
@@ -43,19 +63,8 @@ class Package:
     @property
     def commit2(self) -> Optional[Commit]:
         """Return the commit metadata."""
-        if self._commit is None:
-            return None
-
-        assert self._revision is not None  # noqa: S101
-        assert self._message is not None  # noqa: S101
-        assert self._author is not None  # noqa: S101
-        assert self._authoremail is not None  # noqa: S101
-
-        return Commit(
-            self._commit,
-            self._revision,
-            self._message,
-            Author(self._author, self._authoremail),
+        return Commit.create(
+            self._revision, self._commit, self._message, self._author, self._authoremail
         )
 
     def descend(self, directory: PurePath) -> Package:

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -7,7 +7,6 @@ from typing import Optional
 from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.pathfs import PathFilesystem
 from cutty.filesystems.domain.purepath import PurePath
-from cutty.packages.domain.revisions import Revision
 
 
 @dataclass
@@ -26,26 +25,6 @@ class Commit:
     revision: str
     message: str
     author: Author
-
-    @classmethod
-    def create(
-        cls,
-        _revision: Optional[Revision] = None,
-        _commit: Optional[str] = None,
-        _message: Optional[str] = None,
-        _author: Optional[str] = None,
-        _authoremail: Optional[str] = None,
-    ) -> Optional[Commit]:
-        """Create a commit instance."""
-        if _commit is None:
-            return None
-
-        assert _revision is not None  # noqa: S101
-        assert _message is not None  # noqa: S101
-        assert _author is not None  # noqa: S101
-        assert _authoremail is not None  # noqa: S101
-
-        return cls(_commit, _revision, _message, Author(_author, _authoremail))
 
 
 @dataclass

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -34,28 +34,28 @@ class Package:
 
     name: str
     tree: Path
-    revision: Optional[Revision] = None
-    commit: Optional[str] = None
-    message: Optional[str] = None
-    author: Optional[str] = None
-    authoremail: Optional[str] = None
+    _revision: Optional[Revision] = None
+    _commit: Optional[str] = None
+    _message: Optional[str] = None
+    _author: Optional[str] = None
+    _authoremail: Optional[str] = None
 
     @property
     def commit2(self) -> Optional[Commit]:
         """Return the commit metadata."""
-        if self.commit is None:
+        if self._commit is None:
             return None
 
-        assert self.revision is not None  # noqa: S101
-        assert self.message is not None  # noqa: S101
-        assert self.author is not None  # noqa: S101
-        assert self.authoremail is not None  # noqa: S101
+        assert self._revision is not None  # noqa: S101
+        assert self._message is not None  # noqa: S101
+        assert self._author is not None  # noqa: S101
+        assert self._authoremail is not None  # noqa: S101
 
         return Commit(
-            self.commit,
-            self.revision,
-            self.message,
-            Author(self.author, self.authoremail),
+            self._commit,
+            self._revision,
+            self._message,
+            Author(self._author, self._authoremail),
         )
 
     def descend(self, directory: PurePath) -> Package:
@@ -66,9 +66,9 @@ class Package:
         return Package(
             directory.name,
             tree,
-            self.revision,
-            self.commit,
-            self.message,
-            self.author,
-            self.authoremail,
+            self._revision,
+            self._commit,
+            self._message,
+            self._author,
+            self._authoremail,
         )

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -59,34 +59,14 @@ class DefaultPackageRepository(PackageRepository):
 
     def lookup(self, revision: Optional[Revision]) -> Optional[Commit]:
         """Look up the commit metadata for the given revision."""
-        commit = self.getcommit(revision)
-        resolved_revision = self.getrevision(revision)
-        message = self.getmessage(revision)
-        author = self.getauthor(revision)
-        authoremail = self.getauthoremail(revision)
+        commit = None
+        resolved_revision = revision
+        message = None
+        author = None
+        authoremail = None
 
         return Commit.create(resolved_revision, commit, message, author, authoremail)
-
-    def getcommit(self, revision: Optional[Revision]) -> Optional[Revision]:
-        """Return the commit identifier."""
-        return None
-
-    def getrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
-        """Return the resolved revision."""
-        return revision
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""
         raise ParentRevisionNotImplementedError(self.name)
-
-    def getmessage(self, revision: Optional[Revision]) -> Optional[str]:
-        """Return the commit message."""
-        return None
-
-    def getauthor(self, revision: Optional[Revision]) -> Optional[str]:
-        """Return the commit author."""
-        return None
-
-    def getauthoremail(self, revision: Optional[Revision]) -> Optional[str]:
-        """Return the commit author email."""
-        return None

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -10,6 +10,7 @@ from cutty.errors import CuttyError
 from cutty.filesystems.adapters.disk import DiskFilesystem
 from cutty.filesystems.domain.filesystem import Filesystem
 from cutty.filesystems.domain.path import Path
+from cutty.packages.domain.package import Commit
 from cutty.packages.domain.package import Package
 from cutty.packages.domain.revisions import Revision
 
@@ -54,7 +55,9 @@ class DefaultPackageRepository(PackageRepository):
             tree = Path(filesystem=filesystem)
 
             yield Package(
-                self.name, tree, resolved_revision, commit, message, author, authoremail
+                self.name,
+                tree,
+                Commit.create(resolved_revision, commit, message, author, authoremail),
             )
 
     @contextmanager

--- a/src/cutty/packages/domain/repository.py
+++ b/src/cutty/packages/domain/repository.py
@@ -59,13 +59,7 @@ class DefaultPackageRepository(PackageRepository):
 
     def lookup(self, revision: Optional[Revision]) -> Optional[Commit]:
         """Look up the commit metadata for the given revision."""
-        commit = None
-        resolved_revision = revision
-        message = None
-        author = None
-        authoremail = None
-
-        return Commit.create(resolved_revision, commit, message, author, authoremail)
+        return None
 
     def getparentrevision(self, revision: Optional[Revision]) -> Optional[Revision]:
         """Return the parent revision, if any."""

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -42,10 +42,7 @@ def commitproject(
 
         return builder.commit(
             commitmessage(project.template),
-            author=project.template.commit2.author.name
-            if project.template.commit2
-            else None,
-            authoremail=project.template.commit2.author.email
+            author=project.template.commit2.author
             if project.template.commit2
             else None,
         )

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -42,9 +42,7 @@ def commitproject(
 
         return builder.commit(
             commitmessage(project.template),
-            author=project.template.commit2.author
-            if project.template.commit2
-            else None,
+            author=project.template.commit.author if project.template.commit else None,
         )
 
 

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -40,10 +40,9 @@ def commitproject(
     with repository.build(parent=parent) as builder:
         storeproject(project, builder.path)
 
-        return builder.commit(
-            commitmessage(project.template),
-            author=project.template.commit.author if project.template.commit else None,
-        )
+        author = project.template.commit.author if project.template.commit else None
+
+        return builder.commit(commitmessage(project.template), author=author)
 
 
 def buildproject(

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -42,8 +42,12 @@ def commitproject(
 
         return builder.commit(
             commitmessage(project.template),
-            author=project.template.author,
-            authoremail=project.template.authoremail,
+            author=project.template.commit2.author.name
+            if project.template.commit2
+            else None,
+            authoremail=project.template.commit2.author.email
+            if project.template.commit2
+            else None,
         )
 
 

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -62,7 +62,9 @@ class ProjectGenerator:
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
         revision = (
-            project.template.commit if project.template.commit is not None else None
+            project.template.commit2.id
+            if project.template.commit2 is not None
+            else None
         )
         projectconfig = ProjectConfig(
             project.template.location,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -61,9 +61,7 @@ class ProjectGenerator:
 
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
-        revision = (
-            project.template.commit.id if project.template.commit is not None else None
-        )
+        revision = project.template.commit.id if project.template.commit else None
         projectconfig = ProjectConfig(
             project.template.location,
             bindings,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -62,13 +62,7 @@ class ProjectGenerator:
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
         revision = (
-            project.template.commit
-            if project.template.commit is not None
-            else (
-                None
-                if project.template.commit2 is None
-                else project.template.commit2.revision
-            )
+            project.template.commit if project.template.commit is not None else None
         )
         projectconfig = ProjectConfig(
             project.template.location,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -62,9 +62,7 @@ class ProjectGenerator:
     def addconfig(self, project: Project, bindings: Sequence[Binding]) -> Project:
         """Add a configuration file to the project."""
         revision = (
-            project.template.commit2.id
-            if project.template.commit2 is not None
-            else None
+            project.template.commit.id if project.template.commit is not None else None
         )
         projectconfig = ProjectConfig(
             project.template.location,

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -64,7 +64,11 @@ class ProjectGenerator:
         revision = (
             project.template.commit
             if project.template.commit is not None
-            else project.template.revision
+            else (
+                None
+                if project.template.commit2 is None
+                else project.template.commit2.revision
+            )
         )
         projectconfig = ProjectConfig(
             project.template.location,

--- a/src/cutty/projects/messages.py
+++ b/src/cutty/projects/messages.py
@@ -33,7 +33,7 @@ def linkcommitmessage(template: Template.Metadata) -> str:
 
 def importcommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for importing a template commit."""
-    if template.message:
-        return template.message
+    if template.commit2:
+        return template.commit2.message
     else:  # pragma: no cover
         return updatecommitmessage(template)

--- a/src/cutty/projects/messages.py
+++ b/src/cutty/projects/messages.py
@@ -9,31 +9,31 @@ MessageBuilder = Callable[[Template.Metadata], str]
 
 def createcommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for importing the project."""
-    if template.commit2:
-        return f"Import {template.name} {template.commit2.revision}"
+    if template.commit:
+        return f"Import {template.name} {template.commit.revision}"
     else:
         return f"Import {template.name}"
 
 
 def updatecommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for updating the project."""
-    if template.commit2:
-        return f"Update {template.name} to {template.commit2.revision}"
+    if template.commit:
+        return f"Update {template.name} to {template.commit.revision}"
     else:
         return f"Update {template.name}"
 
 
 def linkcommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for linking the project."""
-    if template.commit2:
-        return f"Link to {template.name} {template.commit2.revision}"
+    if template.commit:
+        return f"Link to {template.name} {template.commit.revision}"
     else:
         return f"Link to {template.name}"
 
 
 def importcommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for importing a template commit."""
-    if template.commit2:
-        return template.commit2.message
+    if template.commit:
+        return template.commit.message
     else:  # pragma: no cover
         return updatecommitmessage(template)

--- a/src/cutty/projects/messages.py
+++ b/src/cutty/projects/messages.py
@@ -9,27 +9,24 @@ MessageBuilder = Callable[[Template.Metadata], str]
 
 def createcommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for importing the project."""
-    revision = None if template.commit2 is None else template.commit2.revision
-    if revision:
-        return f"Import {template.name} {revision}"
+    if template.commit2:
+        return f"Import {template.name} {template.commit2.revision}"
     else:
         return f"Import {template.name}"
 
 
 def updatecommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for updating the project."""
-    revision = None if template.commit2 is None else template.commit2.revision
-    if revision:
-        return f"Update {template.name} to {revision}"
+    if template.commit2:
+        return f"Update {template.name} to {template.commit2.revision}"
     else:
         return f"Update {template.name}"
 
 
 def linkcommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for linking the project."""
-    revision = None if template.commit2 is None else template.commit2.revision
-    if revision:
-        return f"Link to {template.name} {revision}"
+    if template.commit2:
+        return f"Link to {template.name} {template.commit2.revision}"
     else:
         return f"Link to {template.name}"
 

--- a/src/cutty/projects/messages.py
+++ b/src/cutty/projects/messages.py
@@ -9,24 +9,27 @@ MessageBuilder = Callable[[Template.Metadata], str]
 
 def createcommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for importing the project."""
-    if template.revision:
-        return f"Import {template.name} {template.revision}"
+    revision = None if template.commit2 is None else template.commit2.revision
+    if revision:
+        return f"Import {template.name} {revision}"
     else:
         return f"Import {template.name}"
 
 
 def updatecommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for updating the project."""
-    if template.revision:
-        return f"Update {template.name} to {template.revision}"
+    revision = None if template.commit2 is None else template.commit2.revision
+    if revision:
+        return f"Update {template.name} to {revision}"
     else:
         return f"Update {template.name}"
 
 
 def linkcommitmessage(template: Template.Metadata) -> str:
     """Build the commit message for linking the project."""
-    if template.revision:
-        return f"Link to {template.name} {template.revision}"
+    revision = None if template.commit2 is None else template.commit2.revision
+    if revision:
+        return f"Link to {template.name} {revision}"
     else:
         return f"Link to {template.name}"
 

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -11,6 +11,7 @@ import pygit2
 
 from cutty.compat.contextlib import contextmanager
 from cutty.errors import CuttyError
+from cutty.packages.domain.package import Author
 from cutty.projects.config import PROJECT_CONFIG_FILE
 from cutty.util.git import MergeConflictError
 from cutty.util.git import Repository
@@ -34,21 +35,12 @@ class ProjectBuilder:
         """Return the project directory."""
         return self._worktree.path
 
-    def commit(
-        self,
-        message: str,
-        author: Optional[str] = None,
-        authoremail: Optional[str] = None,
-    ) -> str:
+    def commit(self, message: str, author: Optional[Author] = None) -> str:
         """Commit the project."""
         signature = self._worktree.default_signature
         if author is not None:
             signature = pygit2.Signature(
-                author, signature.email, signature.time, signature.offset
-            )
-        if authoremail is not None:
-            signature = pygit2.Signature(
-                signature.name, authoremail, signature.time, signature.offset
+                author.name, author.email, signature.time, signature.offset
             )
 
         self._worktree.commit(message=message, author=signature)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -13,6 +13,7 @@ from cutty.filesystems.domain.path import Path
 from cutty.filesystems.domain.purepath import PurePath
 from cutty.packages.adapters.registry import defaultproviderfactories
 from cutty.packages.adapters.storage import getdefaultproviderstore
+from cutty.packages.domain.package import Commit
 from cutty.packages.domain.registry import ProviderRegistry
 from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
@@ -58,21 +59,9 @@ class TemplateRepository:
             if self.directory is not None:
                 package = package.descend(PurePath(*self.directory.parts))
 
-            if package.commit is None:
-                metadata = Template.Metadata(
-                    self.location, self.directory, package.name
-                )
-            else:
-                metadata = Template.Metadata(
-                    self.location,
-                    self.directory,
-                    package.name,
-                    package.commit.revision,
-                    package.commit.id,
-                    package.commit.message,
-                    package.commit.author.name,
-                    package.commit.author.email,
-                )
+            metadata = Template.Metadata(
+                self.location, self.directory, package.name, package.commit
+            )
 
             yield Template(metadata, package.tree)
 
@@ -92,11 +81,32 @@ class Template:
         location: str
         directory: Optional[pathlib.Path]
         name: str
-        revision: Optional[Revision] = None
-        commit: Optional[str] = None
-        message: Optional[str] = None
-        author: Optional[str] = None
-        authoremail: Optional[str] = None
+        commit2: Optional[Commit] = None
+
+        @property
+        def revision(self) -> Optional[Revision]:
+            """Return the revision."""
+            return None if self.commit2 is None else self.commit2.revision
+
+        @property
+        def commit(self) -> Optional[str]:
+            """Return the commit ID."""
+            return None if self.commit2 is None else self.commit2.id
+
+        @property
+        def message(self) -> Optional[str]:
+            """Return the commit message."""
+            return None if self.commit2 is None else self.commit2.message
+
+        @property
+        def author(self) -> Optional[str]:
+            """Return name of the author."""
+            return None if self.commit2 is None else self.commit2.author.name
+
+        @property
+        def authoremail(self) -> Optional[str]:
+            """Return email of the author."""
+            return None if self.commit2 is None else self.commit2.author.email
 
     metadata: Metadata
     root: Path

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -58,16 +58,21 @@ class TemplateRepository:
             if self.directory is not None:
                 package = package.descend(PurePath(*self.directory.parts))
 
-            metadata = Template.Metadata(
-                self.location,
-                self.directory,
-                package.name,
-                package.revision,
-                package.commit,
-                package.message,
-                package.author,
-                package.authoremail,
-            )
+            if package.commit2 is None:
+                metadata = Template.Metadata(
+                    self.location, self.directory, package.name
+                )
+            else:
+                metadata = Template.Metadata(
+                    self.location,
+                    self.directory,
+                    package.name,
+                    package.commit2.revision,
+                    package.commit2.id,
+                    package.commit2.message,
+                    package.commit2.author.name,
+                    package.commit2.author.email,
+                )
 
             yield Template(metadata, package.tree)
 

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -83,11 +83,6 @@ class Template:
         commit2: Optional[Commit] = None
 
         @property
-        def message(self) -> Optional[str]:
-            """Return the commit message."""
-            return None if self.commit2 is None else self.commit2.message
-
-        @property
         def author(self) -> Optional[str]:
             """Return name of the author."""
             return None if self.commit2 is None else self.commit2.author.name

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -82,15 +82,5 @@ class Template:
         name: str
         commit2: Optional[Commit] = None
 
-        @property
-        def author(self) -> Optional[str]:
-            """Return name of the author."""
-            return None if self.commit2 is None else self.commit2.author.name
-
-        @property
-        def authoremail(self) -> Optional[str]:
-            """Return email of the author."""
-            return None if self.commit2 is None else self.commit2.author.email
-
     metadata: Metadata
     root: Path

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -58,7 +58,7 @@ class TemplateRepository:
             if self.directory is not None:
                 package = package.descend(PurePath(*self.directory.parts))
 
-            if package.commit2 is None:
+            if package.commit is None:
                 metadata = Template.Metadata(
                     self.location, self.directory, package.name
                 )
@@ -67,11 +67,11 @@ class TemplateRepository:
                     self.location,
                     self.directory,
                     package.name,
-                    package.commit2.revision,
-                    package.commit2.id,
-                    package.commit2.message,
-                    package.commit2.author.name,
-                    package.commit2.author.email,
+                    package.commit.revision,
+                    package.commit.id,
+                    package.commit.message,
+                    package.commit.author.name,
+                    package.commit.author.email,
                 )
 
             yield Template(metadata, package.tree)

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -87,7 +87,7 @@ class Template:
         location: str
         directory: Optional[pathlib.Path]
         name: str
-        revision: Optional[Revision]
+        revision: Optional[Revision] = None
         commit: Optional[str] = None
         message: Optional[str] = None
         author: Optional[str] = None

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -16,7 +16,6 @@ from cutty.packages.adapters.storage import getdefaultproviderstore
 from cutty.packages.domain.package import Commit
 from cutty.packages.domain.registry import ProviderRegistry
 from cutty.packages.domain.repository import PackageRepository
-from cutty.packages.domain.revisions import Revision
 
 
 @dataclass
@@ -82,11 +81,6 @@ class Template:
         directory: Optional[pathlib.Path]
         name: str
         commit2: Optional[Commit] = None
-
-        @property
-        def revision(self) -> Optional[Revision]:
-            """Return the revision."""
-            return None if self.commit2 is None else self.commit2.revision
 
         @property
         def commit(self) -> Optional[str]:

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -80,7 +80,7 @@ class Template:
         location: str
         directory: Optional[pathlib.Path]
         name: str
-        commit2: Optional[Commit] = None
+        commit: Optional[Commit] = None
 
     metadata: Metadata
     root: Path

--- a/src/cutty/projects/template.py
+++ b/src/cutty/projects/template.py
@@ -83,11 +83,6 @@ class Template:
         commit2: Optional[Commit] = None
 
         @property
-        def commit(self) -> Optional[str]:
-            """Return the commit ID."""
-            return None if self.commit2 is None else self.commit2.id
-
-        @property
         def message(self) -> Optional[str]:
             """Return the commit message."""
             return None if self.commit2 is None else self.commit2.message

--- a/tests/fixtures/packages/domain/providers.py
+++ b/tests/fixtures/packages/domain/providers.py
@@ -74,9 +74,11 @@ def dictprovider(
         class _PackageRepository(PackageRepository):
             @contextmanager
             def get(self, revision: Optional[Revision] = None) -> Iterator[Package]:
+                assert revision is None
+
                 filesystem = DictFilesystem(mapping or {})
                 path = Path(filesystem=filesystem)
-                yield Package(location.name, path, revision)
+                yield Package(location.name, path)
 
         return _PackageRepository()
 

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -73,7 +73,7 @@ def test_local_revision_tag(url: URL) -> None:
     assert repository is not None
 
     with repository.get("HEAD^") as package:
-        assert package.revision == "v1.0"
+        assert package.commit2 is not None and package.commit2.revision == "v1.0"
 
 
 def test_local_revision_commit(url: URL) -> None:
@@ -84,9 +84,9 @@ def test_local_revision_commit(url: URL) -> None:
 
     with repository.get() as package:
         assert (
-            package.revision is not None
-            and len(package.revision) >= 7
-            and all(c in string.hexdigits for c in package.revision)
+            package.commit2 is not None
+            and len(package.commit2.revision) >= 7
+            and all(c in string.hexdigits for c in package.commit2.revision)
         )
 
 
@@ -97,8 +97,9 @@ def test_local_author(url: URL) -> None:
     assert repository is not None
 
     with repository.get() as package:
-        assert package.author is not None
-        assert package.authoremail is not None
+        assert package.commit2 is not None
+        assert "You" == package.commit2.author.name
+        assert "you@example.com" == package.commit2.author.email
 
 
 @pytest.fixture
@@ -134,7 +135,7 @@ def test_remote_revision_tag(gitprovider: Provider, url: URL) -> None:
     assert repository is not None
 
     with repository.get("HEAD^") as package:
-        assert package.revision == "v1.0"
+        assert package.commit2 is not None and package.commit2.revision == "v1.0"
 
 
 def test_remote_revision_commit(gitprovider: Provider, url: URL) -> None:
@@ -145,9 +146,9 @@ def test_remote_revision_commit(gitprovider: Provider, url: URL) -> None:
 
     with repository.get() as package:
         assert (
-            package.revision is not None
-            and len(package.revision) >= 7
-            and all(c in string.hexdigits for c in package.revision)
+            package.commit2 is not None
+            and len(package.commit2.revision) >= 7
+            and all(c in string.hexdigits for c in package.commit2.revision)
         )
 
 

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -73,7 +73,7 @@ def test_local_revision_tag(url: URL) -> None:
     assert repository is not None
 
     with repository.get("HEAD^") as package:
-        assert package.commit2 is not None and package.commit2.revision == "v1.0"
+        assert package.commit is not None and package.commit.revision == "v1.0"
 
 
 def test_local_revision_commit(url: URL) -> None:
@@ -84,9 +84,9 @@ def test_local_revision_commit(url: URL) -> None:
 
     with repository.get() as package:
         assert (
-            package.commit2 is not None
-            and len(package.commit2.revision) >= 7
-            and all(c in string.hexdigits for c in package.commit2.revision)
+            package.commit is not None
+            and len(package.commit.revision) >= 7
+            and all(c in string.hexdigits for c in package.commit.revision)
         )
 
 
@@ -97,9 +97,9 @@ def test_local_author(url: URL) -> None:
     assert repository is not None
 
     with repository.get() as package:
-        assert package.commit2 is not None
-        assert "You" == package.commit2.author.name
-        assert "you@example.com" == package.commit2.author.email
+        assert package.commit is not None
+        assert "You" == package.commit.author.name
+        assert "you@example.com" == package.commit.author.email
 
 
 @pytest.fixture
@@ -135,7 +135,7 @@ def test_remote_revision_tag(gitprovider: Provider, url: URL) -> None:
     assert repository is not None
 
     with repository.get("HEAD^") as package:
-        assert package.commit2 is not None and package.commit2.revision == "v1.0"
+        assert package.commit is not None and package.commit.revision == "v1.0"
 
 
 def test_remote_revision_commit(gitprovider: Provider, url: URL) -> None:
@@ -146,9 +146,9 @@ def test_remote_revision_commit(gitprovider: Provider, url: URL) -> None:
 
     with repository.get() as package:
         assert (
-            package.commit2 is not None
-            and len(package.commit2.revision) >= 7
-            and all(c in string.hexdigits for c in package.commit2.revision)
+            package.commit is not None
+            and len(package.commit.revision) >= 7
+            and all(c in string.hexdigits for c in package.commit.revision)
         )
 
 

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -85,7 +85,9 @@ def test_revision_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> No
     assert repository is not None
 
     with repository.get() as package:
-        assert package.revision is not None and is_mercurial_shorthash(package.revision)
+        assert package.commit2 is not None and is_mercurial_shorthash(
+            package.commit2.revision
+        )
 
 
 def test_revision_tag(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
@@ -95,7 +97,7 @@ def test_revision_tag(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     assert repository is not None
 
     with repository.get("tip~2") as package:
-        assert package.revision == "v1.0"
+        assert package.commit2 is not None and package.commit2.revision == "v1.0"
 
 
 def test_revision_no_tags(hgprovider: Provider, hg: Hg, tmp_path: pathlib.Path) -> None:
@@ -113,7 +115,9 @@ def test_revision_no_tags(hgprovider: Provider, hg: Hg, tmp_path: pathlib.Path) 
     assert repository is not None
 
     with repository.get() as package:
-        assert package.revision is not None and is_mercurial_shorthash(package.revision)
+        assert package.commit2 is not None and is_mercurial_shorthash(
+            package.commit2.revision
+        )
 
 
 def test_revision_multiple_tags(
@@ -135,7 +139,7 @@ def test_revision_multiple_tags(
     assert repository is not None
 
     with repository.get("tip~2") as package:
-        assert package.revision == "tag1:tag2"
+        assert package.commit2 is not None and package.commit2.revision == "tag1:tag2"
 
 
 def test_not_matching(hgprovider: Provider) -> None:
@@ -155,7 +159,7 @@ def test_update(hgrepository: pathlib.Path, store: Store) -> None:
         assert repository is not None
 
         with repository.get(revision) as package:
-            return package.revision
+            return package.commit2.revision if package.commit2 is not None else None
 
     revision1 = fetchrevision("v1.0")
     revision2 = fetchrevision(None)
@@ -213,7 +217,7 @@ def test_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     assert repository is not None
 
     with repository.get(None) as package:
-        assert package.commit is not None and is_mercurial_hash(package.commit)
+        assert package.commit2 is not None and is_mercurial_hash(package.commit2.id)
 
 
 def test_message(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
@@ -223,7 +227,7 @@ def test_message(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     assert repository is not None
 
     with repository.get(None) as package:
-        assert package.message is not None
+        assert package.commit2 is not None and package.commit2.message
 
 
 def test_author(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
@@ -233,5 +237,6 @@ def test_author(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     assert repository is not None
 
     with repository.get(None) as package:
-        assert "You" == package.author
-        assert "you@example.com" == package.authoremail
+        assert package.commit2 is not None
+        assert "You" == package.commit2.author.name
+        assert "you@example.com" == package.commit2.author.email

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -85,8 +85,8 @@ def test_revision_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> No
     assert repository is not None
 
     with repository.get() as package:
-        assert package.commit2 is not None and is_mercurial_shorthash(
-            package.commit2.revision
+        assert package.commit is not None and is_mercurial_shorthash(
+            package.commit.revision
         )
 
 
@@ -97,7 +97,7 @@ def test_revision_tag(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     assert repository is not None
 
     with repository.get("tip~2") as package:
-        assert package.commit2 is not None and package.commit2.revision == "v1.0"
+        assert package.commit is not None and package.commit.revision == "v1.0"
 
 
 def test_revision_no_tags(hgprovider: Provider, hg: Hg, tmp_path: pathlib.Path) -> None:
@@ -115,8 +115,8 @@ def test_revision_no_tags(hgprovider: Provider, hg: Hg, tmp_path: pathlib.Path) 
     assert repository is not None
 
     with repository.get() as package:
-        assert package.commit2 is not None and is_mercurial_shorthash(
-            package.commit2.revision
+        assert package.commit is not None and is_mercurial_shorthash(
+            package.commit.revision
         )
 
 
@@ -139,7 +139,7 @@ def test_revision_multiple_tags(
     assert repository is not None
 
     with repository.get("tip~2") as package:
-        assert package.commit2 is not None and package.commit2.revision == "tag1:tag2"
+        assert package.commit is not None and package.commit.revision == "tag1:tag2"
 
 
 def test_not_matching(hgprovider: Provider) -> None:
@@ -159,7 +159,7 @@ def test_update(hgrepository: pathlib.Path, store: Store) -> None:
         assert repository is not None
 
         with repository.get(revision) as package:
-            return package.commit2.revision if package.commit2 is not None else None
+            return package.commit.revision if package.commit is not None else None
 
     revision1 = fetchrevision("v1.0")
     revision2 = fetchrevision(None)
@@ -217,7 +217,7 @@ def test_commit(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     assert repository is not None
 
     with repository.get(None) as package:
-        assert package.commit2 is not None and is_mercurial_hash(package.commit2.id)
+        assert package.commit is not None and is_mercurial_hash(package.commit.id)
 
 
 def test_message(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
@@ -227,7 +227,7 @@ def test_message(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     assert repository is not None
 
     with repository.get(None) as package:
-        assert package.commit2 is not None and package.commit2.message
+        assert package.commit is not None and package.commit.message
 
 
 def test_author(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
@@ -237,6 +237,6 @@ def test_author(hgprovider: Provider, hgrepository: pathlib.Path) -> None:
     assert repository is not None
 
     with repository.get(None) as package:
-        assert package.commit2 is not None
-        assert "You" == package.commit2.author.name
-        assert "you@example.com" == package.commit2.author.email
+        assert package.commit is not None
+        assert "You" == package.commit.author.name
+        assert "you@example.com" == package.commit.author.email

--- a/tests/unit/packages/domain/test_registry.py
+++ b/tests/unit/packages/domain/test_registry.py
@@ -123,7 +123,7 @@ def test_with_provider_specific_url(
 def test_unknown_provider_in_url_scheme(providerstore: ProviderStore, url: URL) -> None:
     """It invokes providers with the original scheme."""
     packagepath = Path(filesystem=DictFilesystem({}))
-    package = Package("example", packagepath, None)
+    package = Package("example", packagepath)
 
     factories = [ConstProviderFactory(constprovider("default", package))]
     registry = ProviderRegistry(providerstore, factories)

--- a/tests/unit/projects/conftest.py
+++ b/tests/unit/projects/conftest.py
@@ -8,4 +8,4 @@ from cutty.projects.template import Template
 def template() -> Template.Metadata:
     """Fixture for a `Template.Metadata` instance."""
     location = "https://example.com/template"
-    return Template.Metadata(location, None, "template", None)
+    return Template.Metadata(location, None, "template")

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -105,13 +105,13 @@ def test_commit_message_revision(
         "Release 1.0.0",
         Author("You", "you@example.com"),
     )
-    template = dataclasses.replace(template, commit2=commit)
+    template = dataclasses.replace(template, commit=commit)
 
     creategitrepository(project, template)
 
     repository = Repository.open(project)
     assert (
-        template.commit2 and template.commit2.revision in repository.head.commit.message
+        template.commit and template.commit.revision in repository.head.commit.message
     )
 
 

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -110,8 +110,9 @@ def test_commit_message_revision(
     creategitrepository(project, template)
 
     repository = Repository.open(project)
-    revision = None if template.commit2 is None else template.commit2.revision
-    assert revision in repository.head.commit.message
+    assert (
+        template.commit2 and template.commit2.revision in repository.head.commit.message
+    )
 
 
 def test_existing_repository(

--- a/tests/unit/projects/test_create.py
+++ b/tests/unit/projects/test_create.py
@@ -8,6 +8,8 @@ from cutty.filestorage.adapters.disk import DiskFileStorage
 from cutty.filestorage.domain.files import RegularFile
 from cutty.filestorage.domain.storage import FileStorage
 from cutty.filesystems.domain.purepath import PurePath
+from cutty.packages.domain.package import Author
+from cutty.packages.domain.package import Commit
 from cutty.projects.messages import createcommitmessage
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.template import Template
@@ -97,11 +99,19 @@ def test_commit_message_revision(
     project: pathlib.Path, template: Template.Metadata
 ) -> None:
     """It includes the revision in the commit message."""
-    template = dataclasses.replace(template, revision="1.0.0")
+    commit = Commit(
+        "f4c0629d635865697b3e99b5ca581e78b2c7d976",
+        "v1.0.0",
+        "Release 1.0.0",
+        Author("You", "you@example.com"),
+    )
+    template = dataclasses.replace(template, commit2=commit)
+
     creategitrepository(project, template)
 
     repository = Repository.open(project)
-    assert template.revision in repository.head.commit.message
+    revision = None if template.commit2 is None else template.commit2.revision
+    assert revision in repository.head.commit.message
 
 
 def test_existing_repository(

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -64,10 +64,10 @@ def test_linkproject_commit_message_revision(
         "Release 1.0.0",
         Author("You", "you@example.com"),
     )
-    template = dataclasses.replace(template, commit2=commit)
+    template = dataclasses.replace(template, commit=commit)
 
     linkproject(repository, template)
 
     assert (
-        template.commit2 and template.commit2.revision in repository.head.commit.message
+        template.commit and template.commit.revision in repository.head.commit.message
     )

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -2,6 +2,8 @@
 import dataclasses
 from pathlib import Path
 
+from cutty.packages.domain.package import Author
+from cutty.packages.domain.package import Commit
 from cutty.projects.config import PROJECT_CONFIG_FILE
 from cutty.projects.messages import linkcommitmessage
 from cutty.projects.repository import ProjectRepository
@@ -56,8 +58,15 @@ def test_linkproject_commit_message_revision(
     repository: Repository, template: Template.Metadata
 ) -> None:
     """It includes the template name in the commit message."""
-    template = dataclasses.replace(template, revision="1.0.0")
+    commit = Commit(
+        "f4c0629d635865697b3e99b5ca581e78b2c7d976",
+        "v1.0.0",
+        "Release 1.0.0",
+        Author("You", "you@example.com"),
+    )
+    template = dataclasses.replace(template, commit2=commit)
 
     linkproject(repository, template)
 
-    assert template.revision in repository.head.commit.message
+    revision = None if template.commit2 is None else template.commit2.revision
+    assert revision in repository.head.commit.message

--- a/tests/unit/projects/test_link.py
+++ b/tests/unit/projects/test_link.py
@@ -68,5 +68,6 @@ def test_linkproject_commit_message_revision(
 
     linkproject(repository, template)
 
-    revision = None if template.commit2 is None else template.commit2.revision
-    assert revision in repository.head.commit.message
+    assert (
+        template.commit2 and template.commit2.revision in repository.head.commit.message
+    )

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -174,8 +174,7 @@ def test_updateproject_commit_message_revision(
 
     updateproject(project.path, template)
 
-    revision = None if template.commit2 is None else template.commit2.revision
-    assert revision in project.head.commit.message
+    assert template.commit2 and template.commit2.revision in project.head.commit.message
 
 
 def test_updateproject_no_changes(

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -170,11 +170,11 @@ def test_updateproject_commit_message_revision(
         "Release 1.0.0",
         Author("You", "you@example.com"),
     )
-    template = dataclasses.replace(template, commit2=commit)
+    template = dataclasses.replace(template, commit=commit)
 
     updateproject(project.path, template)
 
-    assert template.commit2 and template.commit2.revision in project.head.commit.message
+    assert template.commit and template.commit.revision in project.head.commit.message
 
 
 def test_updateproject_no_changes(

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from cutty.packages.domain.package import Author
+from cutty.packages.domain.package import Commit
 from cutty.projects.messages import createcommitmessage
 from cutty.projects.messages import updatecommitmessage
 from cutty.projects.repository import ProjectRepository
@@ -162,11 +164,18 @@ def test_updateproject_commit_message_revision(
     project: Repository, template: Template.Metadata
 ) -> None:
     """It includes the template revision in the commit message."""
-    template = dataclasses.replace(template, revision="1.0.0")
+    commit = Commit(
+        "f4c0629d635865697b3e99b5ca581e78b2c7d976",
+        "v1.0.0",
+        "Release 1.0.0",
+        Author("You", "you@example.com"),
+    )
+    template = dataclasses.replace(template, commit2=commit)
 
     updateproject(project.path, template)
 
-    assert template.revision in project.head.commit.message
+    revision = None if template.commit2 is None else template.commit2.revision
+    assert revision in project.head.commit.message
 
 
 def test_updateproject_no_changes(

--- a/tests/unit/projects/test_update.py
+++ b/tests/unit/projects/test_update.py
@@ -25,14 +25,14 @@ def updateproject(projectdir: Path, template: Template.Metadata) -> None:
     project = ProjectRepository(projectdir)
 
     with project.build() as builder:
-        commit = builder.commit(createcommitmessage(template))
+        parent = builder.commit(createcommitmessage(template))
 
-    with project.build(parent=commit) as builder:
+    with project.build(parent=parent) as builder:
         (builder.path / "cutty.json").touch()
-        commit2 = builder.commit(updatecommitmessage(template))
+        commit = builder.commit(updatecommitmessage(template))
 
-    if commit2 != commit:
-        project.import_(commit2)
+    if commit != parent:
+        project.import_(commit)
 
 
 def continue_(projectdir: Path) -> None:
@@ -186,12 +186,12 @@ def test_updateproject_no_changes(
     repository = ProjectRepository(project.path)
 
     with repository.build() as builder:
-        commit = builder.commit(createcommitmessage(template))
+        parent = builder.commit(createcommitmessage(template))
 
-    with repository.build(parent=commit) as builder:
-        commit2 = builder.commit(updatecommitmessage(template))
+    with repository.build(parent=parent) as builder:
+        commit = builder.commit(updatecommitmessage(template))
 
-    if commit2 != commit:
-        repository.import_(commit2)
+    if commit != parent:
+        repository.import_(commit)
 
     assert tip == project.head.commit


### PR DESCRIPTION
- 🔨 [packages] Do not require attribute `Package.revision`
- 🔨 [projects] Do not require attribute `Template.Metadata.revision`
- 🔨 [packages] Derive attribute `Package.commit2` with structured data
- 🔨 [packages] Access `Package` attributes via `Package.commit2`
- 🔨 [packages] Hide `Package` attributes accessible via `Commit`
- 🔨 [packages] Extract function `Commit.create`
- 🔨 [packages] Ignore `revision` in `dictprovider`
- 🔨 [packages] Replace `Package` attributes with `Commit`
- 🔨 [packages] Rename attribute `Package.commit{2 => }`
- 🔨 [packages] Extract function `DefaultPackageRepository.lookup`
- 🔨 [packages] Extract function `GitPackageRepository.lookup`
- 🔨 [packages] Inline function `GitPackageRepository.getcommit`
- 🔨 [packages] Inline functions `GitPackageRepository.get{message,author,authoremail}`
- 🔨 [packages] Replace function `GitPackageRepository.{getrevision => describe}`
- 🔨 [packages] Extract function `MercurialPackageRepository.lookup`
- 🔨 [packages] Inline functions `MercurialPackageRepository.get*`
- 🔨 [packages] Retrieve commit metadata in a single `hg` invocation
- 🔨 [packages] Extract function `MercurialPackageRepository.hg`
- 🔨 [packages] Inline functions `DefaultPackageRepository.get*`
- 🔨 [packages] Inline function `Commit.create`
- 🔨 [projects] Preserve `package.Commit` in `Template.Metadata`
- 🔨 [projects] Inline function `Template.Metadata.revision`
- 🔨 [projects] Remove dead code in `ProjectGenerator.addconfig`
- 🔨 [projects] Inline variable `revision` in `{create,update,link}commitmessage`
- 🔨 [projects] Inline variable `revision` in `ProjectRepository` tests
- 🔨 [projects] Inline function `Template.Metadata.commit`
- 🔨 [projects] Inline function `Template.Metadata.message`
- 🔨 [projects] Inline functions `Template.Metadata.author{,email}`
- 🔨 [projects] Preserve `Author` in `ProjectBuilder.commit`
