### PR TITLE
✨ [projects] Preserve date when importing git commits

### DIFF
--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -1,5 +1,4 @@
 """Providers for git repositories."""
-import datetime
 import pathlib
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -19,14 +18,7 @@ from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
-
-
-def asdatetime(timestamp: int, *, offset: int) -> datetime.datetime:
-    """Build a `datetime` instance from a POSIX timestamp."""
-    return datetime.datetime.fromtimestamp(
-        timestamp,
-        tz=datetime.timezone(offset=datetime.timedelta(minutes=offset)),
-    )
+from cutty.util.time import asdatetime
 
 
 @dataclass

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -1,4 +1,5 @@
 """Providers for git repositories."""
+import datetime
 import pathlib
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -18,6 +19,14 @@ from cutty.packages.domain.providers import RemoteProviderFactory
 from cutty.packages.domain.repository import DefaultPackageRepository
 from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
+
+
+def getcommitdate(commit: pygit2.Commit) -> datetime.datetime:
+    """Return the commit date as a `datetime` instance."""
+    return datetime.datetime.fromtimestamp(
+        commit.author.time,
+        tz=datetime.timezone(offset=datetime.timedelta(minutes=commit.author.offset)),
+    )
 
 
 @dataclass

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -61,8 +61,11 @@ class GitPackageRepository(DefaultPackageRepository):
         """Look up the commit metadata for the given revision."""
         commit = self._lookup(revision)
         author = Author(commit.author.name, commit.author.email)
+        date = getcommitdate(commit)
 
-        return Commit(str(commit.id), self.describe(commit), commit.message, author)
+        return Commit(
+            str(commit.id), self.describe(commit), commit.message, author, date
+        )
 
     def _lookup(self, revision: Optional[Revision]) -> pygit2.Commit:
         """Return the commit object."""

--- a/src/cutty/packages/adapters/providers/git.py
+++ b/src/cutty/packages/adapters/providers/git.py
@@ -21,11 +21,11 @@ from cutty.packages.domain.repository import PackageRepository
 from cutty.packages.domain.revisions import Revision
 
 
-def getcommitdate(commit: pygit2.Commit) -> datetime.datetime:
-    """Return the commit date as a `datetime` instance."""
+def asdatetime(timestamp: int, *, offset: int) -> datetime.datetime:
+    """Build a `datetime` instance from a POSIX timestamp."""
     return datetime.datetime.fromtimestamp(
-        commit.author.time,
-        tz=datetime.timezone(offset=datetime.timedelta(minutes=commit.author.offset)),
+        timestamp,
+        tz=datetime.timezone(offset=datetime.timedelta(minutes=offset)),
     )
 
 
@@ -61,7 +61,7 @@ class GitPackageRepository(DefaultPackageRepository):
         """Look up the commit metadata for the given revision."""
         commit = self._lookup(revision)
         author = Author(commit.author.name, commit.author.email)
