### PR TITLE
👷 [github] Pin pip in virtual environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,15 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt pip
           pip --version
 
+      - name: Upgrade pip in virtual environments
+        shell: python
+        run: |
+          import os
+          import pip
+
+          with open(os.environ["GITHUB_ENV"], mode="a") as io:
+              print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
+
       - name: Install Poetry
         run: |
           pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry

--- a/cutty.json
+++ b/cutty.json
@@ -1,7 +1,7 @@
 {
   "template": {
     "location": "https://github.com/cjolowicz/cookiecutter-hypermodern-python",
-    "revision": "5c5e2562f081c341812f4c6eb4d96f213185a34f",
+    "revision": "92df2adbc6fbeb236adb404c91f332f4b1320e40",
     "directory": null
   },
   "bindings": {


### PR DESCRIPTION
* 👷 [github] Set `VIRTUALENV_PIP` to pin pip in virtual environments

* 👷 [github] Append to GITHUB_ENV in Python

This is horrible, but apparently Powershell's quote handling is too broken to do
this portably in the default shell. The previous version just ate the double
quotes.

Retrocookie-Original-Commit: cjolowicz/cookiecutter-hypermodern-python-instance@4463434
