### PR TITLE
👷 [nox] Run coverage under the latest Python release

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -146,7 +146,7 @@ def tests(session: Session) -> None:
             session.notify("coverage", posargs=[])
 
 
-@session
+@session(python=python_versions[0])
 def coverage(session: Session) -> None:
     """Produce the coverage report."""
     args = session.posargs or ["report"]

--- a/tests/unit/packages/adapters/providers/test_disk.py
+++ b/tests/unit/packages/adapters/providers/test_disk.py
@@ -36,4 +36,4 @@ def test_revision(repositorypath: Path) -> None:
         assert repository
 
         with repository.get("v1.0"):
-            pass
+            pass  # pragma: no cover

--- a/tests/unit/packages/adapters/providers/test_git.py
+++ b/tests/unit/packages/adapters/providers/test_git.py
@@ -64,7 +64,7 @@ def test_local_invalid_revision(url: URL) -> None:
         assert repository
 
         with repository.get("invalid"):
-            pass
+            pass  # pragma: no cover
 
 
 def test_local_revision_tag(url: URL) -> None:

--- a/tests/unit/packages/adapters/providers/test_mercurial.py
+++ b/tests/unit/packages/adapters/providers/test_mercurial.py
@@ -176,7 +176,7 @@ def test_revision_not_found(hgprovider: Provider, hgrepository: pathlib.Path) ->
         assert repository
 
         with repository.get("invalid"):
-            pass
+            pass  # pragma: no cover
 
 
 def test_parent_revision_tip(hgprovider: Provider, hgrepository: pathlib.Path) -> None:

--- a/tests/unit/packages/adapters/providers/test_zip.py
+++ b/tests/unit/packages/adapters/providers/test_zip.py
@@ -43,7 +43,7 @@ def test_local_revision(url: URL) -> None:
         assert repository
 
         with repository.get("v1.0"):
-            pass
+            pass  # pragma: no cover
 
 
 def test_local_not_matching(tmp_path: Path) -> None:

--- a/tests/unit/packages/domain/test_mounters.py
+++ b/tests/unit/packages/domain/test_mounters.py
@@ -19,4 +19,4 @@ def test_unversioned_mounter_fail(tmp_path: Path) -> None:
     mount = unversioned_mounter(DiskFilesystem)
     with pytest.raises(Exception):
         with mount(tmp_path, "v1.0.0"):
-            pass
+            pass  # pragma: no cover

--- a/tests/unit/packages/domain/test_providers.py
+++ b/tests/unit/packages/domain/test_providers.py
@@ -74,7 +74,7 @@ def test_localprovider_revision(tmp_path: pathlib.Path) -> None:
         assert repository
 
         with repository.get("v1.0.0"):
-            pass
+            pass  # pragma: no cover
 
 
 def test_remoteproviderfactory_no_fetchers(store: Store) -> None:

--- a/tests/unit/util/test_git.py
+++ b/tests/unit/util/test_git.py
@@ -366,7 +366,7 @@ def test_worktree_tempfile_failure(
 
     with pytest.raises(Exception, match="boom"):
         with repository.worktree(branch, checkout=False):
-            pass
+            pass  # pragma: no cover
 
 
 def test_cherrypick_adds_file(repository: Repository, path: Path) -> None:


### PR DESCRIPTION
- 👷 [nox] Run coverage under the latest Python release
- 🔧 [coverage] Exclude some `pass` statements in tests from coverage
