### PR TITLE
👷 [github] Test against Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,9 +110,8 @@ jobs:
 
       - name: Run Nox
         run: |
-          nox --force-color --python=$NOXPYTHON
+          nox --force-color --python=${{ startsWith(matrix.python, '3.11.') && '3.11' || matrix.python }}
         env:
-          NOXPYTHON: ${{ startsWith(matrix.python, '3.11.') && '3.11' || matrix.python }}
           YARL_NO_EXTENSIONS: ${{ startsWith(matrix.python, '3.11.') && '1' || '' }}
 
       - name: Upload coverage data

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,19 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - { python: "3.10", os: "macos-latest", session: "tests" }
+          - { python: "3.10", os: "ubuntu-latest", session: "docs-build" }
+          - { python: "3.10", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.10", os: "ubuntu-latest", session: "pre-commit" }
           - { python: "3.10", os: "ubuntu-latest", session: "safety" }
-          - { python: "3.11.0-alpha.2", os: "ubuntu-latest", session: "mypy" }
-          - { python: "3.10", os: "ubuntu-latest", session: "mypy" }
-          - { python: "3.9", os: "ubuntu-latest", session: "mypy" }
-          - { python: "3.11.0-alpha.2", os: "ubuntu-latest", session: "tests" }
           - { python: "3.10", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.9", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.10", os: "windows-latest", session: "tests" }
-          - { python: "3.10", os: "macos-latest", session: "tests" }
           - { python: "3.10", os: "ubuntu-latest", session: "typeguard" }
           - { python: "3.10", os: "ubuntu-latest", session: "xdoctest" }
-          - { python: "3.10", os: "ubuntu-latest", session: "docs-build" }
+          - { python: "3.10", os: "windows-latest", session: "tests" }
+          - { python: "3.9", os: "ubuntu-latest", session: "mypy" }
+          - { python: "3.9", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.11.0-alpha.2", os: "ubuntu-latest", session: "mypy" }
+          - { python: "3.11.0-alpha.2", os: "ubuntu-latest", session: "tests" }
 
     env:
       NOXSESSION: ${{ matrix.session }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,6 +113,7 @@ jobs:
           nox --force-color --python=$NOXPYTHON
         env:
           NOXPYTHON: ${{ startsWith(matrix.python, '3.11.') && '3.11' || matrix.python }}
+          YARL_NO_EXTENSIONS: ${{ startsWith(matrix.python, '3.11.') && '1' || '' }}
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,25 @@ jobs:
           restore-keys: |
             ${{ steps.pre-commit-cache.outputs.result }}-
 
+      - name: Install libgit2
+        if: matrix.os == 'ubuntu-latest' && startsWith(matrix.python, '3.11.')
+        run: |
+          package=libgit2
+          version=1.3.0
+          url=https://github.com/$package/$package/archive/refs/tags/v$version.tar.gz
+          directory=.thirdparty/$package-$version
+
+          sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+          cat /etc/apt/sources.list
+          sudo apt-get update && sudo apt-get build-dep -y $package
+          mkdir -p $directory && cd $directory
+          curl -fsSL $url | tar --gunzip --extract --strip-components=1
+          mkdir build && cd build
+          cmake ..
+          cmake --build .
+          sudo make install
+          sudo ldconfig -v
+
       - name: Run Nox
         run: |
           nox --force-color --python=$NOXPYTHON

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,10 @@ jobs:
         include:
           - { python: "3.10", os: "ubuntu-latest", session: "pre-commit" }
           - { python: "3.10", os: "ubuntu-latest", session: "safety" }
+          - { python: "3.11.0-alpha.2", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.10", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.9", os: "ubuntu-latest", session: "mypy" }
+          - { python: "3.11.0-alpha.2", os: "ubuntu-latest", session: "tests" }
           - { python: "3.10", os: "ubuntu-latest", session: "tests" }
           - { python: "3.9", os: "ubuntu-latest", session: "tests" }
           - { python: "3.10", os: "windows-latest", session: "tests" }
@@ -89,7 +91,9 @@ jobs:
 
       - name: Run Nox
         run: |
-          nox --force-color --python=${{ matrix.python }}
+          nox --force-color --python=$NOXPYTHON
+        env:
+          NOXPYTHON: ${{ startsWith(matrix.python, '3.11.') && '3.11' || matrix.python }}
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 package = "cutty"
-python_versions = ["3.10", "3.9"]
+python_versions = ["3.10", "3.9", "3.11"]
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     "pre-commit",


### PR DESCRIPTION
- 👷 [github] Test against Python 3.11
- 👷 [github] Group matrix entries by Python version
- 👷 [github] Build and install libgit2 on Python 3.11
- 👷 [github] Do not compile extensions for yarl on Python 3.11
- fix windows