-        date = getcommitdate(commit)
+        date = asdatetime(commit.author.time, offset=commit.author.offset)
 
         return Commit(
             str(commit.id), self.describe(commit), commit.message, author, date

--- a/src/cutty/packages/domain/package.py
+++ b/src/cutty/packages/domain/package.py
@@ -1,6 +1,7 @@
 """Package."""
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass
 from typing import Optional
 
@@ -25,6 +26,7 @@ class Commit:
     revision: str
     message: str
     author: Author
+    date: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
 
 
 @dataclass

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -1,4 +1,5 @@
 """Building projects in a repository."""
+import datetime
 from collections.abc import Iterator
 from typing import Optional
 
@@ -42,18 +43,20 @@ def commitproject(
         storeproject(project, builder.path)
 
         author: Optional[Author] = None
+        date: Optional[datetime.datetime] = None
 
         if commitmessage is not None:
             message = commitmessage(project.template)
         elif project.template.commit:
             message = project.template.commit.message
             author = project.template.commit.author
+            date = project.template.commit.date
         else:  # pragma: no cover
             # The `commitmessage` is only None when importing, and imports are only
             # possible when there's a `template.commit`. So this should be unreachable.
             message = f"Import {project.template.name}"
 
-        return builder.commit(message, author=author)
+        return builder.commit(message, author=author, date=date)
 
 
 def buildproject(

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -1,6 +1,7 @@
 """Project repositories."""
 from __future__ import annotations
 
+import datetime
 from collections.abc import Iterable
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -35,12 +36,21 @@ class ProjectBuilder:
         """Return the project directory."""
         return self._worktree.path
 
-    def commit(self, message: str, author: Optional[Author] = None) -> str:
+    def commit(
+        self,
+        message: str,
+        author: Optional[Author] = None,
+        date: Optional[datetime.datetime] = None,
+    ) -> str:
         """Commit the project."""
         signature = self._worktree.default_signature
         if author is not None:
             signature = pygit2.Signature(
                 author.name, author.email, signature.time, signature.offset
+            )
+        if date is not None:
+            signature = pygit2.Signature(
+                signature.name, signature.email, int(date.timestamp()), 0
             )
 
         self._worktree.commit(message=message, author=signature)

--- a/src/cutty/util/time.py
+++ b/src/cutty/util/time.py
@@ -1,0 +1,10 @@
+"""Time utilities."""
+import datetime
+
+
+def asdatetime(timestamp: int, *, offset: int) -> datetime.datetime:
+    """Build a `datetime` instance from a POSIX timestamp."""
+    return datetime.datetime.fromtimestamp(
+        timestamp,
+        tz=datetime.timezone(offset=datetime.timedelta(minutes=offset)),
+    )

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -4,6 +4,7 @@ import pathlib
 import string
 from typing import Optional
 
+import pygit2
 import pytest
 from yarl import URL
 
@@ -101,13 +102,18 @@ def test_local_author(url: URL) -> None:
         assert "you@example.com" == package.commit.author.email
 
 
-def test_local_date(url: URL) -> None:
-    """It retrieves the commit date."""
-    commit = Repository.open(aspath(url)).head.commit
-    commitdate = datetime.datetime.fromtimestamp(
+def getcommitdate(commit: pygit2.Commit) -> datetime.datetime:
+    """Return the commit date as a `datetime` instance."""
+    return datetime.datetime.fromtimestamp(
         commit.author.time,
         tz=datetime.timezone(offset=datetime.timedelta(minutes=commit.author.offset)),
     )
+
+
+def test_local_date(url: URL) -> None:
+    """It retrieves the commit date."""
+    commit = Repository.open(aspath(url)).head.commit
+    commitdate = getcommitdate(commit)
 
     repository = localgitprovider.provide(url)
 

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -7,7 +7,6 @@ import pytest
 from yarl import URL
 
 from cutty.errors import CuttyError
-from cutty.packages.adapters.providers.git import asdatetime
 from cutty.packages.adapters.providers.git import gitproviderfactory
 from cutty.packages.adapters.providers.git import localgitprovider
 from cutty.packages.domain.locations import aspath
@@ -15,6 +14,7 @@ from cutty.packages.domain.locations import asurl
 from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.stores import Store
 from cutty.util.git import Repository
+from cutty.util.time import asdatetime
 from tests.util.git import updatefile
 
 

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -3,7 +3,6 @@ import pathlib
 import string
 from typing import Optional
 
-import pygit2
 import pytest
 from yarl import URL
 
@@ -15,8 +14,6 @@ from cutty.packages.domain.providers import Provider
 from cutty.packages.domain.stores import Store
 from cutty.util.git import Repository
 from tests.util.git import updatefile
-
-signature = pygit2.Signature("you", "you@example.com")
 
 
 @pytest.fixture

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -99,6 +99,17 @@ def test_local_author(url: URL) -> None:
         assert "you@example.com" == package.commit.author.email
 
 
+def test_local_date(url: URL) -> None:
+    """It retrieves the commit date."""
+    repository = localgitprovider.provide(url)
+
+    assert repository is not None
+
+    with repository.get() as package:
+        assert package.commit is not None
+        assert package.commit.date
+
+
 @pytest.fixture
 def gitprovider(store: Store) -> Provider:
     """Fixture for a git provider."""

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -1,14 +1,13 @@
 """Unit tests for cutty.packages.adapters.providers.git."""
-import datetime
 import pathlib
 import string
 from typing import Optional
 
-import pygit2
 import pytest
 from yarl import URL
 
 from cutty.errors import CuttyError
+from cutty.packages.adapters.providers.git import getcommitdate
 from cutty.packages.adapters.providers.git import gitproviderfactory
 from cutty.packages.adapters.providers.git import localgitprovider
 from cutty.packages.domain.locations import aspath
@@ -100,14 +99,6 @@ def test_local_author(url: URL) -> None:
         assert package.commit is not None
         assert "You" == package.commit.author.name
         assert "you@example.com" == package.commit.author.email
-
-
-def getcommitdate(commit: pygit2.Commit) -> datetime.datetime:
-    """Return the commit date as a `datetime` instance."""
-    return datetime.datetime.fromtimestamp(
-        commit.author.time,
-        tz=datetime.timezone(offset=datetime.timedelta(minutes=commit.author.offset)),
-    )
 
 
 def test_local_date(url: URL) -> None:

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -7,7 +7,7 @@ import pytest
 from yarl import URL
 
 from cutty.errors import CuttyError
-from cutty.packages.adapters.providers.git import getcommitdate
+from cutty.packages.adapters.providers.git import asdatetime
 from cutty.packages.adapters.providers.git import gitproviderfactory
 from cutty.packages.adapters.providers.git import localgitprovider
 from cutty.packages.domain.locations import aspath
@@ -104,7 +104,7 @@ def test_local_author(url: URL) -> None:
 def test_local_date(url: URL) -> None:
     """It retrieves the commit date."""
     commit = Repository.open(aspath(url)).head.commit
-    commitdate = getcommitdate(commit)
+    commitdate = asdatetime(commit.author.time, offset=commit.author.offset)
 
     repository = localgitprovider.provide(url)
 


### PR DESCRIPTION
- 🔨 [packages] Remove constant `signature` from `test_git`
- ✅ [packages] Add test for git provider retrieving commit date
- 🔨 [packages] Add optional attribute `Commit.date`
- ✅ [packages] Add test for git provider retrieving the exact commit date
- 🔨 [packages] Extract function `getcommitdate`
- 🔨 [packages] Move function `getcommitdate` to `providers.git`
- ✨ [packages] Retrieve commit date in git provider
- 🔨 [packages] Replace `getcommitdate(commit)` with `asdatetime(timestamp, offset)`
- 🔨 [util] Move function `asdatetime` from git provider to `util.time`
- ✅ [functional] Add test for `cutty import` preserving commit dates
- ✨ [projects] Add optional parameter `date` to `ProjectBuilder.commit`
- ✨ [projects] Preserve date when importing git commits
