### PR TITLE
🐛 [projects] Remove cutty.json from "Conflicts:" comment when committing

### DIFF
--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -15,6 +15,7 @@ from cutty.errors import CuttyError
 from cutty.packages.domain.package import Author
 from cutty.projects.config import PROJECT_CONFIG_FILE
 from cutty.util.git import MergeConflictError
+from cutty.util.git import MergeMessage
 from cutty.util.git import Repository
 
 
@@ -181,12 +182,11 @@ class ProjectRepository:
 
 def _patch_merge_msg(repositorypath: Path) -> None:
     """Remove cutty.json from MERGE_MSG."""
-    path = repositorypath / ".git" / "MERGE_MSG"
-    if not path.is_file():
+    message = MergeMessage.read(repositorypath)
+    if message is None:
         return
 
-    text = path.read_text()
-    lines = text.splitlines(keepends=True)
+    lines = message.lines
 
     for _reverse_index, line in enumerate(reversed(lines)):
         if line.rstrip() == "# Conflicts:":
@@ -203,4 +203,4 @@ def _patch_merge_msg(repositorypath: Path) -> None:
         line for line in lines[index:] if line.rstrip() != "# \tcutty.json"
     ]
 
-    path.write_text("".join(lines))
+    message.write(repositorypath)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -186,19 +186,11 @@ def _patch_merge_msg(repositorypath: Path) -> None:
     if message is None:
         return
 
+    index = message.findconflicts(prefix="# ")
+    if index == -1:
+        return
+
     lines = message.lines
-
-    for _reverse_index, line in enumerate(reversed(lines)):
-        if line.rstrip() == "# Conflicts:":
-            break
-    else:
-        return
-
-    index = -_reverse_index - 1
-
-    if not all(line.startswith("# \t") for line in lines[index + 1 :]):
-        return
-
     lines[index:] = [
         line for line in lines[index:] if line.rstrip() != "# \tcutty.json"
     ]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -190,9 +190,8 @@ def _patch_merge_msg(repositorypath: Path) -> None:
     if index == -1:
         return
 
