### PR TITLE
🐛 [projects] Do not remove bindings from cutty.json when importing old commits

### DIFF
--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -1,6 +1,7 @@
 """Building projects in a repository."""
 import datetime
 from collections.abc import Iterator
+from collections.abc import Sequence
 from typing import Optional
 
 from cutty.compat.contextlib import contextmanager
@@ -12,11 +13,16 @@ from cutty.projects.project import Project
 from cutty.projects.repository import ProjectRepository
 from cutty.projects.store import storeproject
 from cutty.projects.template import TemplateProvider
+from cutty.variables.domain.bindings import Binding
 
 
 @contextmanager
 def createproject(
-    config: ProjectConfig, *, interactive: bool, createconfigfile: bool = True
+    config: ProjectConfig,
+    *,
+    interactive: bool,
+    createconfigfile: bool = True,
+    userbindings: Sequence[Binding] = (),
 ) -> Iterator[Project]:
     """Create the project."""
     provider = TemplateProvider.create()
@@ -28,6 +34,7 @@ def createproject(
             config.bindings,
             interactive=interactive,
             createconfigfile=createconfigfile,
+            userbindings=userbindings,
         )
 
 

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -70,12 +70,15 @@ def buildproject(
     repository: ProjectRepository,
     config: ProjectConfig,
     *,
+    userbindings: Sequence[Binding] = (),
     interactive: bool,
     parent: Optional[str] = None,
     commitmessage: Optional[MessageBuilder] = None,
 ) -> str:
     """Build the project, returning the commit ID."""
-    with createproject(config, interactive=interactive) as project:
+    with createproject(
+        config, userbindings=userbindings, interactive=interactive
+    ) as project:
         return commitproject(
             repository, project, parent=parent, commitmessage=commitmessage
         )

--- a/src/cutty/projects/build.py
+++ b/src/cutty/projects/build.py
@@ -88,6 +88,7 @@ def buildparentproject(
     repository: ProjectRepository,
     config: ProjectConfig,
     *,
+    userbindings: Sequence[Binding] = (),
     revision: Optional[str],
     interactive: bool,
 ) -> Optional[str]:
