### PR TITLE
✨ [entrypoints] Report success from `cutty {import,update} --{abort,continue}`

### DIFF
--- a/src/cutty/entrypoints/cli/import_.py
+++ b/src/cutty/entrypoints/cli/import_.py
@@ -75,6 +75,7 @@ def import_(
 
     if abort:
         project.abort()
+        click.secho("The import has been aborted.", fg="green")
         return
 
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]

--- a/src/cutty/entrypoints/cli/import_.py
+++ b/src/cutty/entrypoints/cli/import_.py
@@ -71,6 +71,7 @@ def import_(
 
     if continue_:
         project.continue_()
+        click.secho("The project has been updated.", fg="green")
         return
 
     if abort:

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -78,6 +78,7 @@ def update(
 
     if abort:
         project.abort()
+        click.secho("The update has been aborted.", fg="green")
         return
 
     extrabindings = [Binding(key, value) for key, value in extra_context.items()]

--- a/src/cutty/entrypoints/cli/update.py
+++ b/src/cutty/entrypoints/cli/update.py
@@ -73,6 +73,7 @@ def update(
 
     if continue_:
         project.continue_()
+        click.secho("The project has been updated.", fg="green")
         return
 
     if abort:

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -345,6 +345,23 @@ def test_console_message(runcutty: RunCutty, project: Path) -> None:
     assert output
 
 
+def test_continue_console_message(
+    runcutty: RunCutty, templateproject: Path, project: Path
+) -> None:
+    """It prints a message on success."""
+    updatefile(project / "LICENSE", "a")
+    updatefile(templateproject / "LICENSE", "b")
+
+    with pytest.raises(Exception, match="conflict"):
+        runcutty("import", "--non-interactive", f"--cwd={project}")
+
+    resolveconflicts(project, project / "LICENSE", Side.THEIRS)
+
+    output = runcutty("import", "--non-interactive", f"--cwd={project}", "--continue")
+
+    assert output
+
+
 def test_abort_console_message(
     runcutty: RunCutty, templateproject: Path, project: Path
 ) -> None:

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -345,6 +345,21 @@ def test_console_message(runcutty: RunCutty, project: Path) -> None:
     assert output
 
 
+def test_abort_console_message(
+    runcutty: RunCutty, templateproject: Path, project: Path
+) -> None:
+    """It prints a message on success."""
+    updatefile(project / "LICENSE", "a")
+    updatefile(templateproject / "LICENSE", "b")
+
+    with pytest.raises(Exception, match="conflict"):
+        runcutty("import", "--non-interactive", f"--cwd={project}")
+
+    output = runcutty("import", "--non-interactive", f"--cwd={project}", "--abort")
+
+    assert output
+
+
 def test_projectvariable(project: Path) -> None:
     """It raises if the variable is not defined."""
     with pytest.raises(StopIteration):

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -457,3 +457,18 @@ def test_continue_message(
     output = runcutty("update", "--non-interactive", f"--cwd={project}", "--continue")
 
     assert output
+
+
+def test_abort_message(
+    runcutty: RunCutty, templateproject: Path, project: Path
+) -> None:
+    """It prints a message on success."""
+    updatefile(project / "LICENSE", "a")
+    updatefile(templateproject / "LICENSE", "b")
+
+    with pytest.raises(Exception, match="conflict"):
+        runcutty("update", "--non-interactive", f"--cwd={project}")
+
+    output = runcutty("update", "--non-interactive", f"--cwd={project}", "--abort")
+
+    assert output

--- a/tests/functional/test_update.py
+++ b/tests/functional/test_update.py
@@ -440,3 +440,20 @@ def test_message(runcutty: RunCutty, project: Path) -> None:
     output = runcutty("update", "--non-interactive", f"--cwd={project}")
 
     assert output
+
+
+def test_continue_message(
+    runcutty: RunCutty, templateproject: Path, project: Path
+) -> None:
+    """It prints a message on success."""
+    updatefile(project / "LICENSE", "a")
+    updatefile(templateproject / "LICENSE", "b")
+
+    with pytest.raises(Exception, match="conflict"):
+        runcutty("update", "--non-interactive", f"--cwd={project}")
+
+    resolveconflicts(project, project / "LICENSE", Side.THEIRS)
+
+    output = runcutty("update", "--non-interactive", f"--cwd={project}", "--continue")
+
+    assert output


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty import --abort` reporting success
- ✨ [entrypoints] Report success from `cutty import --abort`
- ✅ [functional] Add test for `cutty import --continue` reporting success
- ✨ [entrypoints] Report success from `cutty import --continue`
- ✅ [functional] Add test for `cutty update --continue` reporting success
- ✨ [entrypoints] Report success from `cutty update --continue`
- ✅ [functional] Add test for `cutty import --abort` reporting success
- ✨ [entrypoints] Report success from `cutty update --abort`