-    lines = message.lines
-    lines[index:] = [
-        line for line in lines[index:] if line.rstrip() != "# \tcutty.json"
+    message.lines[index:] = [
+        line for line in message.lines[index:] if line.rstrip() != "# \tcutty.json"
     ]
 
     message.write(repositorypath)

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -182,9 +182,9 @@ class ProjectRepository:
 
 def _patch_merge_msg(repositorypath: Path) -> None:
     """Remove cutty.json from MERGE_MSG."""
-    if message := MergeMessage.read(repositorypath):
+    if message := MergeMessage.read(repositorypath):  # pragma: no branch
         index = message.findconflicts(prefix="# ")
-        if index != -1:
+        if index != -1:  # pragma: no branch
             message.lines[index:] = [
                 line
                 for line in message.lines[index:]

--- a/src/cutty/projects/repository.py
+++ b/src/cutty/projects/repository.py
@@ -182,16 +182,12 @@ class ProjectRepository:
 
 def _patch_merge_msg(repositorypath: Path) -> None:
     """Remove cutty.json from MERGE_MSG."""
-    message = MergeMessage.read(repositorypath)
-    if message is None:
-        return
-
-    index = message.findconflicts(prefix="# ")
-    if index == -1:
-        return
-
-    message.lines[index:] = [
-        line for line in message.lines[index:] if line.rstrip() != "# \tcutty.json"
-    ]
-
-    message.write(repositorypath)
+    if message := MergeMessage.read(repositorypath):
+        index = message.findconflicts(prefix="# ")
+        if index != -1:
+            message.lines[index:] = [
+                line
+                for line in message.lines[index:]
+                if line.rstrip() != "# \tcutty.json"
+            ]
+            message.write(repositorypath)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -393,9 +393,9 @@ def _patch_merge_msg(repositorypath: Path) -> None:
     if message is None:
         return
 
-    for _reverse_index, line in enumerate(reversed(message.lines)):
+    for index, line in enumerate(reversed(message.lines)):
         if line.rstrip() == "Conflicts:":
-            index = -_reverse_index - 1
+            index = -index - 1
             break
     else:
         return

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -403,13 +403,8 @@ class MergeMessage:
 def _patch_merge_msg(repositorypath: Path) -> None:
     """Insert comment markers for "Conflicts:" hint in MERGE_MSG."""
     # https://github.com/libgit2/libgit2/issues/6131
-    message = MergeMessage.read(repositorypath)
-    if message is None:
-        return
-
-    index = message.findconflicts()
-    if index == -1:
-        return
-
-    message.lines[index:] = [f"# {line}" for line in message.lines[index:]]
-    message.write(repositorypath)
+    if message := MergeMessage.read(repositorypath):
+        index = message.findconflicts()
+        if index != -1:
+            message.lines[index:] = [f"# {line}" for line in message.lines[index:]]
+            message.write(repositorypath)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -390,12 +390,14 @@ class MergeMessage:
         path = self.path(repositorypath)
         path.write_text(self.format())
 
-    def findconflicts(self) -> int:
+    def findconflicts(self, *, prefix: str = "") -> int:
         """Find the position of the "Conflicts:" hint."""
         for index, line in enumerate(reversed(self.lines)):
-            if line.rstrip() == "Conflicts:":
+            if line.rstrip() == f"{prefix}Conflicts:":
                 index = -index - 1
-                if all(line.startswith("\t") for line in self.lines[index + 1 :]):
+                if all(
+                    line.startswith(f"{prefix}\t") for line in self.lines[index + 1 :]
+                ):
                     return index
 
         return -1

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -395,11 +395,10 @@ def _patch_merge_msg(repositorypath: Path) -> None:
 
     for _reverse_index, line in enumerate(reversed(message.lines)):
         if line.rstrip() == "Conflicts:":
+            index = -_reverse_index - 1
             break
     else:
         return
-
-    index = -_reverse_index - 1
 
     if not all(line.startswith("\t") for line in message.lines[index + 1 :]):
         return

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -380,6 +380,11 @@ class MergeMessage:
         """Return the contents as a string."""
         return "".join(self.lines)
 
+    def write(self, repositorypath: Path) -> None:
+        """Write the merge message to the git repository."""
+        path = repositorypath / ".git" / "MERGE_MSG"
+        path.write_text(self.format())
+
 
 def _patch_merge_msg(repositorypath: Path) -> None:
     """Insert comment markers for "Conflicts:" hint in MERGE_MSG."""
@@ -400,6 +405,4 @@ def _patch_merge_msg(repositorypath: Path) -> None:
         return
 
     message.lines[index:] = [f"# {line}" for line in message.lines[index:]]
-
-    path = repositorypath / ".git" / "MERGE_MSG"
-    path.write_text(message.format())
+    message.write(repositorypath)

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -395,14 +395,10 @@ class MergeMessage:
         for index, line in enumerate(reversed(self.lines)):
             if line.rstrip() == "Conflicts:":
                 index = -index - 1
-                break
-        else:
-            return -1
+                if all(line.startswith("\t") for line in self.lines[index + 1 :]):
+                    return index
 
-        if not all(line.startswith("\t") for line in self.lines[index + 1 :]):
-            return -1
-
-        return index
+        return -1
 
 
 def _patch_merge_msg(repositorypath: Path) -> None:

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -361,6 +361,10 @@ class MergeMessage:
 
     lines: list[str]
 
+    def format(self) -> str:
+        """Return the contents as a string."""
+        return "".join(self.lines)
+
 
 def _patch_merge_msg(repositorypath: Path) -> None:
     """Insert comment markers for "Conflicts:" hint in MERGE_MSG."""
@@ -385,4 +389,4 @@ def _patch_merge_msg(repositorypath: Path) -> None:
 
     message.lines[index:] = [f"# {line}" for line in message.lines[index:]]
 
-    path.write_text("".join(message.lines))
+    path.write_text(message.format())

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -361,6 +361,11 @@ class MergeMessage:
 
     lines: list[str]
 
+    @classmethod
+    def parse(cls, text: str) -> MergeMessage:
+        """Parse the merge message from the contents of a MERGE_MSG file."""
+        return cls(text.splitlines(keepends=True))
+
     def format(self) -> str:
         """Return the contents as a string."""
         return "".join(self.lines)
@@ -374,7 +379,7 @@ def _patch_merge_msg(repositorypath: Path) -> None:
         return
 
     text = path.read_text()
-    message = MergeMessage(text.splitlines(keepends=True))
+    message = MergeMessage.parse(text)
 
     for _reverse_index, line in enumerate(reversed(message.lines)):
         if line.rstrip() == "Conflicts:":

--- a/src/cutty/util/git.py
+++ b/src/cutty/util/git.py
@@ -362,9 +362,14 @@ class MergeMessage:
     lines: list[str]
 
     @classmethod
+    def path(cls, repositorypath: Path) -> Path:
+        """Return the path to the MERGE_MSG file."""
+        return repositorypath / ".git" / "MERGE_MSG"
+
+    @classmethod
     def read(cls, repositorypath: Path) -> Optional[MergeMessage]:
         """Read the merge message from the git repository."""
-        path = repositorypath / ".git" / "MERGE_MSG"
+        path = cls.path(repositorypath)
         if not path.is_file():
             return None
 
@@ -382,7 +387,7 @@ class MergeMessage:
 
     def write(self, repositorypath: Path) -> None:
         """Write the merge message to the git repository."""
-        path = repositorypath / ".git" / "MERGE_MSG"
+        path = self.path(repositorypath)
         path.write_text(self.format())
 
     def findconflicts(self) -> int:

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -149,6 +149,24 @@ def test_conflict_message(
     assert "cutty.json" not in str(exceptioninfo.value)
 
 
+def test_conflict_commit_message(
+    runcutty: RunCutty, templateproject: Path, project: Path
+) -> None:
+    """It does not include cutty.json in the merge message."""
+    updatefile(templateproject / "extra")
+    updatefile(templateproject / "marker", "a")
+    updatefile(project / "marker", "b")
+
+    with pytest.raises(Exception):
+        with chdir(project):
+            runcutty("import")
+
+    with (project / ".git" / "MERGE_MSG").open() as io:
+        lines = list(io)
+
+    assert "# \tcutty.json\n" not in lines
+
+
 def test_conflict_commit_message_comment(
     runcutty: RunCutty, templateproject: Path, project: Path
 ) -> None:


### PR DESCRIPTION
- ✅ [functional] Add test that MERGE_MSG does not include cutty.json
- 🐛 [projects] Remove cutty.json from "Conflicts:" comment when committing
- 🔨 [git] Extract class MergeMessage
- 🔨 [git] Extract function `MergeMessage.format`
- 🔨 [git] Extract function `MergeMessage.parse`
- 🔨 [git] Extract function `MergeMessage.read`
- 🔨 [git] Extract function `MergeMessage.write`
- 🔨 [git] Slide assignment of `index`
- 🔨 [git] Rename variable `{_reverse_ => }index`
- 🔨 [git] Extract function `MergeMessage.findconflicts`
- 🔨 [git] Replace guard clauses with nested if
- 🔨 [git] Extract function `MergeMessage.path`
- 🔨 [projects] Replace inline code with `MergeMessage.{read,write}`
- 🔨 [git] Replace guard clauses in `MergeMessage.findconflicts` with nested if
- 🔨 [git] Add parameter `prefix` to `MergeMessage.findconflicts`
- 🔨 [projects] Replace inline code with `MergeMessage.findconflicts`
- 🔨 [projects] Inline variable `lines`
- 🔨 [projects] Replace guard clauses with nested if
- 🙈 [coverage] Ignore some branches when patching MERGE_MSG
