### PR TITLE
👷 [github] Enable colors from pre-commit, pytest, Sphinx, and xdoctest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,8 @@ jobs:
 
     env:
       NOXSESSION: ${{ matrix.session }}
+      FORCE_COLOR: "1"
+      PRE_COMMIT_COLOR: "always"
 
     steps:
       - name: Check out the repository

--- a/cutty.json
+++ b/cutty.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "location": "https://github.com/cjolowicz/cookiecutter-hypermodern-python",
-    "revision": "f08fd6ec34ba7b17324e48b19c35da3ca39199fe",
+    "revision": "efd03a02f50433b43e15d3d04438e59598d790c6",
     "directory": null
   },
   "bindings": {

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 """Nox sessions."""
+import os
 import shutil
 import sys
 import tarfile
@@ -229,16 +230,25 @@ def typeguard(session: Session) -> None:
 @session(python=python_versions)
 def xdoctest(session: Session) -> None:
     """Run examples with xdoctest."""
-    args = session.posargs or ["all"]
+    if session.posargs:
+        args = [package, *session.posargs]
+    else:
+        args = [f"--modname={package}", "--command=all"]
+        if "FORCE_COLOR" in os.environ:
+            args.append("--colored=1")
+
     session.install(".")
     session.install("xdoctest[colors]")
-    session.run("python", "-m", "xdoctest", package, *args)
+    session.run("python", "-m", "xdoctest", *args)
 
 
 @session(name="docs-build", python=python_versions[0])
 def docs_build(session: Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]
+    if not session.posargs and "FORCE_COLOR" in os.environ:
+        args.insert(0, "--color")
+
     session.install(".")
     session.install(*dependencies["doc"])
 


### PR DESCRIPTION
* 👷 [github] Force color output from pytest using `FORCE_COLOR`

* 👷 [github] Force color output from pre-commit using `PRE_COMMIT_COLOR`

* 👷 [nox] Force color output from Sphinx when `FORCE_COLOR` is set

* 👷 [nox] Force color output from xdoctest if `FORCE_COLOR` is set

Retrocookie-Original-Commit: https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance@5348eed