@@ -97,7 +98,12 @@ def buildparentproject(
 
     if parentrevision := templates.getparentrevision(revision):
         with templates.get(parentrevision) as template:
-            project = generate(template, config.bindings, interactive=interactive)
+            project = generate(
+                template,
+                config.bindings,
+                userbindings=userbindings,
+                interactive=interactive,
+            )
             return commitproject(repository, project)
 
     return None

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -84,10 +84,10 @@ def generate(
 ) -> Project:
     """Generate a project from a project template."""
     generator = ProjectGenerator.create(template)
-    bindings = generator.bind(interactive=interactive, bindings=bindings)
-    project = generator.generate(bindings)
+    bindings2 = generator.bind(interactive=interactive, bindings=bindings)
+    project = generator.generate(bindings2)
 
     if createconfigfile:
-        project = generator.addconfig(project, bindings)
+        project = generator.addconfig(project, [*bindings, *bindings2])
 
     return project

--- a/src/cutty/projects/generate.py
+++ b/src/cutty/projects/generate.py
@@ -80,11 +80,14 @@ def generate(
     /,
     *,
     interactive: bool,
+    userbindings: Sequence[Binding] = (),
     createconfigfile: bool = True,
 ) -> Project:
     """Generate a project from a project template."""
     generator = ProjectGenerator.create(template)
-    bindings2 = generator.bind(interactive=interactive, bindings=bindings)
+    bindings2 = generator.bind(
+        interactive=interactive, bindings=[*bindings, *userbindings]
+    )
     project = generator.generate(bindings2)
 
     if createconfigfile:

--- a/src/cutty/services/cookiecutter.py
+++ b/src/cutty/services/cookiecutter.py
@@ -21,10 +21,13 @@ def create(
     fileexists: FileExistsPolicy,
 ) -> None:
     """Generate projects from Cookiecutter templates."""
-    config = ProjectConfig(location, extrabindings, checkout, directory)
+    config = ProjectConfig(location, (), checkout, directory)
 
     with createproject(
-        config, interactive=interactive, createconfigfile=False
+        config,
+        userbindings=extrabindings,
+        interactive=interactive,
+        createconfigfile=False,
     ) as project:
         storeproject(
             project,

--- a/src/cutty/services/create.py
+++ b/src/cutty/services/create.py
@@ -22,9 +22,11 @@ def create(
     in_place: bool,
 ) -> None:
     """Generate projects from templates."""
-    config = ProjectConfig(location, extrabindings, revision, directory)
+    config = ProjectConfig(location, (), revision, directory)
 
-    with createproject(config, interactive=interactive) as project:
+    with createproject(
+        config, userbindings=extrabindings, interactive=interactive
+    ) as project:
         projectdir = outputdir if in_place else outputdir / project.name
         repository = ProjectRepository.create(projectdir, message="Initial commit")
         commit = commitproject(repository, project, commitmessage=createcommitmessage)

--- a/src/cutty/services/import_.py
+++ b/src/cutty/services/import_.py
@@ -24,7 +24,7 @@ def import_(
 
     config2 = ProjectConfig(
         config1.template,
-        [*config1.bindings, *extrabindings],
+        config1.bindings,
         revision,
         config1.directory if directory is None else directory,
     )
@@ -35,7 +35,13 @@ def import_(
         repository, config1, revision=revision, interactive=interactive
     )
 
-    commit = buildproject(repository, config2, interactive=interactive, parent=parent)
+    commit = buildproject(
+        repository,
+        config2,
+        userbindings=extrabindings,
+        interactive=interactive,
+        parent=parent,
+    )
 
     # If `commit` and `parent` are identical then so is the template revision
     # stored in their cutty.json. But for the version control systems we

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -66,15 +66,14 @@ def link(
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a template."""
-    config = createprojectconfig(
-        projectdir, location, extrabindings, revision, directory
-    )
+    config = createprojectconfig(projectdir, location, (), revision, directory)
 
     repository = ProjectRepository(projectdir)
 
     commit = buildproject(
         repository,
         config,
+        userbindings=extrabindings,
         interactive=interactive,
         commitmessage=linkcommitmessage,
     )

--- a/src/cutty/services/link.py
+++ b/src/cutty/services/link.py
@@ -33,15 +33,15 @@ def loadprojectconfig(projectdir: pathlib.Path) -> Optional[ProjectConfig]:
 def createprojectconfig(
     projectdir: pathlib.Path,
     location: Optional[str],
-    bindings: Sequence[Binding],
     revision: Optional[str],
     directory: Optional[pathlib.Path],
 ) -> ProjectConfig:
     """Assemble project configuration from parameters and the existing project."""
+    bindings: Sequence[Binding] = ()
     config = loadprojectconfig(projectdir)
 
     if config is not None:
-        bindings = [*config.bindings, *bindings]
+        bindings = config.bindings
 
         if location is None:
             location = config.template
@@ -66,7 +66,7 @@ def link(
     directory: Optional[pathlib.Path],
 ) -> None:
     """Link project to a template."""
-    config = createprojectconfig(projectdir, location, (), revision, directory)
+    config = createprojectconfig(projectdir, location, revision, directory)
 
     repository = ProjectRepository(projectdir)
 

--- a/src/cutty/services/update.py
+++ b/src/cutty/services/update.py
@@ -24,7 +24,7 @@ def update(
 
     config2 = ProjectConfig(
         config1.template,
-        [*config1.bindings, *extrabindings],
+        config1.bindings,
         revision,
         config1.directory if directory is None else directory,
     )
@@ -41,6 +41,7 @@ def update(
     commit = buildproject(
         repository,
         config2,
+        userbindings=extrabindings,
         interactive=interactive,
         commitmessage=updatecommitmessage,
         parent=parent,

--- a/tests/functional/test_create.py
+++ b/tests/functional/test_create.py
@@ -256,3 +256,11 @@ def test_message(runcutty: RunCutty, template: Path) -> None:
     output = runcutty("create", "--non-interactive", str(template))
 
     assert output
+
+
+def test_unknown_binding(runcutty: RunCutty, template: Path) -> None:
+    """It does not store unknown bindings in cutty.json."""
+    runcutty("create", "--non-interactive", str(template), "bogus=")
+
+    config = readprojectconfigfile(Path("example"))
+    assert "bogus" not in {binding.name for binding in config.bindings}

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -418,3 +418,16 @@ def test_projectvariable(project: Path) -> None:
     """It raises if the variable is not defined."""
     with pytest.raises(StopIteration):
         projectvariable(project, "undefined")
+
+
+def test_reorder_commits(
+    runcutty: RunCutty, template: Path, templateproject: Path, project: Path
+) -> None:
+    """It does not remove bindings when changes are reordered."""
+    updatefile(templateproject / "marker")
+    updatetemplatevariable(template, "status", ["alpha", "beta", "stable"])
+
+    runcutty("import", "--non-interactive", f"--cwd={project}", "status=stable")
+    runcutty("import", "--non-interactive", f"--cwd={project}", "--revision=HEAD^")
+
+    assert "stable" == projectvariable(project, "status")


### PR DESCRIPTION
- ✅ [functional] Add test for `cutty create` not storing unknown bindings
- ✅ [functional] Add test for reordered imports with new bindings
- 🐛 [projects] Do not remove bindings from previous generations
- 🔨 [projects] Add optional parameter `userbindings` to `generate`
- 🔨 [projects] Add optional parameter `userbindings` to `createproject`
- 🔨 [projects] Add optional parameter `userbindings` to `buildproject`
- 🔨 [projects] Add optional parameter `userbindings` to `buildparentproject`
- ✨ [services] Do not store unknown bindings passed to `cutty create`
- 🔨 [services] Use `userbindings` for bindings passed via `cutty cookiecutter`
- ✨ [services] Do not store unknown bindings passed to `cutty import`
- ✨ [services] Do not store unknown bindings passed to `cutty link`
- 🔨 [services] Remove parameter `bindings` from `createprojectconfig`
- ✨ [services] Do not store unknown bindings passed to `cutty update`
