### PR TITLE
✨ [projects] Only copy author information when importing template commits

### DIFF
--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -49,6 +49,8 @@ def commitproject(
             message = project.template.commit.message
             author = project.template.commit.author
         else:  # pragma: no cover
+            # The `commitmessage` is only None when importing, and imports are only
+            # possible when there's a `template.commit`. So this should be unreachable.
             message = f"Import {project.template.name}"
 
         return builder.commit(message, author=author)

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -49,7 +49,7 @@ def commitproject(
             message = project.template.commit.message
             author = project.template.commit.author
         else:  # pragma: no cover
-            message = f"Update {project.template.name}"
+            message = f"Import {project.template.name}"
 
         return builder.commit(message, author=author)
 

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -49,9 +49,9 @@ def commitproject(
         else:
             if project.template.commit:
                 message = project.template.commit.message
+                author = project.template.commit.author
             else:  # pragma: no cover
                 message = updatecommitmessage(project.template)
-            author = project.template.commit.author if project.template.commit else None
 
         return builder.commit(message, author=author)
 

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -5,6 +5,7 @@ from typing import Optional
 from cutty.compat.contextlib import contextmanager
 from cutty.projects.config import ProjectConfig
 from cutty.projects.generate import generate
+from cutty.projects.messages import importcommitmessage
 from cutty.projects.messages import MessageBuilder
 from cutty.projects.project import Project
 from cutty.projects.repository import ProjectRepository
@@ -34,7 +35,7 @@ def commitproject(
     project: Project,
     *,
     parent: Optional[str] = None,
-    commitmessage: MessageBuilder,
+    commitmessage: Optional[MessageBuilder] = None,
 ) -> str:
     """Build the project, returning the commit ID."""
     with repository.build(parent=parent) as builder:
@@ -42,7 +43,12 @@ def commitproject(
 
         author = project.template.commit.author if project.template.commit else None
 
-        return builder.commit(commitmessage(project.template), author=author)
+        if commitmessage is not None:
+            message = commitmessage(project.template)
+        else:
+            message = importcommitmessage(project.template)
+
+        return builder.commit(message, author=author)
 
 
 def buildproject(

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -72,7 +72,6 @@ def buildparentproject(
     *,
     revision: Optional[str],
     interactive: bool,
-    commitmessage: MessageBuilder,
 ) -> Optional[str]:
     """Build the project for the parent revision."""
     provider = TemplateProvider.create()
@@ -81,6 +80,6 @@ def buildparentproject(
     if parentrevision := templates.getparentrevision(revision):
         with templates.get(parentrevision) as template:
             project = generate(template, config.bindings, interactive=interactive)
-            return commitproject(repository, project, commitmessage=commitmessage)
+            return commitproject(repository, project)
 
     return None

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -46,12 +46,11 @@ def commitproject(
 
         if commitmessage is not None:
             message = commitmessage(project.template)
-        else:
-            if project.template.commit:
-                message = project.template.commit.message
-                author = project.template.commit.author
-            else:  # pragma: no cover
-                message = updatecommitmessage(project.template)
+        elif project.template.commit:
+            message = project.template.commit.message
+            author = project.template.commit.author
+        else:  # pragma: no cover
+            message = updatecommitmessage(project.template)
 
         return builder.commit(message, author=author)
 

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -7,7 +7,6 @@ from cutty.packages.domain.package import Author
 from cutty.projects.config import ProjectConfig
 from cutty.projects.generate import generate
 from cutty.projects.messages import MessageBuilder
-from cutty.projects.messages import updatecommitmessage
 from cutty.projects.project import Project
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
@@ -50,7 +49,7 @@ def commitproject(
             message = project.template.commit.message
             author = project.template.commit.author
         else:  # pragma: no cover
-            message = updatecommitmessage(project.template)
+            message = f"Update {project.template.name}"
 
         return builder.commit(message, author=author)
 

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -6,8 +6,8 @@ from cutty.compat.contextlib import contextmanager
 from cutty.packages.domain.package import Author
 from cutty.projects.config import ProjectConfig
 from cutty.projects.generate import generate
-from cutty.projects.messages import importcommitmessage
 from cutty.projects.messages import MessageBuilder
+from cutty.projects.messages import updatecommitmessage
 from cutty.projects.project import Project
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
@@ -47,7 +47,10 @@ def commitproject(
         if commitmessage is not None:
             message = commitmessage(project.template)
         else:
-            message = importcommitmessage(project.template)
+            if project.template.commit:
+                message = project.template.commit.message
+            else:  # pragma: no cover
+                message = updatecommitmessage(project.template)
             author = project.template.commit.author if project.template.commit else None
 
         return builder.commit(message, author=author)

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -3,6 +3,7 @@ from collections.abc import Iterator
 from typing import Optional
 
 from cutty.compat.contextlib import contextmanager
+from cutty.packages.domain.package import Author
 from cutty.projects.config import ProjectConfig
 from cutty.projects.generate import generate
 from cutty.projects.messages import importcommitmessage
@@ -41,12 +42,13 @@ def commitproject(
     with repository.build(parent=parent) as builder:
         storeproject(project, builder.path)
 
-        author = project.template.commit.author if project.template.commit else None
+        author: Optional[Author] = None
 
         if commitmessage is not None:
             message = commitmessage(project.template)
         else:
             message = importcommitmessage(project.template)
+            author = project.template.commit.author if project.template.commit else None
 
         return builder.commit(message, author=author)
 

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -57,7 +57,7 @@ def buildproject(
     *,
     interactive: bool,
     parent: Optional[str] = None,
-    commitmessage: MessageBuilder,
+    commitmessage: Optional[MessageBuilder] = None,
 ) -> str:
     """Build the project, returning the commit ID."""
     with createproject(config, interactive=interactive) as project:

--- a/src/cutty/projects/messages.py
+++ b/src/cutty/projects/messages.py
@@ -29,11 +29,3 @@ def linkcommitmessage(template: Template.Metadata) -> str:
         return f"Link to {template.name} {template.commit.revision}"
     else:
         return f"Link to {template.name}"
-
-
-def importcommitmessage(template: Template.Metadata) -> str:
-    """Build the commit message for importing a template commit."""
-    if template.commit:
-        return template.commit.message
-    else:  # pragma: no cover
-        return updatecommitmessage(template)

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -7,7 +7,6 @@ from cutty.projects.build import buildparentproject
 from cutty.projects.build import buildproject
 from cutty.projects.config import ProjectConfig
 from cutty.projects.config import readprojectconfigfile
-from cutty.projects.messages import importcommitmessage
 from cutty.projects.repository import ProjectRepository
 from cutty.variables.domain.bindings import Binding
 
@@ -33,11 +32,7 @@ def import_(
     repository = ProjectRepository(projectdir)
 
     parent = buildparentproject(
-        repository,
-        config1,
-        revision=revision,
-        interactive=interactive,
-        commitmessage=importcommitmessage,
+        repository, config1, revision=revision, interactive=interactive
     )
 
     commit = buildproject(repository, config2, interactive=interactive, parent=parent)

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -40,13 +40,7 @@ def import_(
         commitmessage=importcommitmessage,
     )
 
-    commit = buildproject(
-        repository,
-        config2,
-        interactive=interactive,
-        commitmessage=importcommitmessage,
-        parent=parent,
-    )
+    commit = buildproject(repository, config2, interactive=interactive, parent=parent)
 
     # If `commit` and `parent` are identical then so is the template revision
     # stored in their cutty.json. But for the version control systems we

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for functional tests."""
 import json
 from collections.abc import Iterator
+from collections.abc import Mapping
 from pathlib import Path
 from textwrap import dedent
 from typing import Optional
@@ -39,7 +40,12 @@ def runner() -> Iterator[CliRunner]:
 class RunCutty(Protocol):
     """Invoke the cutty CLI."""
 
-    def __call__(self, *args: str, input: Optional[str] = None) -> str:
+    def __call__(
+        self,
+        *args: str,
+        input: Optional[str] = ...,
+        env: Optional[Mapping[str, str]] = ...
+    ) -> str:
         """Invoke the cutty CLI."""
 
 
@@ -51,11 +57,13 @@ class RunCuttyError(Exception):
 def runcutty(runner: CliRunner, pipeinput: PipeInput) -> RunCutty:
     """Fixture for invoking the cutty CLI."""
 
-    def _run(*args: str, input: Optional[str] = None) -> str:
+    def _run(
+        *args: str, input: Optional[str] = None, env: Optional[Mapping[str, str]] = None
+    ) -> str:
         if input is not None:
             pipeinput.send_text(input)
 
-        result = runner.invoke(main, args, catch_exceptions=False)
+        result = runner.invoke(main, args, env=env, catch_exceptions=False)
 
         if result.exit_code != 0:
             raise RunCuttyError(result.output or str(result.exit_code))

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -234,3 +234,18 @@ def test_commit_hash(runcutty: RunCutty, template: Path) -> None:
         and len(revision) == 40
         and all(c in string.hexdigits for c in revision)
     )
+
+
+def test_author(runcutty: RunCutty, template: Path) -> None:
+    """It does not copy author metadata from the template."""
+    env = {
+        "GIT_AUTHOR_NAME": "The project author",
+        "GIT_AUTHOR_EMAIL": "the.project.author@example.com",
+    }
+
+    runcutty("create", "--non-interactive", str(template), env=env)
+
+    author = Repository.open(Path("example")).head.commit.author
+
+    assert env["GIT_AUTHOR_NAME"] == author.name
+    assert env["GIT_AUTHOR_EMAIL"] == author.email


### PR DESCRIPTION
- 🔨 [functional] Add optional parameter `env` to `runcutty` fixture
- ✅ [functional] Add test for `cutty create` using project author for commit
- 🔨 [projects] Do not require `commitmessage` parameter in `commitproject`
- 🔨 [projects] Do not require `commitmessage` parameter in `buildproject`
- 🔨 [services] Remove redundant `commitmessage` parameter in `import_`
- 🔨 [projects] Remove redundant `commitmessage` parameter in `buildparentproject`
- ✨ [projects] Commit as project author unless importing template commits
- 🔨 [projects] Inline function `importcommitmessage`
- 🔨 [projects] Slide assignment of `author`
- 🔨 [projects] Replace nested `if` with `elif`
- 🔨 [projects] Inline function `updatecommitmessage` in `commitproject`
- 🔨 [projects] Improve commit message in unreachable branch of `commitproject`
- 💡 [projects] Add comment about unreachability in `commitproject`
